### PR TITLE
Migrate missing doc_fragments that went missing to this collection

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2016 Matt Davis, <mdavis@ansible.com>
+# Copyright: (c) 2016 Chris Houseknecht, <house@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+    # Azure doc fragment
+    DOCUMENTATION = r'''
+
+options:
+    ad_user:
+        description:
+            - Active Directory username. Use when authenticating with an Active Directory user rather than service
+              principal.
+        type: str
+    password:
+        description:
+            - Active Directory user password. Use when authenticating with an Active Directory user rather than service
+              principal.
+        type: str
+    profile:
+        description:
+            - Security profile found in ~/.azure/credentials file.
+        type: str
+    subscription_id:
+        description:
+            - Your Azure subscription Id.
+        type: str
+    client_id:
+        description:
+            - Azure client ID. Use when authenticating with a Service Principal.
+        type: str
+    secret:
+        description:
+            - Azure client secret. Use when authenticating with a Service Principal.
+        type: str
+    tenant:
+        description:
+            - Azure tenant ID. Use when authenticating with a Service Principal.
+        type: str
+    cloud_environment:
+        description:
+            - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),
+              C(AzureUSGovernment)), or a metadata discovery endpoint URL (required for Azure Stack). Can also be set via credential file profile or
+              the C(AZURE_CLOUD_ENVIRONMENT) environment variable.
+        type: str
+        default: AzureCloud
+        version_added: '2.4'
+    adfs_authority_url:
+        description:
+            - Azure AD authority url. Use when authenticating with Username/password, and has your own ADFS authority.
+        type: str
+        version_added: '2.6'
+    cert_validation_mode:
+        description:
+            - Controls the certificate validation behavior for Azure endpoints. By default, all modules will validate the server certificate, but
+              when an HTTPS proxy is in use, or against Azure Stack, it may be necessary to disable this behavior by passing C(ignore). Can also be
+              set via credential file profile or the C(AZURE_CERT_VALIDATION) environment variable.
+        type: str
+        choices: [ ignore, validate ]
+        version_added: '2.5'
+    auth_source:
+        description:
+            - Controls the source of the credentials to use for authentication.
+            - If not specified, ANSIBLE_AZURE_AUTH_SOURCE environment variable will be used and default to C(auto) if variable is not defined.
+            - C(auto) will follow the default precedence of module parameters -> environment variables -> default profile in credential file
+              C(~/.azure/credentials).
+            - When set to C(cli), the credentials will be sources from the default Azure CLI profile.
+            - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
+            - When set to C(msi), the host machine must be an azure resource with an enabled MSI extension. C(subscription_id) or the
+              environment variable C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if the resource is granted
+              access to more than one subscription, otherwise the first subscription is chosen.
+            - The C(msi) was added in Ansible 2.6.
+        type: str
+        choices:
+        - auto
+        - cli
+        - credential_file
+        - env
+        - msi
+        version_added: '2.5'
+    api_profile:
+        description:
+        - Selects an API profile to use when communicating with Azure services. Default value of C(latest) is appropriate for public clouds;
+          future values will allow use with Azure Stack.
+        type: str
+        default: latest
+        version_added: '2.5'
+requirements:
+    - python >= 2.7
+    - azure >= 2.0.0
+
+notes:
+    - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
+      in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login).
+    - Authentication is also possible using a service principal or Active Directory user.
+    - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
+      variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
+    - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and
+      AZURE_PASSWORD in the environment.
+    - "Alternatively, credentials can be stored in ~/.azure/credentials. This is an ini file containing
+      a [default] section and the following keys: subscription_id, client_id, secret and tenant or
+      subscription_id, ad_user and password. It is also possible to add additional profiles. Specify the profile
+      by passing profile or setting AZURE_PROFILE in the environment."
+
+seealso:
+    - name: Sign in with Azure CLI
+      link: https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest
+      description: How to authenticate using the C(az login) command.
+    '''

