### PR TITLE
Add execution environment metadata

### DIFF
--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,3 @@
+dependencies:
+  python: requirements-azure.txt
+version: 1


### PR DESCRIPTION
##### SUMMARY
We are building tooling to enable building container images with necessary python & system requirements necessary to use content inside of a collection. The project for this is at:

https://github.com/ansible/ansible-builder

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meta/

##### ADDITIONAL INFORMATION
It is intended that this doesn't break any `ansible-test` tests.

For the case of this collection, the only thing we need is a pointer to identify where the python requirements are.

The schema is relatively well stabilized, but could always still change depending on feedback.
