### PR TITLE
Add ability to remove all Subnet Service Endpoints when supplying an empty list

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -285,7 +285,7 @@ class AzureRMSubnet(AzureRMModuleBase):
                     results['route_table']['id'] = self.route_table
                     self.log("CHANGED: subnet {0} route_table to {1}".format(self.name, route_table.get('name')))
 
-                if self.service_endpoints:
+                if self.service_endpoints or self.service_endpoints == []:
                     oldd = {}
                     for item in self.service_endpoints:
                         name = item['service']

--- a/tests/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -94,6 +94,18 @@
 - assert:
     that: not output.changed
 
+- name: Able to completely remove service endpoints
+  azure_rm_subnet:
+    name: foobar
+    virtual_network_name: My_Virtual_Network
+    resource_group: "{{ resource_group }}"
+    address_prefix_cidr: "10.1.0.0/16"
+    service_endpoints: []
+  register: output
+
+- assert:
+    that: output.state.service_endpoints is not defined
+
 - name: Create network security group in another resource group
   azure_rm_securitygroup:
     name: secgroupfoo


### PR DESCRIPTION
##### SUMMARY
Previously it was impossible to completely remove Service Endpoints from a subnet because of the way the code was written. Even explicitly supplying an empty list would result in the code not comparing with the current state. This PR adds a minor tweak to fix this scenario and adds a test for it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_subnet

##### ADDITIONAL INFORMATION
The problem was the way the code evaluated the supplied value for service_endpoints:

```
if self.service_endpoints:
```

When self.service_endpoints is equal to None (default) or '[]', the code will not enter the if-loop. Extending the if-statement as follows will enable to completely remove all Service Endpoints:

```
if self.service_endpoints or self.service_endpoints == []:
```