--- a/plugins/doc_fragments/azure_tags.py
+++ b/plugins/doc_fragments/azure_tags.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2016, Matt Davis, <mdavis@ansible.com>
+# Copyright: (c) 2016, Chris Houseknecht, <house@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+    # Azure doc fragment
+    DOCUMENTATION = r'''
+options:
+    tags:
+        description:
+            - Dictionary of string:string pairs to assign as metadata to the object.
+            - Metadata tags on the object will be updated with any provided values.
+            - To remove tags set append_tags option to false.
+        type: dict
+    append_tags:
+        description:
+            - Use to control if tags field is canonical or just appends to existing tags.
+            - When canonical, any tags not found in the tags parameter will be removed from the object's metadata.
+        type: bool
+        default: yes
+    '''

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -9,7 +9,7 @@ DOCUMENTATION = r'''
     plugin_type: inventory
     short_description: Azure Resource Manager inventory plugin
     extends_documentation_fragment:
-      - azure
+      - azure.azcollection.azure
     description:
         - Query VM details from Azure Resource Manager
         - Requires a YAML configuration file whose name ends with 'azure_rm.(yml|yaml)'

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -226,7 +226,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -227,7 +227,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Sertac Ozercan (@sozercan)

--- a/plugins/modules/azure_rm_aks_info.py
+++ b/plugins/modules/azure_rm_aks_info.py
@@ -43,7 +43,7 @@ options:
             - admin
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_aksversion_info.py
+++ b/plugins/modules/azure_rm_aksversion_info.py
@@ -33,7 +33,7 @@ options:
             - Get the upgrade versions available for a managed Kubernetes cluster version.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -378,7 +378,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -379,7 +379,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_applicationsecuritygroup.py
+++ b/plugins/modules/azure_rm_applicationsecuritygroup.py
@@ -43,7 +43,7 @@ options:
         - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_applicationsecuritygroup.py
+++ b/plugins/modules/azure_rm_applicationsecuritygroup.py
@@ -44,7 +44,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_applicationsecuritygroup_info.py
+++ b/plugins/modules/azure_rm_applicationsecuritygroup_info.py
@@ -33,7 +33,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_appserviceplan.py
+++ b/plugins/modules/azure_rm_appserviceplan.py
@@ -61,7 +61,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_appserviceplan.py
+++ b/plugins/modules/azure_rm_appserviceplan.py
@@ -62,7 +62,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_appserviceplan_info.py
+++ b/plugins/modules/azure_rm_appserviceplan_info.py
@@ -36,7 +36,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_automationaccount.py
+++ b/plugins/modules/azure_rm_automationaccount.py
@@ -46,7 +46,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_automationaccount.py
+++ b/plugins/modules/azure_rm_automationaccount.py
@@ -47,7 +47,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_automationaccount_info.py
+++ b/plugins/modules/azure_rm_automationaccount_info.py
@@ -52,7 +52,7 @@ options:
         type: bool
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_autoscale.py
+++ b/plugins/modules/azure_rm_autoscale.py
@@ -213,7 +213,7 @@ options:
 
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_autoscale.py
+++ b/plugins/modules/azure_rm_autoscale.py
@@ -214,7 +214,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_autoscale_info.py
+++ b/plugins/modules/azure_rm_autoscale_info.py
@@ -34,7 +34,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_availabilityset.py
+++ b/plugins/modules/azure_rm_availabilityset.py
@@ -65,7 +65,7 @@ options:
             - Aligned
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Julien Stroheker (@julienstroheker)

--- a/plugins/modules/azure_rm_availabilityset.py
+++ b/plugins/modules/azure_rm_availabilityset.py
@@ -64,7 +64,7 @@ options:
             - Classic
             - Aligned
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_availabilityset_info.py
+++ b/plugins/modules/azure_rm_availabilityset_info.py
@@ -34,7 +34,7 @@ options:
             - List of tags to be matched.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Julien Stroheker (@julienstroheker)

--- a/plugins/modules/azure_rm_azurefirewall.py
+++ b/plugins/modules/azure_rm_azurefirewall.py
@@ -226,7 +226,7 @@ options:
             - absent
             - present
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_azurefirewall.py
+++ b/plugins/modules/azure_rm_azurefirewall.py
@@ -227,7 +227,7 @@ options:
             - present
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
     - Zim Kalinowski (@zikalino)
     - Jurijs Fadejevs (@needgithubid)

--- a/plugins/modules/azure_rm_azurefirewall_info.py
+++ b/plugins/modules/azure_rm_azurefirewall_info.py
@@ -30,7 +30,7 @@ options:
             - Resource name.
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 author:
     - Liu Qingyi (@smile37773)
 

--- a/plugins/modules/azure_rm_batchaccount.py
+++ b/plugins/modules/azure_rm_batchaccount.py
@@ -81,7 +81,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Junyi Yi (@JunyiYi)

--- a/plugins/modules/azure_rm_batchaccount.py
+++ b/plugins/modules/azure_rm_batchaccount.py
@@ -80,7 +80,7 @@ options:
             - absent
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_cdnendpoint.py
+++ b/plugins/modules/azure_rm_cdnendpoint.py
@@ -119,7 +119,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_cdnendpoint.py
+++ b/plugins/modules/azure_rm_cdnendpoint.py
@@ -120,7 +120,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_cdnendpoint_info.py
+++ b/plugins/modules/azure_rm_cdnendpoint_info.py
@@ -40,7 +40,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -51,7 +51,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -52,7 +52,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_cdnprofile_info.py
+++ b/plugins/modules/azure_rm_cdnprofile_info.py
@@ -35,7 +35,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_containerinstance.py
+++ b/plugins/modules/azure_rm_containerinstance.py
@@ -143,7 +143,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_containerinstance.py
+++ b/plugins/modules/azure_rm_containerinstance.py
@@ -142,7 +142,7 @@ options:
         default: 'no'
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_containerinstance_info.py
+++ b/plugins/modules/azure_rm_containerinstance_info.py
@@ -34,7 +34,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_containerregistry.py
+++ b/plugins/modules/azure_rm_containerregistry.py
@@ -53,7 +53,7 @@ options:
             - Premium
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_containerregistry.py
+++ b/plugins/modules/azure_rm_containerregistry.py
@@ -54,7 +54,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yawei Wang (@yaweiw)

--- a/plugins/modules/azure_rm_containerregistry_info.py
+++ b/plugins/modules/azure_rm_containerregistry_info.py
@@ -39,7 +39,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_containerregistryreplication.py
+++ b/plugins/modules/azure_rm_containerregistryreplication.py
@@ -42,7 +42,7 @@ options:
             - Resource location. If not set, location from the resource group will be used as default.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - "Zim Kalinowski (@zikalino)"

--- a/plugins/modules/azure_rm_containerregistryreplication_facts.py
+++ b/plugins/modules/azure_rm_containerregistryreplication_facts.py
@@ -36,7 +36,7 @@ options:
         required: True
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - "Zim Kalinowski (@zikalino)"

--- a/plugins/modules/azure_rm_containerregistrywebhook.py
+++ b/plugins/modules/azure_rm_containerregistrywebhook.py
@@ -59,7 +59,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - "Zim Kalinowski (@zikalino)"

--- a/plugins/modules/azure_rm_containerregistrywebhook_facts.py
+++ b/plugins/modules/azure_rm_containerregistrywebhook_facts.py
@@ -36,7 +36,7 @@ options:
         required: True
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - "Zim Kalinowski (@zikalino)"

--- a/plugins/modules/azure_rm_cosmosdbaccount.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount.py
@@ -138,7 +138,7 @@ options:
         - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_cosmosdbaccount.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount.py
@@ -139,7 +139,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_cosmosdbaccount_info.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount_info.py
@@ -44,7 +44,7 @@ options:
         type: bool
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_deployment.py
+++ b/plugins/modules/azure_rm_deployment.py
@@ -89,7 +89,7 @@ options:
         - absent
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_deployment.py
+++ b/plugins/modules/azure_rm_deployment.py
@@ -90,7 +90,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - David Justice (@devigned)

--- a/plugins/modules/azure_rm_deployment_info.py
+++ b/plugins/modules/azure_rm_deployment_info.py
@@ -31,7 +31,7 @@ options:
             - The name of the deployment.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlab.py
+++ b/plugins/modules/azure_rm_devtestlab.py
@@ -54,7 +54,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlab.py
+++ b/plugins/modules/azure_rm_devtestlab.py
@@ -53,7 +53,7 @@ options:
         - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlab_info.py
+++ b/plugins/modules/azure_rm_devtestlab_info.py
@@ -36,7 +36,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabarmtemplate_info.py
+++ b/plugins/modules/azure_rm_devtestlabarmtemplate_info.py
@@ -43,7 +43,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabartifact_info.py
+++ b/plugins/modules/azure_rm_devtestlabartifact_info.py
@@ -43,7 +43,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabartifactsource.py
+++ b/plugins/modules/azure_rm_devtestlabartifactsource.py
@@ -73,7 +73,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabartifactsource.py
+++ b/plugins/modules/azure_rm_devtestlabartifactsource.py
@@ -72,7 +72,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabartifactsource_info.py
+++ b/plugins/modules/azure_rm_devtestlabartifactsource_info.py
@@ -42,7 +42,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabcustomimage.py
+++ b/plugins/modules/azure_rm_devtestlabcustomimage.py
@@ -67,7 +67,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabcustomimage.py
+++ b/plugins/modules/azure_rm_devtestlabcustomimage.py
@@ -68,7 +68,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabcustomimage_info.py
+++ b/plugins/modules/azure_rm_devtestlabcustomimage_info.py
@@ -42,7 +42,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabenvironment.py
+++ b/plugins/modules/azure_rm_devtestlabenvironment.py
@@ -65,7 +65,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabenvironment.py
+++ b/plugins/modules/azure_rm_devtestlabenvironment.py
@@ -66,7 +66,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabenvironment_info.py
+++ b/plugins/modules/azure_rm_devtestlabenvironment_info.py
@@ -47,7 +47,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabpolicy.py
+++ b/plugins/modules/azure_rm_devtestlabpolicy.py
@@ -67,7 +67,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabpolicy.py
+++ b/plugins/modules/azure_rm_devtestlabpolicy.py
@@ -68,7 +68,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabpolicy_info.py
+++ b/plugins/modules/azure_rm_devtestlabpolicy_info.py
@@ -47,7 +47,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabschedule.py
+++ b/plugins/modules/azure_rm_devtestlabschedule.py
@@ -53,7 +53,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabschedule.py
+++ b/plugins/modules/azure_rm_devtestlabschedule.py
@@ -54,7 +54,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabschedule_info.py
+++ b/plugins/modules/azure_rm_devtestlabschedule_info.py
@@ -42,7 +42,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabvirtualmachine.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualmachine.py
@@ -130,7 +130,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabvirtualmachine.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualmachine.py
@@ -129,7 +129,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabvirtualmachine_info.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualmachine_info.py
@@ -42,7 +42,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabvirtualnetwork.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualnetwork.py
@@ -51,7 +51,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_devtestlabvirtualnetwork.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualnetwork.py
@@ -50,7 +50,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_devtestlabvirtualnetwork_info.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualnetwork_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -91,7 +91,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Obezimnaka Boms (@ozboms)

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -90,7 +90,7 @@ options:
                     - Primary data value for all record types.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_dnsrecordset_info.py
+++ b/plugins/modules/azure_rm_dnsrecordset_info.py
@@ -41,7 +41,7 @@ options:
         type: int
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_dnsrecordset_info.py
+++ b/plugins/modules/azure_rm_dnsrecordset_info.py
@@ -42,7 +42,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Ozi Boms (@ozboms)

--- a/plugins/modules/azure_rm_dnszone.py
+++ b/plugins/modules/azure_rm_dnszone.py
@@ -76,7 +76,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Obezimnaka Boms (@ozboms)

--- a/plugins/modules/azure_rm_dnszone.py
+++ b/plugins/modules/azure_rm_dnszone.py
@@ -75,7 +75,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_dnszone_info.py
+++ b/plugins/modules/azure_rm_dnszone_info.py
@@ -35,7 +35,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_dnszone_info.py
+++ b/plugins/modules/azure_rm_dnszone_info.py
@@ -36,7 +36,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Obezimnaka Boms (@ozboms)

--- a/plugins/modules/azure_rm_functionapp.py
+++ b/plugins/modules/azure_rm_functionapp.py
@@ -79,7 +79,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_functionapp.py
+++ b/plugins/modules/azure_rm_functionapp.py
@@ -80,7 +80,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Thomas Stringer (@trstringer)

--- a/plugins/modules/azure_rm_functionapp_info.py
+++ b/plugins/modules/azure_rm_functionapp_info.py
@@ -34,7 +34,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Thomas Stringer (@trstringer)

--- a/plugins/modules/azure_rm_gallery.py
+++ b/plugins/modules/azure_rm_gallery.py
@@ -51,7 +51,7 @@ options:
             - present
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
     - Zim Kalinowski (@zikalino)
 

--- a/plugins/modules/azure_rm_gallery.py
+++ b/plugins/modules/azure_rm_gallery.py
@@ -50,7 +50,7 @@ options:
             - absent
             - present
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_gallery_info.py
+++ b/plugins/modules/azure_rm_gallery_info.py
@@ -30,7 +30,7 @@ options:
             - Resource name
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 author:
     - Liu Qingyi (@smile37773)
 

--- a/plugins/modules/azure_rm_galleryimage.py
+++ b/plugins/modules/azure_rm_galleryimage.py
@@ -170,7 +170,7 @@ options:
         type: str
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
   - Zim Kalinowski (@zikalino)
 

--- a/plugins/modules/azure_rm_galleryimage.py
+++ b/plugins/modules/azure_rm_galleryimage.py
@@ -169,7 +169,7 @@ options:
             - present
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
   - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_galleryimage_info.py
+++ b/plugins/modules/azure_rm_galleryimage_info.py
@@ -36,7 +36,7 @@ options:
             - Resource name.
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 author:
     - Liu Qingyi (@smile37773)
 

--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -169,7 +169,7 @@ options:
         type: str
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
     - Zim Kalinowski (@zikalino)
 

--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -168,7 +168,7 @@ options:
             - present
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_galleryimageversion_info.py
+++ b/plugins/modules/azure_rm_galleryimageversion_info.py
@@ -41,7 +41,7 @@ options:
             - Resource name.
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 author:
     - Liu Qingyi (@smile37773)
 

--- a/plugins/modules/azure_rm_hdinsightcluster.py
+++ b/plugins/modules/azure_rm_hdinsightcluster.py
@@ -124,7 +124,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_hdinsightcluster.py
+++ b/plugins/modules/azure_rm_hdinsightcluster.py
@@ -123,7 +123,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_hdinsightcluster_info.py
+++ b/plugins/modules/azure_rm_hdinsightcluster_info.py
@@ -33,7 +33,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_image.py
+++ b/plugins/modules/azure_rm_image.py
@@ -59,7 +59,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_image.py
+++ b/plugins/modules/azure_rm_image.py
@@ -60,7 +60,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_image_info.py
+++ b/plugins/modules/azure_rm_image_info.py
@@ -33,7 +33,7 @@ options:
             - List of tags to be matched.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Madhura Naniwadekar (@Madhura-CSI)

--- a/plugins/modules/azure_rm_iotdevice.py
+++ b/plugins/modules/azure_rm_iotdevice.py
@@ -99,7 +99,7 @@ options:
         type: dict
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_iotdevice.py
+++ b/plugins/modules/azure_rm_iotdevice.py
@@ -98,7 +98,7 @@ options:
             - Not supported in IoT Hub with Basic tier.
         type: dict
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_iotdevice_info.py
+++ b/plugins/modules/azure_rm_iotdevice_info.py
@@ -60,7 +60,7 @@ options:
         type: int
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_iotdevice_info.py
+++ b/plugins/modules/azure_rm_iotdevice_info.py
@@ -59,7 +59,7 @@ options:
             - List the top n devices in the query.
         type: int
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_iotdevicemodule.py
+++ b/plugins/modules/azure_rm_iotdevicemodule.py
@@ -93,7 +93,7 @@ options:
         type: dict
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_iotdevicemodule.py
+++ b/plugins/modules/azure_rm_iotdevicemodule.py
@@ -92,7 +92,7 @@ options:
             - List is not supported.
         type: dict
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_iothub.py
+++ b/plugins/modules/azure_rm_iothub.py
@@ -189,7 +189,7 @@ options:
                 type: str
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_iothub.py
+++ b/plugins/modules/azure_rm_iothub.py
@@ -188,7 +188,7 @@ options:
                        see U(https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-routing-query-syntax)"
                 type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_iothub_info.py
+++ b/plugins/modules/azure_rm_iothub_info.py
@@ -66,7 +66,7 @@ options:
             - Note this will have network overhead for each IoT Hub.
         type: bool
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_iothubconsumergroup.py
+++ b/plugins/modules/azure_rm_iothubconsumergroup.py
@@ -50,7 +50,7 @@ options:
         type: str
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_iothubconsumergroup.py
+++ b/plugins/modules/azure_rm_iothubconsumergroup.py
@@ -49,7 +49,7 @@ options:
             - Name of the consumer group.
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -150,7 +150,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -151,7 +151,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_keyvault_info.py
+++ b/plugins/modules/azure_rm_keyvault_info.py
@@ -33,7 +33,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -48,7 +48,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Ian Philpot (@iphilpot)

--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -47,7 +47,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -50,7 +50,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -41,7 +41,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -42,7 +42,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Ian Philpot (@iphilpot)

--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -50,7 +50,7 @@ options:
         type: dict
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Jose Angel Munoz (@imjoseangel)

--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -350,7 +350,7 @@ options:
             - (deprecated) The protocol for the NAT pool.
             - This option has been deprecated, and will be removed in 2.9. Use I(inbound_nat_pools) instead.
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -351,7 +351,7 @@ options:
             - This option has been deprecated, and will be removed in 2.9. Use I(inbound_nat_pools) instead.
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Thomas Stringer (@trstringer)

--- a/plugins/modules/azure_rm_loadbalancer_info.py
+++ b/plugins/modules/azure_rm_loadbalancer_info.py
@@ -36,7 +36,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Thomas Stringer (@trstringer)

--- a/plugins/modules/azure_rm_lock.py
+++ b/plugins/modules/azure_rm_lock.py
@@ -60,7 +60,7 @@ options:
             - can_not_delete
             - read_only
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_lock_info.py
+++ b/plugins/modules/azure_rm_lock_info.py
@@ -47,7 +47,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_loganalyticsworkspace.py
+++ b/plugins/modules/azure_rm_loganalyticsworkspace.py
@@ -64,7 +64,7 @@ options:
             - Other intelligence packs not list in this property will not be changed.
         type: dict
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_loganalyticsworkspace.py
+++ b/plugins/modules/azure_rm_loganalyticsworkspace.py
@@ -65,7 +65,7 @@ options:
         type: dict
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_loganalyticsworkspace_info.py
+++ b/plugins/modules/azure_rm_loganalyticsworkspace_info.py
@@ -48,7 +48,7 @@ options:
             - Show the list of usages for a workspace.
             - Note this will cost one more network overhead for each workspace, expected slow response.
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -124,7 +124,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
     - Bruno Medina (@brusMX)
 '''

