### PR TITLE
For Ansible 2.10 compat, change imports to use module_utils already in this collection

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>2.8'

--- a/plugins/modules/azure_rm_lock.py
+++ b/plugins/modules/azure_rm_lock.py
@@ -101,7 +101,7 @@ id:
     sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Authorization/locks/keep"
 '''  # NOQA
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_lock_info.py
+++ b/plugins/modules/azure_rm_lock_info.py
@@ -116,8 +116,8 @@ locks:
 import json
 import re
 from ansible.module_utils.common.dict_transformations import _camel_to_snake
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils.azure_rm_common_rest import GenericRestClient
+from ..module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common_rest import GenericRestClient
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_loganalyticsworkspace.py
+++ b/plugins/modules/azure_rm_loganalyticsworkspace.py
@@ -151,7 +151,7 @@ usages:
               }
 '''  # NOQA
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
+from ..module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 
 try:

--- a/plugins/modules/azure_rm_loganalyticsworkspace_info.py
+++ b/plugins/modules/azure_rm_loganalyticsworkspace_info.py
@@ -137,7 +137,7 @@ usages:
               }
 '''  # NOQA
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
+from ..module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 
 try:

--- a/plugins/modules/azure_rm_managementgroup.py
+++ b/plugins/modules/azure_rm_managementgroup.py
@@ -211,8 +211,8 @@ properties:
 
 import time
 import json
-from ansible.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible.module_utils.azure_rm_common_rest import GenericRestClient
+from ..module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+from ..module_utils.azure_rm_common_rest import GenericRestClient
 try:
     from msrestazure.azure_exceptions import CloudError
 except ImportError:

--- a/plugins/modules/azure_rm_mariadbconfiguration.py
+++ b/plugins/modules/azure_rm_mariadbconfiguration.py
@@ -74,7 +74,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mariadbconfiguration_info.py
+++ b/plugins/modules/azure_rm_mariadbconfiguration_info.py
@@ -100,7 +100,7 @@ settings:
             sample: system-default
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mariadbdatabase.py
+++ b/plugins/modules/azure_rm_mariadbdatabase.py
@@ -90,7 +90,7 @@ name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.mgmt.rdbms.mariadb import MariaDBManagementClient

--- a/plugins/modules/azure_rm_mariadbdatabase_info.py
+++ b/plugins/modules/azure_rm_mariadbdatabase_info.py
@@ -106,7 +106,7 @@ databases:
             sample: English_United States.1252
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mariadbfirewallrule.py
+++ b/plugins/modules/azure_rm_mariadbfirewallrule.py
@@ -79,7 +79,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mariadbfirewallrule_info.py
+++ b/plugins/modules/azure_rm_mariadbfirewallrule_info.py
@@ -100,7 +100,7 @@ rules:
             sample: 10.0.0.18
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mariadbserver.py
+++ b/plugins/modules/azure_rm_mariadbserver.py
@@ -140,7 +140,7 @@ fully_qualified_domain_name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.mgmt.rdbms.mariadb import MariaDBManagementClient

--- a/plugins/modules/azure_rm_mariadbserver_info.py
+++ b/plugins/modules/azure_rm_mariadbserver_info.py
@@ -155,7 +155,7 @@ servers:
             sample: { tag1: abc }
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_monitorlogprofile.py
+++ b/plugins/modules/azure_rm_monitorlogprofile.py
@@ -118,7 +118,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
+from ..module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mysqlconfiguration.py
+++ b/plugins/modules/azure_rm_mysqlconfiguration.py
@@ -73,7 +73,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mysqlconfiguration_info.py
+++ b/plugins/modules/azure_rm_mysqlconfiguration_info.py
@@ -98,7 +98,7 @@ settings:
             sample: system-default
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mysqldatabase.py
+++ b/plugins/modules/azure_rm_mysqldatabase.py
@@ -88,7 +88,7 @@ name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.mgmt.rdbms.mysql import MySQLManagementClient

--- a/plugins/modules/azure_rm_mysqldatabase_info.py
+++ b/plugins/modules/azure_rm_mysqldatabase_info.py
@@ -104,7 +104,7 @@ databases:
             sample: English_United States.1252
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mysqlfirewallrule.py
+++ b/plugins/modules/azure_rm_mysqlfirewallrule.py
@@ -79,7 +79,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mysqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_mysqlfirewallrule_info.py
@@ -98,7 +98,7 @@ rules:
             sample: 10.0.0.18
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_mysqlserver.py
+++ b/plugins/modules/azure_rm_mysqlserver.py
@@ -138,7 +138,7 @@ fully_qualified_domain_name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.mgmt.rdbms.mysql import MySQLManagementClient

--- a/plugins/modules/azure_rm_mysqlserver_info.py
+++ b/plugins/modules/azure_rm_mysqlserver_info.py
@@ -153,7 +153,7 @@ servers:
             sample: { tag1: abc }
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_postgresqlconfiguration.py
+++ b/plugins/modules/azure_rm_postgresqlconfiguration.py
@@ -73,7 +73,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_postgresqlconfiguration_info.py
+++ b/plugins/modules/azure_rm_postgresqlconfiguration_info.py
@@ -98,7 +98,7 @@ settings:
             sample: system-default
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_postgresqldatabase.py
+++ b/plugins/modules/azure_rm_postgresqldatabase.py
@@ -89,7 +89,7 @@ name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient

--- a/plugins/modules/azure_rm_postgresqldatabase_info.py
+++ b/plugins/modules/azure_rm_postgresqldatabase_info.py
@@ -104,7 +104,7 @@ databases:
             sample: English_United States.1252
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_postgresqlfirewallrule.py
+++ b/plugins/modules/azure_rm_postgresqlfirewallrule.py
@@ -77,7 +77,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_postgresqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_postgresqlfirewallrule_info.py
@@ -98,7 +98,7 @@ rules:
             sample: 10.0.0.18
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_postgresqlserver.py
+++ b/plugins/modules/azure_rm_postgresqlserver.py
@@ -139,7 +139,7 @@ fully_qualified_domain_name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient

--- a/plugins/modules/azure_rm_postgresqlserver_info.py
+++ b/plugins/modules/azure_rm_postgresqlserver_info.py
@@ -154,7 +154,7 @@ servers:
             sample: { tag1: abc }
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_rediscache.py
+++ b/plugins/modules/azure_rm_rediscache.py
@@ -219,7 +219,7 @@ host_name:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_rediscache_info.py
+++ b/plugins/modules/azure_rm_rediscache_info.py
@@ -189,7 +189,7 @@ rediscaches:
                     sample: X2xXXxx7xxxxxx5xxxx0xxxxx75xxxxxxxxXXXxxxxx=
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.common import AzureHttpError

--- a/plugins/modules/azure_rm_rediscachefirewallrule.py
+++ b/plugins/modules/azure_rm_rediscachefirewallrule.py
@@ -86,7 +86,7 @@ id:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_roleassignment.py
+++ b/plugins/modules/azure_rm_roleassignment.py
@@ -83,7 +83,7 @@ id:
 '''
 
 import uuid
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_roleassignment_info.py
+++ b/plugins/modules/azure_rm_roleassignment_info.py
@@ -104,7 +104,7 @@ roleassignments:
 '''
 
 import time
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError

--- a/plugins/modules/azure_rm_roledefinition.py
+++ b/plugins/modules/azure_rm_roledefinition.py
@@ -97,7 +97,7 @@ id:
 '''
 
 import uuid
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils._text import to_native
 
 try:

