### PR TITLE
Bugfix azure_rm_virtualmachine: Protect against no diskSizeGB

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -1593,7 +1593,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 vhd=data_disk_vhd,
                                 caching=data_disk.get('caching'),
                                 create_option=data_disk.get('createOption'),
-                                disk_size_gb=int(data_disk['diskSizeGB']),
+                                disk_size_gb=int(data_disk.get('diskSizeGB', 0)) or None,
                                 managed_disk=data_disk_managed_disk,
                             ))
                         vm_resource.storage_profile.data_disks = data_disks


### PR DESCRIPTION
##### SUMMARY

Disks' `diskSizeGB` is not reported if the Virtual Machine is
deallocated.  Trying to fetch it is causing a `KeyError`. This guards
against that `KeyError` and then nulls out the key so it isn't set
incorrectly in the update call.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`azure_rm_virtualmachine` 


##### ADDITIONAL INFORMATION

```
     File "/tmp/ansible_azure.azcollection.azure_rm_virtualmachine_payload_eqvuk8bm/ansible_azure.azcollection.azure_rm_virtualmachine_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_virtualmachine.py", line 2224, in <module>
      File "/tmp/ansible_azure.azcollection.azure_rm_virtualmachine_payload_eqvuk8bm/ansible_azure.azcollection.azure_rm_virtualmachine_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_virtualmachine.py", line 2220, in main
      File "/tmp/ansible_azure.azcollection.azure_rm_virtualmachine_payload_eqvuk8bm/ansible_azure.azcollection.azure_rm_virtualmachine_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_virtualmachine.py", line 911, in __init__
      File "/tmp/ansible_azure.azcollection.azure_rm_virtualmachine_payload_eqvuk8bm/ansible_azure.azcollection.azure_rm_virtualmachine_payload.zip/ansible_collections/azure/azcollection/plugins/module_utils/azure_rm_common.py", line 428, in __init__
      File "/tmp/ansible_azure.azcollection.azure_rm_virtualmachine_payload_eqvuk8bm/ansible_azure.azcollection.azure_rm_virtualmachine_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_virtualmachine.py", line 1596, in exec_module
    KeyError: 'diskSizeGB'
```