--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -123,7 +123,7 @@ options:
         version_added: '2.10'
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
     - Bruno Medina (@brusMX)

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -43,7 +43,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Bruno Medina (@brusMX)

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -42,7 +42,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_managementgroup.py
+++ b/plugins/modules/azure_rm_managementgroup.py
@@ -70,7 +70,7 @@ options:
         type: str
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
     - Zim Kalinowski (@zikalino)
 

--- a/plugins/modules/azure_rm_managementgroup.py
+++ b/plugins/modules/azure_rm_managementgroup.py
@@ -69,7 +69,7 @@ options:
             - present
         type: str
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbconfiguration.py
+++ b/plugins/modules/azure_rm_mariadbconfiguration.py
@@ -47,7 +47,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbconfiguration_info.py
+++ b/plugins/modules/azure_rm_mariadbconfiguration_info.py
@@ -39,7 +39,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbdatabase.py
+++ b/plugins/modules/azure_rm_mariadbdatabase.py
@@ -58,7 +58,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbdatabase_info.py
+++ b/plugins/modules/azure_rm_mariadbdatabase_info.py
@@ -39,7 +39,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbfirewallrule.py
+++ b/plugins/modules/azure_rm_mariadbfirewallrule.py
@@ -50,7 +50,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbfirewallrule_info.py
+++ b/plugins/modules/azure_rm_mariadbfirewallrule_info.py
@@ -39,7 +39,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbserver.py
+++ b/plugins/modules/azure_rm_mariadbserver.py
@@ -87,7 +87,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_mariadbserver.py
+++ b/plugins/modules/azure_rm_mariadbserver.py
@@ -88,7 +88,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mariadbserver_info.py
+++ b/plugins/modules/azure_rm_mariadbserver_info.py
@@ -38,7 +38,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_monitorlogprofile.py
+++ b/plugins/modules/azure_rm_monitorlogprofile.py
@@ -74,7 +74,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_monitorlogprofile.py
+++ b/plugins/modules/azure_rm_monitorlogprofile.py
@@ -75,7 +75,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_mysqlconfiguration.py
+++ b/plugins/modules/azure_rm_mysqlconfiguration.py
@@ -46,7 +46,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqlconfiguration_info.py
+++ b/plugins/modules/azure_rm_mysqlconfiguration_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqldatabase.py
+++ b/plugins/modules/azure_rm_mysqldatabase.py
@@ -57,7 +57,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqldatabase_info.py
+++ b/plugins/modules/azure_rm_mysqldatabase_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqlfirewallrule.py
+++ b/plugins/modules/azure_rm_mysqlfirewallrule.py
@@ -51,7 +51,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_mysqlfirewallrule_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqlserver.py
+++ b/plugins/modules/azure_rm_mysqlserver.py
@@ -86,7 +86,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_mysqlserver.py
+++ b/plugins/modules/azure_rm_mysqlserver.py
@@ -87,7 +87,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_mysqlserver_info.py
+++ b/plugins/modules/azure_rm_mysqlserver_info.py
@@ -37,7 +37,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -207,7 +207,7 @@ options:
         version_added: '2.7'
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -206,7 +206,7 @@ options:
         type: list
         version_added: '2.7'
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_networkinterface_info.py
+++ b/plugins/modules/azure_rm_networkinterface_info.py
@@ -37,7 +37,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_postgresqlconfiguration.py
+++ b/plugins/modules/azure_rm_postgresqlconfiguration.py
@@ -46,7 +46,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqlconfiguration_info.py
+++ b/plugins/modules/azure_rm_postgresqlconfiguration_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqldatabase.py
+++ b/plugins/modules/azure_rm_postgresqldatabase.py
@@ -57,7 +57,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqldatabase_info.py
+++ b/plugins/modules/azure_rm_postgresqldatabase_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqlfirewallrule.py
+++ b/plugins/modules/azure_rm_postgresqlfirewallrule.py
@@ -49,7 +49,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_postgresqlfirewallrule_info.py
@@ -38,7 +38,7 @@ options:
         type: str
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqlserver.py
+++ b/plugins/modules/azure_rm_postgresqlserver.py
@@ -89,7 +89,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_postgresqlserver.py
+++ b/plugins/modules/azure_rm_postgresqlserver.py
@@ -88,7 +88,7 @@ options:
             - absent
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_postgresqlserver_info.py
+++ b/plugins/modules/azure_rm_postgresqlserver_info.py
@@ -37,7 +37,7 @@ options:
         type: list
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -98,7 +98,7 @@ options:
         version_added: "2.8"
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -99,7 +99,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_publicipaddress_info.py
+++ b/plugins/modules/azure_rm_publicipaddress_info.py
@@ -37,7 +37,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_rediscache.py
+++ b/plugins/modules/azure_rm_rediscache.py
@@ -157,7 +157,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_rediscache.py
+++ b/plugins/modules/azure_rm_rediscache.py
@@ -158,7 +158,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_rediscache_info.py
+++ b/plugins/modules/azure_rm_rediscache_info.py
@@ -41,7 +41,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_rediscachefirewallrule.py
+++ b/plugins/modules/azure_rm_rediscachefirewallrule.py
@@ -52,7 +52,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_resource.py
+++ b/plugins/modules/azure_rm_resource.py
@@ -105,7 +105,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -58,7 +58,7 @@ options:
                     - Subresource name.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_resourcegroup.py
