### PR TITLE
Add support for managing the 'Firewall and virtual networks' settings of a Storage Account.

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -110,7 +110,7 @@ options:
                 default: Allow
             bypass:
                 description:
-                    - When C(default_action) is set to 'Deny' this controls which Azure components can still reach the Storage Account.
+                    - When I(default_action=Deny) this controls which Azure components can still reach the Storage Account.
                     - The list is comma separated.
                     - It can be any combination of the following: AzureServices, Logging, Metrics.
                     - If no Azure components are allowed, explicitly set C(bypass="").

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -103,7 +103,7 @@ options:
             default_action:
                 description:
                     - Default firewall traffic rule.
-                    - If set to 'Allow' no other settings have effect.
+                    - If I(default_action=Allow) no other settings have effect.
                 choices:
                     - Allow
                     - Deny

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -118,7 +118,7 @@ options:
                 suboptions:
                     virtual_network_rules:
                         description:
-                            - A list of subnets and their actions
+                            - A list of subnets and their actions.
                         suboptions:
                             id:
                                 description:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -129,7 +129,7 @@ options:
                                 default: 'Allow'
                     ip_rules:
                         description:
-                            - A list of ip addresses or ranges in CIDR format
+                            - A list of IP addresses or ranges in CIDR format.
                         suboptions:
                             value:
                                 description:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -136,7 +136,7 @@ options:
                                     - The ip address or range.
                             action:
                                 description:
-                                    - The only logical action is 'Allow' because this setting is only accessible when C(default_action) is set to 'Deny'.
+                                    - The only logical I(action=Allow) because this setting is only accessible when I(default_action=Deny).
                                 default: 'Allow'
     blob_cors:
         description:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -113,7 +113,7 @@ options:
                     - When I(default_action=Deny) this controls which Azure components can still reach the Storage Account.
                     - The list is comma separated.
                     - It can be any combination of the following: AzureServices, Logging, Metrics.
-                    - If no Azure components are allowed, explicitly set C(bypass="").
+                    - If no Azure components are allowed, explicitly set I(bypass="").
                 default: AzureServices
                 suboptions:
                     virtual_network_rules:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -94,6 +94,50 @@ options:
             -  Allows https traffic only to storage service when set to C(true).
         type: bool
         version_added: "2.8"
+    network_acls:
+        description:
+            - Manages the Firewall and virtual networks settings of the storage account.
+        type: dict
+        version_added: "2.10"
+        suboptions:
+            default_action:
+                description:
+                    - Default firewall traffic rule.
+                    - If set to 'Allow' no other settings have effect.
+                choices:
+                    - Allow
+                    - Deny
+                default: Allow
+            bypass:
+                description:
+                    - When C(default_action) is set to 'Deny' this controls which Azure components can still reach the Storage Account.
+                    - The list is comma separated.
+                    - It can be any combination of the following: AzureServices, Logging, Metrics.
+                    - If no Azure components are allowed, explicitly set C(bypass="").
+                default: AzureServices
+                suboptions:
+                    virtual_network_rules:
+                        description:
+                            - A list of subnets and their actions
+                        suboptions:
+                            id:
+                                description:
+                                    - The complete path to the subnet.
+                            action:
+                                description:
+                                    - The only logical action is 'Allow' because this setting is only accessible when C(default_action) is set to 'Deny'.
+                                default: 'Allow'
+                    ip_rules:
+                        description:
+                            - A list of ip addresses or ranges in CIDR format
+                        suboptions:
+                            value:
+                                description:
+                                    - The ip address or range.
+                            action:
+                                description:
+                                    - The only logical action is 'Allow' because this setting is only accessible when C(default_action) is set to 'Deny'.
+                                default: 'Allow'
     blob_cors:
         description:
             - Specifies CORS rules for the Blob service.