--- a/plugins/modules/azure_rm_roledefinition_info.py
+++ b/plugins/modules/azure_rm_roledefinition_info.py
@@ -120,7 +120,7 @@ roledefinitions:
                     sample: [ 'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write' ]
 '''
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils._text import to_native
 
 try:

--- a/plugins/modules/azure_rm_route.py
+++ b/plugins/modules/azure_rm_route.py
@@ -99,7 +99,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.common.dict_transformations import _snake_to_camel
 
 

--- a/plugins/modules/azure_rm_servicebus.py
+++ b/plugins/modules/azure_rm_servicebus.py
@@ -78,7 +78,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 from ansible.module_utils._text import to_native
 from datetime import datetime, timedelta

--- a/plugins/modules/azure_rm_servicebus_info.py
+++ b/plugins/modules/azure_rm_servicebus_info.py
@@ -383,7 +383,7 @@ except Exception:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict
+from ..module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict
 from ansible.module_utils.common.dict_transformations import _camel_to_snake
 from ansible.module_utils._text import to_native
 from datetime import datetime, timedelta

--- a/plugins/modules/azure_rm_servicebusqueue.py
+++ b/plugins/modules/azure_rm_servicebusqueue.py
@@ -143,7 +143,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 from ansible.module_utils._text import to_native
 from datetime import datetime, timedelta

--- a/plugins/modules/azure_rm_servicebussaspolicy.py
+++ b/plugins/modules/azure_rm_servicebussaspolicy.py
@@ -159,7 +159,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 from ansible.module_utils._text import to_native
 from datetime import datetime, timedelta

--- a/plugins/modules/azure_rm_servicebustopic.py
+++ b/plugins/modules/azure_rm_servicebustopic.py
@@ -123,7 +123,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 from ansible.module_utils._text import to_native
 from datetime import datetime, timedelta

--- a/plugins/modules/azure_rm_servicebustopicsubscription.py
+++ b/plugins/modules/azure_rm_servicebustopicsubscription.py
@@ -136,7 +136,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ..module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
 from ansible.module_utils._text import to_native
 from datetime import datetime, timedelta


### PR DESCRIPTION
##### SUMMARY
This collection will not work with Ansible 2.10 because that will no longer host the old `module_utils` specific to content like this.

I verified that imports fail with `ansible==2.10.0a1`.

This solution, using relative imports, will sacrifice compatibility with Ansible 2.8, and I am updating metadata to reflect that. It is still possible to make this work with both 2.8 and 2.10 if you type out the fully qualified collection name for each import, which is like

https://github.com/ansible-collections/azure/blob/8aad2a0c43d16cf0f5619164751e1e7049316f69/plugins/modules/azure_rm_resourcegroup.py#L132

As you can see from this link, some modules already use these fully-qualified style imports. I'm not changing those here.

Why are some modules using fully-qualified imports and others not? I see the one I linked in #45, which states that it is the 4th migration of modules... and I can find #52 migrated a much larger number without using the fully-qualified imports.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils

##### ADDITIONAL INFORMATION
The module utils were already here:

I previously put up #115, and this is very similar, although it's not moving anything, just redirecting stuff.