+++ b/plugins/modules/azure_rm_resourcegroup.py
@@ -47,7 +47,7 @@ options:
             - absent
             - present
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_resourcegroup.py
+++ b/plugins/modules/azure_rm_resourcegroup.py
@@ -48,7 +48,7 @@ options:
             - present
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_resourcegroup_info.py
+++ b/plugins/modules/azure_rm_resourcegroup_info.py
@@ -39,7 +39,7 @@ options:
         version_added: "2.8"
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_roleassignment.py
+++ b/plugins/modules/azure_rm_roleassignment.py
@@ -50,7 +50,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_roleassignment_info.py
+++ b/plugins/modules/azure_rm_roleassignment_info.py
@@ -41,7 +41,7 @@ options:
             - Resource id of role definition.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_roledefinition.py
+++ b/plugins/modules/azure_rm_roledefinition.py
@@ -66,7 +66,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_roledefinition_info.py
+++ b/plugins/modules/azure_rm_roledefinition_info.py
@@ -40,7 +40,7 @@ options:
             - custom
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu(@yungezz)

--- a/plugins/modules/azure_rm_route.py
+++ b/plugins/modules/azure_rm_route.py
@@ -61,7 +61,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_route.py
+++ b/plugins/modules/azure_rm_route.py
@@ -60,7 +60,7 @@ options:
 
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_routetable.py
+++ b/plugins/modules/azure_rm_routetable.py
@@ -47,7 +47,7 @@ options:
             - Derived from I(resource_group) if not specified.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_routetable.py
