### PR TITLE
Make inventory_hostname configurable with hostvar_expressions

### DIFF
--- a/plugins/doc_fragments/azure_rm.py
+++ b/plugins/doc_fragments/azure_rm.py
@@ -79,4 +79,15 @@ options:
         type: bool
         default: False
         version_added: '2.8'
+    hostnames:
+        description:
+        - A list of Jinja2 expressions in order of precedence to compose inventory_hostname.
+        - Ignores expression if result is an empty string or None value.
+        - By default, inventory_hostname is generated to be globally unique based on the VM host name.
+            See C(plain_host_names) for more details on the default.
+        - An expression of 'default' will force using the default hostname generator if no previous hostname expression
+            resulted in a valid hostname.
+        - Use ``default_inventory_hostname`` to access the default hostname generator's value in any of the Jinja2 expressions.
+        type: list
+        default: [default]
 '''

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -507,7 +507,8 @@ class AzureHost(object):
             ) if self._vmss else {},
             virtual_machine_size=self._vm_model['properties']['hardwareProfile']['vmSize'] if self._vm_model['properties'].get('hardwareProfile') else None,
             plan=self._vm_model['properties']['plan']['name'] if self._vm_model['properties'].get('plan') else None,
-            resource_group=parse_resource_id(self._vm_model['id']).get('resource_group').lower()
+            resource_group=parse_resource_id(self._vm_model['id']).get('resource_group').lower(),
+            default_inventory_hostname=self.default_inventory_hostname,
         )
 
         # set nic-related values from the primary NIC first

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -17,18 +17,6 @@ DOCUMENTATION = r'''
         - By default, sets C(ansible_host) to the first public IP address found (preferring the primary NIC). If no
           public IPs are found, the first private IP (also preferring the primary NIC). The default may be overridden
           via C(hostvar_expressions); see examples.
-        hostnames:
-          description:
-            - A list of Jinja2 expressions in order of precedence to compose inventory_hostname.
-            - Ignores expression if result is an empty string or None value.
-            - By default, inventory_hostname is generated to be globally unique based on the VM host name.
-              See C(plain_host_names) for more details on the default.
-            - An expression of 'default' will force using the default hostname generator if no previous
-              hostname expression resulted in a valid hostname.
-            - Use ``default_inventory_hostname`` to access the default hostname generator's value in
-              any of the Jinja2 expressions.
-          type: list
-          default: [default]
 '''
 
 EXAMPLES = '''

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -73,6 +73,9 @@ hostvar_expressions:
   # overrides the default ansible_host value with a custom Jinja2 expression, in this case, the first DNS hostname, or
   # if none are found, the first public IP address.
   ansible_host: (public_dns_hostnames + public_ipv4_addresses) | first
+  # overrides the default inventory_hostname value with a custom Jinja2 expression, in this case, a tag called vm_name.
+  # if the tag is not found, use the default_inventory_hostname (see plain_host_names).
+  inventory_hostname: tags.vm_name | default(default_inventory_hostname)
 
 # places hosts in dynamically-created groups based on a variable value.
 keyed_groups:


### PR DESCRIPTION
#### SUMMARY
Allow configuring inventory_hostname with a constructable/compose expression in hostvar_expressions.

Currently, you can add inventory_hostname to compose vars, but that is too late, as the hostname is already set. If you try, ansible with override it with a magic var to ensure that the var matches the hostname.

Resolves #104

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm inventory plugin

##### ADDITIONAL INFORMATION
Example of how this could be used with tags:
```yaml
hostvar_expressions:
  inventory_hostname: tags.FQDN | default(default_inventory_hostname)
```