### PR TITLE
Get address_prefixes info from virtualnetwork

### DIFF
--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -155,7 +155,7 @@ options:
                 description:
                     - Whether the IP configuration is the primary one in the list.
                 type: bool
-                default: 'no'
+                default: True
             application_security_groups:
                 description:
                     - List of application security groups in which the IP configuration is included.
@@ -526,7 +526,7 @@ ip_configuration_spec = dict(
     public_ip_address_name=dict(type='str', aliases=['public_ip_address', 'public_ip_name']),
     public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
     load_balancer_backend_address_pools=dict(type='list'),
-    primary=dict(type='bool', default=False),
+    primary=dict(type='bool', default=True),
     application_security_groups=dict(type='list', elements='raw')
 )
 

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -154,8 +154,9 @@ options:
             primary:
                 description:
                     - Whether the IP configuration is the primary one in the list.
+                    - The first IP configuration default set to I(primary=True).
                 type: bool
-                default: True
+                default: False
             application_security_groups:
                 description:
                     - List of application security groups in which the IP configuration is included.
@@ -526,7 +527,7 @@ ip_configuration_spec = dict(
     public_ip_address_name=dict(type='str', aliases=['public_ip_address', 'public_ip_name']),
     public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
     load_balancer_backend_address_pools=dict(type='list'),
-    primary=dict(type='bool', default=True),
+    primary=dict(type='bool', default=False),
     application_security_groups=dict(type='list', elements='raw')
 )
 

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -162,6 +162,12 @@ virtualnetworks:
                         returned: always
                         type: str
                         sample: '10.1.0.0/16'
+                    address_prefixes:
+                        description:
+                            - Both IPv4 and IPv6 address prefixes for the subnet, will return null if only an  IPv4 set.
+                        returned: always
+                        type: list
+                        sample: ["10.1.0.0/16", "fdda:e69b:2547:485e::/64"]
                     network_security_group:
                         description:
                             - Existing security group ID with which to associate the subnet.
@@ -322,6 +328,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             name=subnet.name,
             provisioning_state=subnet.provisioning_state,
             address_prefix=subnet.address_prefix,
+            address_prefixes=subnet.address_prefixes if subnet.address_prefixes else None,
             network_security_group=subnet.network_security_group.id if subnet.network_security_group else None,
             route_table=subnet.route_table.id if subnet.route_table else None
         )

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -85,6 +85,7 @@
     that:
       - output.changed
       - output.state.id
+      - output.state.ip_configuration.primary
 
 - name: Get fact of the new created NIC
   azure_rm_networkinterface_info:
@@ -97,6 +98,7 @@
       - "facts.networkinterfaces | length == 1"
       - facts.networkinterfaces[0].id == output.state.id
       - "facts.networkinterfaces[0].ip_configurations | length == 1"
+      - facts.networkinterfaces[0].ip_configurations[0].primary == True
       - not facts.networkinterfaces[0].security_group
       - not facts.networkinterfaces[0].ip_configurations[0].public_ip_address
       - not facts.networkinterfaces[0].enable_ip_forwarding
@@ -233,6 +235,7 @@
             primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
           - name: ipconfig1
             public_ip_name: "tn{{ rpfx }}"
+            primary: False
             load_balancer_backend_address_pools:
               - "{{ lb.state.backend_address_pools[0].id }}"
               - name: backendaddrpool1
@@ -266,6 +269,7 @@
             primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
           - name: ipconfig1
             public_ip_name: "tn{{ rpfx }}"
+            primary: False
             load_balancer_backend_address_pools:
               - "{{ lb.state.backend_address_pools[0].id }}"
               - name: backendaddrpool1

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -235,7 +235,6 @@
             primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
           - name: ipconfig1
             public_ip_name: "tn{{ rpfx }}"
-            primary: False
             load_balancer_backend_address_pools:
               - "{{ lb.state.backend_address_pools[0].id }}"
               - name: backendaddrpool1
@@ -269,7 +268,6 @@
             primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
           - name: ipconfig1
             public_ip_name: "tn{{ rpfx }}"
-            primary: False
             load_balancer_backend_address_pools:
               - "{{ lb.state.backend_address_pools[0].id }}"
               - name: backendaddrpool1
@@ -294,6 +292,8 @@
       - 'facts.networkinterfaces[0].security_group.endswith("tn{{ rpfx }}sg")'
       - facts.networkinterfaces[0].enable_accelerated_networking
       - facts.networkinterfaces[0].enable_ip_forwarding
+      - facts.networkinterfaces[0].ip_configurations[0].primary == True
+      - facts.networkinterfaces[0].ip_configurations[1].primary == False
 
 - name: Remove one dns server and ip configuration
   azure_rm_networkinterface:

--- a/tests/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
@@ -14,17 +14,19 @@
     address_prefixes_cidr:
       - 10.1.0.0/16
       - 172.100.0.0/16
+      - fdda:e69b:1587:495e::/64
     tags:
       testing: testing
       delete: on-exit
     resource_group: "{{ resource_group }}"
 
-- name: Create virtual network
+- name: Update virtual network with dns server
   azure_rm_virtualnetwork:
     name: "{{ vnetname }}"
     address_prefixes_cidr:
       - 10.1.0.0/16
       - 172.100.0.0/16
+      - fdda:e69b:1587:495e::/64
     dns_servers:
       - 127.0.0.1
       - 127.0.0.3
@@ -36,7 +38,7 @@
 
 - assert:
     that:
-      - "output.state.address_prefixes | length == 2"
+      - "output.state.address_prefixes | length == 3"
       - "output.state.dns_servers | length == 2"
       - "output.state.tags.delete == 'on-exit'"
       - "output.state.tags | length == 2"
@@ -60,7 +62,7 @@
     that:
       - "facts.virtualnetworks | length == 1"
       - "facts.virtualnetworks[0].dns_servers | length == 2"
-      - "facts.virtualnetworks[0].address_prefixes | length == 2"
+      - "facts.virtualnetworks[0].address_prefixes | length == 3"
       - "facts.virtualnetworks[0].subnets | length == 1"
 
 - name: Gather facts by resource group, tags
@@ -88,6 +90,7 @@
     address_prefixes_cidr:
       - 10.1.0.0/16
       - 172.100.0.0/16
+      - fdda:e69b:1587:495e::/64
     dns_servers:
       - 127.0.0.1
       - 127.0.0.3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add new parameter for get subnet IPv6 info.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualnetwork_info, azure_rm_networkinterface
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