+++ b/plugins/modules/azure_rm_routetable.py
@@ -48,7 +48,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_routetable_info.py
+++ b/plugins/modules/azure_rm_routetable_info.py
@@ -36,7 +36,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -141,7 +141,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -140,7 +140,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_securitygroup_info.py
+++ b/plugins/modules/azure_rm_securitygroup_info.py
@@ -38,7 +38,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_servicebus.py
+++ b/plugins/modules/azure_rm_servicebus.py
@@ -50,7 +50,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_servicebus.py
+++ b/plugins/modules/azure_rm_servicebus.py
@@ -49,7 +49,7 @@ options:
         default: standard
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_servicebus_info.py
+++ b/plugins/modules/azure_rm_servicebus_info.py
@@ -59,7 +59,7 @@ options:
             - Note if enable this option, the facts module will raise two more HTTP call for each resources, need more network overhead.
         type: bool
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_servicebusqueue.py
+++ b/plugins/modules/azure_rm_servicebusqueue.py
@@ -112,7 +112,7 @@ options:
             - send_disabled
             - receive_disabled
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_servicebusqueue.py
+++ b/plugins/modules/azure_rm_servicebusqueue.py
@@ -113,7 +113,7 @@ options:
             - receive_disabled
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_servicebussaspolicy.py
+++ b/plugins/modules/azure_rm_servicebussaspolicy.py
@@ -71,7 +71,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_servicebussaspolicy.py
+++ b/plugins/modules/azure_rm_servicebussaspolicy.py
@@ -70,7 +70,7 @@ options:
             - listen_send
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_servicebustopic.py
+++ b/plugins/modules/azure_rm_servicebustopic.py
@@ -93,7 +93,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_servicebustopic.py
+++ b/plugins/modules/azure_rm_servicebustopic.py
@@ -92,7 +92,7 @@ options:
             - receive_disabled
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_servicebustopicsubscription.py
+++ b/plugins/modules/azure_rm_servicebustopicsubscription.py
@@ -105,7 +105,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yuwei Zhou (@yuwzho)

