### PR TITLE
Several changes related to multiple IP configs (ipv4 + ipv6)

### DIFF
--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -156,7 +156,7 @@ options:
                 description:
                     - Whether the IP configuration is the primary one in the list.
                 type: bool
-                default: 'no'
+                required: true
             application_security_groups:
                 description:
                     - List of application security groups in which the IP configuration is included.
@@ -533,7 +533,7 @@ ip_configuration_spec = dict(
     public_ip_address_name=dict(type='str', aliases=['public_ip_address', 'public_ip_name']),
     public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
     load_balancer_backend_address_pools=dict(type='list'),
-    primary=dict(type='bool', default=False),
+    primary=dict(type='bool', required=True),
     application_security_groups=dict(type='list', elements='raw')
 )
 

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -162,6 +162,12 @@ virtualnetworks:
                         returned: always
                         type: str
                         sample: '10.1.0.0/16'
+                    address_prefixes:
+                        description:
+                            - Both IPv4 and IPv6 address prefixes for the subnet, will return null if only an IPv4 is set.
+                        returned: always
+                        type: list
+                        sample: [{"10.1.0.0/16", "fdda:e69b:2547:485e::/64"}]
                     network_security_group:
                         description:
                             - Existing security group ID with which to associate the subnet.
@@ -322,6 +328,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             name=subnet.name,
             provisioning_state=subnet.provisioning_state,
             address_prefix=subnet.address_prefix,
+            address_prefixes=subnet.address_prefixes if subnet.address_prefixes else None,
             network_security_group=subnet.network_security_group.id if subnet.network_security_group else None,
             route_table=subnet.route_table.id if subnet.route_table else None
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**azure_rm_networkinterface.py**
We should make the primary option required because if it's not set, the default value is always "no", while Azure's default value is "yes" when ip configurations total == 1 and "no" when ip configurations total > 1. This causes the state of the task to be "changed" on every run (and make it not seem idempotent). Requiring this option to be set, will fix this issue and remove any confusion.

**azure_rm_virtualnetwork_info**
Return all address prefixes if both an IPv4 and IPv6 prefix have been set

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_networkinterface.py
azure_rm_virtualnetwork_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
