### PR TITLE
Support azure cli credentials with multiple `subscription_id`s

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -68,16 +68,19 @@ options:
     auth_source:
         description:
             - Controls the source of the credentials to use for authentication.
-            - If not specified, ANSIBLE_AZURE_AUTH_SOURCE environment variable will be used and default to C(auto) if variable is not defined.
-            - C(auto) will follow the default precedence of module parameters -> environment variables -> default profile in credential file
-              C(~/.azure/credentials).
-            - When set to C(cli), the credentials will be sources from the default Azure CLI profile.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
+            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
+            - When set to C(env), the credentials will be read from the environment variables
+            - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
+            - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable
+              C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if more than one is present otherwise the default
+              az cli subscription is used.
             - When set to C(msi), the host machine must be an azure resource with an enabled MSI extension. C(subscription_id) or the
               environment variable C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if the resource is granted
               access to more than one subscription, otherwise the first subscription is chosen.
             - The C(msi) was added in Ansible 2.6.
         type: str
+        default: auto
         choices:
         - auto
         - cli

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1448,7 +1448,7 @@ class AzureRMAuth(object):
             arg_credentials[attribute] = params.get(attribute, None)
 
         if auth_source == 'msi':
-            self.log('Retrieving credenitals from MSI')
+            self.log('Retrieving credentials from MSI')
             return self._get_msi_credentials(subscription_id=params.get('subscription_id'), client_id=params.get('client_id'))
 
         if auth_source == 'cli':

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1275,8 +1275,10 @@ class AzureRMAuth(object):
                           "define a profile in ~/.azure/credentials, or install Azure CLI and log in (`az login`).")
 
         # cert validation mode precedence: module-arg, credential profile, env, "validate"
-        self._cert_validation_mode = cert_validation_mode or self.credentials.get('cert_validation_mode') or \
-            os.environ.get('AZURE_CERT_VALIDATION_MODE') or 'validate'
+        self._cert_validation_mode = cert_validation_mode or \
+            self.credentials.get('cert_validation_mode') or \
+            os.environ.get('AZURE_CERT_VALIDATION_MODE') or \
+            'validate'
 
         if self._cert_validation_mode not in ['validate', 'ignore']:
             self.fail('invalid cert_validation_mode: {0}'.format(self._cert_validation_mode))

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1234,6 +1234,8 @@ class AzureRMAuthException(Exception):
 
 
 class AzureRMAuth(object):
+    _cloud_environment = None
+    _adfs_authority_url = None
     def __init__(self, auth_source='auto', profile=None, subscription_id=None, client_id=None, secret=None,
                  tenant=None, ad_user=None, password=None, cloud_environment='AzureCloud', cert_validation_mode='validate',
                  api_profile='latest', adfs_authority_url=None, fail_impl=None, is_ad_resource=False, **kwargs):
@@ -1242,9 +1244,6 @@ class AzureRMAuth(object):
             self._fail_impl = fail_impl
         else:
             self._fail_impl = self._default_fail_impl
-
-        self._cloud_environment = None
-        self._adfs_authority_url = None
         self.is_ad_resource = is_ad_resource
 
         # authenticate

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1248,9 +1248,18 @@ class AzureRMAuth(object):
 
         # authenticate
         self.credentials = self._get_credentials(
-            dict(auth_source=auth_source, profile=profile, subscription_id=subscription_id, client_id=client_id, secret=secret,
-                 tenant=tenant, ad_user=ad_user, password=password, cloud_environment=cloud_environment,
-                 cert_validation_mode=cert_validation_mode, api_profile=api_profile, adfs_authority_url=adfs_authority_url))
+            auth_source=auth_source,
+            profile=profile,
+            subscription_id=subscription_id,
+            client_id=client_id,
+            secret=secret,
+            tenant=tenant,
+            ad_user=ad_user,
+            password=password,
+            cloud_environment=cloud_environment,
+            cert_validation_mode=cert_validation_mode,
+            api_profile=api_profile,
+            adfs_authority_url=adfs_authority_url)
 
         if not self.credentials:
             if HAS_AZURE_CLI_CORE:
@@ -1419,8 +1428,7 @@ class AzureRMAuth(object):
 
         return None
 
-    # TODO: use explicit kwargs instead of intermediate dict
-    def _get_credentials(self, params):
+    def _get_credentials(self, auth_source=None, **params):
         # Get authentication credentials.
         self.log('Getting credentials')
 


### PR DESCRIPTION
##### SUMMARY

This is very similar to #53  but taken a bit further:
* rebased onto `dev` branch 
* Added more documentation
* Tried to cleanup/simply `azure_rm_common` a bit (not very much).
  * move some defaults  out of `__init__` onto class
  * use python kwargs instead fo passing in a `dict(...)`
  * use ansible's `env_fallback` for `auth_source`.

I'm hoping to get a bit further but wanted to put up the WIP and get any feedback.