--- a/plugins/modules/azure_rm_servicebustopicsubscription.py
+++ b/plugins/modules/azure_rm_servicebustopicsubscription.py
@@ -104,7 +104,7 @@ options:
             - receive_disabled
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_snapshot.py
+++ b/plugins/modules/azure_rm_snapshot.py
@@ -90,7 +90,7 @@ options:
           - present
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 author:
     - Zim Kalinowski (@zikalino)
 

--- a/plugins/modules/azure_rm_snapshot.py
+++ b/plugins/modules/azure_rm_snapshot.py
@@ -89,7 +89,7 @@ options:
           - absent
           - present
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_sqldatabase.py
+++ b/plugins/modules/azure_rm_sqldatabase.py
@@ -135,7 +135,7 @@ options:
         - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_sqldatabase.py
+++ b/plugins/modules/azure_rm_sqldatabase.py
@@ -136,7 +136,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_sqldatabase_info.py
+++ b/plugins/modules/azure_rm_sqldatabase_info.py
@@ -41,7 +41,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_sqlfirewallrule.py
+++ b/plugins/modules/azure_rm_sqlfirewallrule.py
@@ -51,7 +51,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_sqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_sqlfirewallrule_info.py
@@ -35,7 +35,7 @@ options:
             - The name of the firewall rule.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_sqlserver.py