@@ -162,6 +206,23 @@ EXAMPLES = '''
         kind: FileStorage
         tags:
           testing: testing
+
+   - name: configure firewall and virtual networks
+      azure_rm_storageaccount:
+        resource_group: myResourceGroup
+        name: clh0002
+        type: Standard_RAGRS
+        network_acls:
+          bypass: AzureServices,Metrics
+          default_action: Deny
+          virtual_network_rules:
+            - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+              action: Allow
+          ip_rules:
+            - value: 1.2.3.4
+              action: Allow
+            - value: 123.234.123.0/24
+              action: Allow
 
     - name: create an account with blob CORS
       azure_rm_storageaccount:
@@ -233,6 +294,31 @@ state:
             returned: always
             type: str
             sample: clh0003
+        network_acls:
+            description:
+                - A set of firewall and virtual network rules
+            returned: always
+            type: dict
+            sample: {
+                    "bypass": "AzureServices",
+                    "default_action": "Deny",
+                    "virtual_network_rules": [
+                        {
+                            "action": "Allow",
+                            "id": "/subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
+                            }
+                        ],
+                    "ip_rules": [
+                        {
+                            "action": "Allow",
+                            "value": "1.2.3.4"
+                        },
+                        {
+                            "action": "Allow",
+                            "value": "123.234.123.0/24"
+                        }
+                    ]
+                    }
         primary_endpoints:
             description:
                 - The URLs to retrieve the public I(blob), I(queue), or I(table) object from the primary location.
@@ -362,6 +448,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             kind=dict(type='str', default='Storage', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
             access_tier=dict(type='str', choices=['Hot', 'Cool']),
             https_only=dict(type='bool', default=False),
+            network_acls=dict(type='dict'),
             blob_cors=dict(type='list', options=cors_rule_spec, elements='dict')
         )
 
@@ -382,6 +469,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         self.kind = None
         self.access_tier = None
         self.https_only = None
+        self.network_acls = None
         self.blob_cors = None
 
         super(AzureRMStorageAccount, self).__init__(self.module_arg_spec,
@@ -478,7 +566,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             status_of_secondary=(account_obj.status_of_secondary.value
                                  if account_obj.status_of_secondary is not None else None),
             primary_location=account_obj.primary_location,
-            https_only=account_obj.enable_https_traffic_only
+            https_only=account_obj.enable_https_traffic_only,
+            network_acls=account_obj.network_rule_set
         )
         account_dict['custom_domain'] = None
         if account_obj.custom_domain:
@@ -512,10 +601,70 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                 exposed_headers=[to_native(y) for y in x.exposed_headers],
                 allowed_headers=[to_native(y) for y in x.allowed_headers]
             ) for x in blob_service_props.cors.cors_rules]
+
+        account_dict['network_acls'] = None
+        if account_obj.network_rule_set:
+            account_dict['network_acls'] = dict(
+                bypass=account_obj.network_rule_set.bypass,
+                default_action=account_obj.network_rule_set.default_action
+            )
+            account_dict['network_acls']['virtual_network_rules'] = []
+            if account_obj.network_rule_set.virtual_network_rules:
+                for rule in account_obj.network_rule_set.virtual_network_rules:
+                    account_dict['network_acls']['virtual_network_rules'].append(dict(id=rule.virtual_network_resource_id, action=rule.action))
+
+            account_dict['network_acls']['ip_rules'] = []
+            if account_obj.network_rule_set.ip_rules:
+                for rule in account_obj.network_rule_set.ip_rules:
+                    account_dict['network_acls']['ip_rules'].append(dict(value=rule.ip_address_or_range, action=rule.action))
+
         return account_dict
+
+    def update_network_rule_set(self):
+        if not self.check_mode:
+            try:
+                parameters = self.storage_models.StorageAccountUpdateParameters(network_rule_set=self.network_acls)
+                self.storage_client.storage_accounts.update(self.resource_group,
+                                                            self.name,
+                                                            parameters)
+            except Exception as exc:
+                self.fail("Failed to update account type: {0}".format(str(exc)))
+
+    def sort_list_of_dicts(self, rule_set, dict_key):
+        return sorted(rule_set, key = lambda i: i[dict_key])
 
     def update_account(self):
         self.log('Update storage account {0}'.format(self.name))
+        if self.network_acls:
+            if self.network_acls.get('default_action', 'Allow') != self.account_dict['network_acls']['default_action']:
+                self.results['changed'] = True
+                self.account_dict['network_acls']['default_action'] = self.network_acls['default_action']
+                self.update_network_rule_set()
+
+            if self.network_acls.get('default_action', 'Allow') == 'Deny':
+                if sorted(self.network_acls['bypass'].replace(' ','').split(',')) != sorted(self.account_dict['network_acls']['bypass'].replace(' ','').split(',')):
+                    self.results['changed'] = True
+                    self.account_dict['network_acls']['bypass'] = self.network_acls['bypass']
+                    self.update_network_rule_set()
+
+                if self.network_acls.get('virtual_network_rules', None) != None and self.account_dict['network_acls']['virtual_network_rules'] != []:
+                    if self.sort_list_of_dicts(self.network_acls['virtual_network_rules'], 'id') != self.sort_list_of_dicts(self.account_dict['network_acls']['virtual_network_rules'], 'id'):
+                        self.results['changed'] = True
+                        self.account_dict['network_acls']['virtual_network_rules'] = self.network_acls['virtual_network_rules']
+                        self.update_network_rule_set()
+                if self.network_acls.get('virtual_network_rules', None) != None and self.account_dict['network_acls']['virtual_network_rules'] == []:
+                    self.results['changed'] = True
+                    self.update_network_rule_set()
+
+                if self.network_acls.get('ip_rules', None) != None and self.account_dict['network_acls']['ip_rules'] != []:
+                    if self.sort_list_of_dicts(self.network_acls['ip_rules'], 'value') != self.sort_list_of_dicts(self.account_dict['network_acls']['ip_rules'], 'value'):
+                        self.results['changed'] = True
+                        self.account_dict['network_acls']['ip_rules'] = self.network_acls['ip_rules']
+                        self.update_network_rule_set()
+                if self.network_acls.get('ip_rules', None) != None and self.account_dict['network_acls']['ip_rules'] == []:
+                    self.results['changed'] = True
+                    self.update_network_rule_set()
+
         if bool(self.https_only) != bool(self.account_dict.get('https_only')):
             self.results['changed'] = True
             self.account_dict['https_only'] = self.https_only
@@ -619,10 +768,13 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                 name=self.name,
                 resource_group=self.resource_group,
                 enable_https_traffic_only=self.https_only,
+                networks_acls=dict(),
                 tags=dict()
             )
             if self.tags:
                 account_dict['tags'] = self.tags
+            if self.network_acls:
+                account_dict['network_acls'] = self.network_acls
             if self.blob_cors:
                 account_dict['blob_cors'] = self.blob_cors
             return account_dict
@@ -633,6 +785,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                                                                         kind=self.kind,
                                                                         location=self.location,
                                                                         tags=self.tags,
+                                                                        enable_https_traffic_only=self.https_only,
                                                                         access_tier=self.access_tier)
         self.log(str(parameters))
         try:
@@ -641,6 +794,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         except CloudError as e:
             self.log('Error creating storage account.')
             self.fail("Failed to create account: {0}".format(str(e)))
+        if self.network_acls:
+            self.set_network_acls()
         if self.blob_cors:
             self.set_blob_cors()
         # the poller doesn't actually return anything
@@ -688,6 +843,14 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         except Exception as exc:
             self.fail("Failed to set CORS rules: {0}".format(str(exc)))
 
+    def set_network_acls(self):
+        try:
+            parameters = self.storage_models.StorageAccountUpdateParameters(network_rule_set=self.network_acls)
+            self.storage_client.storage_accounts.update(self.resource_group,
+                                                        self.name,
+                                                        parameters)
+        except Exception as exc:
+            self.fail("Failed to update account type: {0}".format(str(exc)))
 
 def main():
     AzureRMStorageAccount()

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -125,7 +125,7 @@ options:
                                     - The complete path to the subnet.
                             action:
                                 description:
-                                    - The only logical action is 'Allow' because this setting is only accessible when C(default_action) is set to 'Deny'.
+                                    - The only logical I(action=Allow) because this setting is only accessible when I(default_action=Deny).
                                 default: 'Allow'
                     ip_rules:
                         description:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -133,7 +133,7 @@ options:
                         suboptions:
                             value:
                                 description:
-                                    - The ip address or range.
+                                    - The IP address or range.
                             action:
                                 description:
                                     - The only logical I(action=Allow) because this setting is only accessible when I(default_action=Deny).

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -173,6 +173,31 @@ storageaccounts:
             returned: always
             type: bool
             sample: false
+        network_acls:
+            description:
+                - A set of firewall and virtual network rules
+            returned: always
+            type: dict
+            sample: {
+                    "bypass": "AzureServices",
+                    "default_action": "Deny",
+                    "virtual_network_rules": [
+                        {
+                            "action": "Allow",
+                            "id": "/subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
+                            }
+                        ],
+                    "ip_rules": [
+                        {
+                            "action": "Allow",
+                            "value": "1.2.3.4"
+                        },
+                        {
+                            "action": "Allow",
+                            "value": "123.234.123.0/24"
+                        }
+                    ]
+                    }
         provisioning_state:
             description:
                 - The status of the storage account at the time the operation was called.
@@ -478,6 +503,23 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 name=account_obj.custom_domain.name,
                 use_sub_domain=account_obj.custom_domain.use_sub_domain
             )
+
+        account_dict['network_acls'] = None
+        if account_obj.network_rule_set:
+            account_dict['network_acls'] = dict(
+                bypass=account_obj.network_rule_set.bypass,
+                default_action=account_obj.network_rule_set.default_action,
+                ip_rules=account_obj.network_rule_set.ip_rules
+            )
+            if account_obj.network_rule_set.virtual_network_rules:
+                account_dict['network_acls']['virtual_network_rules'] = []
+                for rule in account_obj.network_rule_set.virtual_network_rules:
+                    account_dict['network_acls']['virtual_network_rules'].append(dict(id=rule.virtual_network_resource_id, action=rule.action))
+
+            if account_obj.network_rule_set.ip_rules:
+                account_dict['network_acls']['ip_rules'] = []
+                for rule in account_obj.network_rule_set.ip_rules:
+                    account_dict['network_acls']['ip_rules'].append(dict(value=rule.ip_address_or_range, action=rule.action))
 
         account_dict['primary_endpoints'] = None
         if account_obj.primary_endpoints:

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -41,6 +41,14 @@
        tags:
            test: test
            galaxy: galaxy
+       http_only: yes
+       network_acls:
+         bypass: AzureServices
+         default_action: Deny
+         ip_rules:
+           - value: '9.9.9.9'
+             action: Allow
+
    register: output
 
  - name: Assert status succeeded and results include an Id value 
@@ -49,6 +57,10 @@
        - output.changed
        - output.state.id is defined
        - output.state.blob_cors | length == 1
+       - output.state.https_only
+       - output.state.network_acls.bypass == "AzureServices"
+       - output.state.network_acls.default_action == "Deny"
+       - output.state.network_acls.ip_rules | length == 1
 
  - name: Create new storage account (idempotence)
    azure_rm_storageaccount:
@@ -72,6 +84,13 @@
        tags:
            test: test
            galaxy: galaxy
+       http_only: yes
+       network_acls:
+         bypass: AzureServices
+         default_action: Deny
+         ip_rules:
+           - value: '9.9.9.9'
+             action: Allow
    register: output
   
  - assert:
@@ -138,12 +157,15 @@
 
  - assert:
        that:
-           - "output.storageaccounts| length == 1"
            - "output.storageaccounts | length == 1"
            - not output.storageaccounts[0].custom_domain
            - output.storageaccounts[0].account_type == "Standard_GRS"
            - output.storageaccounts[0].primary_endpoints.blob.connectionstring
            - output.storageaccounts[0].blob_cors
+           - output.storageaccounts[0].https_only
+           - output.storageaccounts[0].network_acls.bypass == "AzureServices"
+           - output.storageaccounts[0].network_acls.default_action == "Deny"
+           - output.storageaccounts[0].network_acls.ip_rules | length == 1
 
  - name: Gather facts
    azure_rm_storageaccount_info:


### PR DESCRIPTION
Add support for managing the 'Firewall and virtual networks' settings of a Storage Account.

##### SUMMARY
This PR adds support for managing the 'Firewall and virtual networks' settings of a Storage account.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Storage Account, Firewall and virtual networks

##### ADDITIONAL INFORMATION
Additionally this PR fixes not setting the https_only setting on creation of the storage account as this was a one line fix.