### PR TITLE
Fix return value docs for azure_rm_functionapp*

### DIFF
--- a/plugins/modules/azure_rm_functionapp.py
+++ b/plugins/modules/azure_rm_functionapp.py
@@ -152,7 +152,7 @@ state:
             host_type: Repository
         server_farm_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Web/serverfarms/EastUSPlan
         reserved: false
-        last_modified_time_utc: 2017-08-22T18:54:01.190Z
+        last_modified_time_utc: '2017-08-22T18:54:01.190Z'
         scm_site_also_stopped: false
         client_affinity_enabled: true
         client_cert_enabled: false

--- a/plugins/modules/azure_rm_functionapp_info.py
+++ b/plugins/modules/azure_rm_functionapp_info.py
@@ -87,7 +87,7 @@ azure_functionapps:
             host_type: Repository
         server_farm_id: /subscriptions/.../resourceGroups/ansible-rg/providers/Microsoft.Web/serverfarms/EastUSPlan
         reserved: false
-        last_modified_time_utc: 2017-08-22T18:54:01.190Z
+        last_modified_time_utc: '2017-08-22T18:54:01.190Z'
         scm_site_also_stopped: false
         client_affinity_enabled: true
         client_cert_enabled: false


### PR DESCRIPTION
##### SUMMARY
Escape two datetimes in return value samples which are parsed by YAML parser as `datetime` objects instead of strings. This makes `ansible-doc --json` crash on these modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
azure_rm_functionapp
azure_rm_functionapp_info