+++ b/plugins/modules/azure_rm_sqlserver.py
@@ -55,7 +55,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_sqlserver.py
+++ b/plugins/modules/azure_rm_sqlserver.py
@@ -56,7 +56,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_sqlserver_info.py
+++ b/plugins/modules/azure_rm_sqlserver_info.py
@@ -31,7 +31,7 @@ options:
             - The name of the server.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_sqlserver_info.py
+++ b/plugins/modules/azure_rm_sqlserver_info.py
@@ -32,7 +32,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -130,7 +130,7 @@ options:
                 required: true
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -131,7 +131,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -52,7 +52,7 @@ options:
         version_added: "2.8"
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_storageblob.py
+++ b/plugins/modules/azure_rm_storageblob.py
@@ -113,7 +113,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_storageblob.py
+++ b/plugins/modules/azure_rm_storageblob.py
@@ -112,7 +112,7 @@ options:
             - blob
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -80,7 +80,7 @@ options:
         version_added: "2.8"
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_subnet_info.py
+++ b/plugins/modules/azure_rm_subnet_info.py
@@ -35,7 +35,7 @@ options:
             - The name of the subnet.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_trafficmanager.py
+++ b/plugins/modules/azure_rm_trafficmanager.py
@@ -146,7 +146,7 @@ options:
                     - The list of countries/regions mapped to this endpoint when using the 'Geographic' traffic routing method.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_trafficmanager.py
+++ b/plugins/modules/azure_rm_trafficmanager.py
@@ -147,7 +147,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - "Hai Cao <t-haicao@microsoft.com>"

--- a/plugins/modules/azure_rm_trafficmanagerendpoint.py
+++ b/plugins/modules/azure_rm_trafficmanagerendpoint.py
@@ -91,7 +91,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_trafficmanagerendpoint_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerendpoint_info.py
@@ -44,7 +44,7 @@ options:
             - nested_endpoints
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_trafficmanagerprofile.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile.py
@@ -104,7 +104,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_trafficmanagerprofile.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile.py
@@ -103,7 +103,7 @@ options:
             path: /
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_trafficmanagerprofile_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile_info.py
@@ -35,7 +35,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Hai Cao (@caohai)

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -382,7 +382,7 @@ options:
                 required: false
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -383,7 +383,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -38,7 +38,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Gustavo Muniz do Carmo (@gustavomcarmo)

--- a/plugins/modules/azure_rm_virtualmachineextension.py
+++ b/plugins/modules/azure_rm_virtualmachineextension.py
@@ -68,7 +68,7 @@ options:
         type: bool
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Sertac Ozercan (@sozercan)

--- a/plugins/modules/azure_rm_virtualmachineextension_info.py
+++ b/plugins/modules/azure_rm_virtualmachineextension_info.py
@@ -38,7 +38,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_virtualmachineimage_info.py
+++ b/plugins/modules/azure_rm_virtualmachineimage_info.py
@@ -45,7 +45,7 @@ options:
             - Specific version number of an image.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -263,7 +263,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Sertac Ozercan (@sozercan)

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -262,7 +262,7 @@ options:
         version_added: "2.10"
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_virtualmachinescaleset_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset_info.py
@@ -47,7 +47,7 @@ options:
         version_added: "2.6"
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Sertac Ozercan (@sozercan)

--- a/plugins/modules/azure_rm_virtualmachinescalesetextension.py
+++ b/plugins/modules/azure_rm_virtualmachinescalesetextension.py
@@ -73,7 +73,7 @@ options:
 
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_virtualmachinescalesetextension_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescalesetextension_info.py
@@ -35,7 +35,7 @@ options:
             - The name of the virtual machine extension.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_virtualmachinescalesetinstance.py
+++ b/plugins/modules/azure_rm_virtualmachinescalesetinstance.py
@@ -64,7 +64,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_virtualmachinescalesetinstance_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescalesetinstance_info.py
@@ -38,7 +38,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Zim Kalinowski (@zikalino)

--- a/plugins/modules/azure_rm_virtualnetwork.py
+++ b/plugins/modules/azure_rm_virtualnetwork.py
@@ -68,7 +68,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_virtualnetwork.py
+++ b/plugins/modules/azure_rm_virtualnetwork.py
@@ -67,7 +67,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -37,7 +37,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Chris Houseknecht (@chouseknecht)

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -115,7 +115,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Madhura Naniwadekar (@Madhura-CSI)

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -114,7 +114,7 @@ options:
                 required: True
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -69,7 +69,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_virtualnetworkpeering_info.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering_info.py
@@ -33,7 +33,7 @@ options:
             - Name of the virtual network peering.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -187,7 +187,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -186,7 +186,7 @@ options:
             - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_webapp_info.py
+++ b/plugins/modules/azure_rm_webapp_info.py
@@ -41,7 +41,7 @@ options:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
 
 author:
     - Yunge Zhu (@yungezz)

--- a/plugins/modules/azure_rm_webappslot.py
+++ b/plugins/modules/azure_rm_webappslot.py
@@ -167,7 +167,7 @@ options:
           - present
 
 extends_documentation_fragment:
-    - azure
+    - azure.azcollection.azure
     - azure_tags
 
 author:

--- a/plugins/modules/azure_rm_webappslot.py
+++ b/plugins/modules/azure_rm_webappslot.py
@@ -168,7 +168,7 @@ options:
 
 extends_documentation_fragment:
     - azure.azcollection.azure
-    - azure_tags
+    - azure.azcollection.azure_tags
 
 author:
     - Yunge Zhu(@yungezz)


### PR DESCRIPTION
##### SUMMARY
See issue https://github.com/ansible-collections/azure/issues/103

This pulls in:

https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/plugins/doc_fragments/azure.py
https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/plugins/doc_fragments/azure_tags.py

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
doc_fragments/azure.py
doc_fragments/azure_tags.py

##### ADDITIONAL INFORMATION
I tried to do due diligence asking here:

https://github.com/ansible/ansible/pull/67684#issuecomment-628095773

About whether or not the current code in this collection will be allowed to work. There was some confusion on that point, but they have clearly answered that nothing is planned that will support the non-FQCN doc fragment. I see no way to get this fixed in any reasonable timeframe other than the collection, itself, making this change.

Example of testing this:

```
ANSIBLE_COLLECTIONS_PATHS=../../.. ansible-doc azure.azcollection.azure_rm_image
```

This renders correctly (using Ansible `devel` branch), and makes use of both doc fragments. I have also tested the inventory plugin with `ansible-inventory`.

Ping @gundalow, because I know he has tried to do a sweep to check for items that went missing in the great collection migration. This isn't the first time this kind of situation has happened. Doc fragments were not around when several collections started out, so there's a clear story of how it got here.

if you consult the Ansible core file (the current file) `.github//BOTMETA.yml`, then you will find:

```
  lib/ansible/plugins/doc_fragments/azure.py:
    migrated_to: azure.azcollection
  lib/ansible/plugins/doc_fragments/azure_tags.py:
    migrated_to: azure.azcollection
```

So clearly _it_ thinks that these files moved here.