### PR TITLE
Azure rm subscription info

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -966,9 +966,9 @@ class AzureRMModuleBase(object):
         self.log('Getting subscription client...')
         if not self._subscription_client:
             self._subscription_client = self.get_mgmt_svc_client(SubscriptionClient,
-                                                            base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            suppress_subscription_id=True,
-                                                            api_version='2019-11-01')
+                                                                 base_url=self._cloud_environment.endpoints.resource_manager,
+                                                                 suppress_subscription_id=True,
+                                                                 api_version='2019-11-01')
         return self._subscription_client
 
     @property

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -44,6 +44,11 @@ options:
             - Option has no effect when searching by id or name, and will be silently ignored.
         default: False
         type: bool
+    tags:
+        description:
+            - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
+            - Option has no effect when searching by id or name, and will be silently ignored.
+        type: list
 
 extends_documentation_fragment:
     - azure.azcollection.azure
@@ -64,6 +69,12 @@ EXAMPLES = '''
 - name: Get facts for all subscriptions, including ones that are disabled.
   azure_rm_subscription_info:
     all: True
+
+- name: Get facts for subscriptions containing tags provided.
+    azure_rm_subscription_info:
+    tags:
+        - testing
+        - foo:bar
 '''
 
 RETURN = '''
@@ -124,6 +135,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             id=dict(type='str'),
+            tags=dict(type='list'),
             all=dict(type='bool')
         )
 
@@ -134,6 +146,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
 
         self.name = None
         self.id = None
+        self.tags = None
         self.all = False
 
         super(AzureRMSubscriptionInfo, self).__init__(self.module_arg_spec,
@@ -184,7 +197,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
             # If name is not defined and either state is Enabled or all is true, return result.
             if ( self.name and self.name.lower() == item.display_name.lower() ):
                 results.append(self.to_dict(item) )
-            elif ( not self.name and ( self.all or item.state == "Enabled" ) ):
+            elif ( not self.name and ( self.all or item.state == "Enabled" ) and self.has_tags(item.tags, self.tags) ):
                 results.append(self.to_dict(item) )
 
         return results

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2020 Paul Aiton, < @paultaiton >
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_subscription_info
+
+version_added: "1.2.0"
+
+short_description: Get Azure Subscription facts
+
+description:
+    - Get facts for a specific subscription or all subscriptions.
+
+options:
+    id:
+        description:
+            - Limit results to a specific subscription by id.
+            - Cannot be used together with name.
+    name:
+        description:
+            - Limit results to a specific subscription by name.
+            - Cannot be used together with id.
+        aliases:
+            - subscription_name
+    all:
+        description:
+            - If true, will return all subscriptions.
+            - If false will omit disabled subscriptions (default).
+            - Option has no effect when searching by id or name.
+        default: False
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Paul Aiton ( @paultaiton )
+'''
+
+EXAMPLES = '''
+- name: Get facts for one subscription by id
+  azure_rm_subscription_info:
+    id: 00000000-0000-0000-0000-000000000000
+
+- name: Get facts for one subscription by name
+  azure_rm_subscription_info:
+    name: "my-subscription"
+
+- name: Get facts for all subscriptions, including ones that are disabled.
+  azure_rm_subscription_info:
+    all: True
+'''
+
+RETURN = '''
+subscriptions:
+    description:
+        - List of subscription dicts.
+    returned: always
+    type: list
+    contains:
+        display_name:
+            description: Subscription display name.
+            returned: always
+            type: str
+            sample: my-subscription
+        fqid:
+            description: Subscription fully qualified id.
+            returned: always
+            type: str
+            sample: "/subscriptions/00000000-0000-0000-0000-000000000000"
+        subscription_id:
+            description: Subscription guid.
+            returned: always
+            type: str
+            sample: "00000000-0000-0000-0000-000000000000"
+        state:
+            description: Subscription state.
+            returned: always
+            type: str
+            sample: "'Enabled' or 'Disabled'"
+        tags:
+            description: Tags assigned to resource group.
+            returned: always
+            type: dict
+            sample: { "tag1": "value1", "tag2": "value2" }
+        tenant_id:
+            description: Subscription tenant id
+            returned: always
+            type: str
+            sample: "00000000-0000-0000-0000-000000000000"
+'''
+
+try:
+    from msrestazure.azure_exceptions import CloudError
+except Exception:
+    # This is handled in azure_rm_common
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+AZURE_OBJECT_CLASS = 'Subscription'
+
+
+class AzureRMSubscriptionInfo(AzureRMModuleBase):
+
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            name=dict(type='str'),
+            id=dict(type='str'),
+            all=dict(type='bool')
+        )
+
+        self.results = dict(
+            changed=False,
+            subscriptions=[]
+        )
+
+        self.name = None
+        self.id = None
+        self.all = False
+
+        super(AzureRMSubscriptionInfo, self).__init__(self.module_arg_spec,
+                                                       supports_tags=False,
+                                                       facts_module=True)
+
+    def exec_module(self, **kwargs):
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.id and self.name:
+            self.fail("Parameter error: cannot search subscriptions by both name and id.")
+
+        result = []
+
+        if self.id:
+            result = self.get_item()
+        else:
+            result = self.list_items()
+
+        self.results['subscriptions'] = result
+        return self.results
+
+    def get_item(self):
+        self.log('Get properties for {0}'.format(self.id))
+        item = None
+        result = []
+
+        try:
+            item = self.subscription_client.subscriptions.get(self.id)
+        except CloudError:
+            pass
+
+        result = self.to_dict(item)
+
+        return result
+
+    def list_items(self):
+        self.log('List all items')
+        try:
+            response = self.subscription_client.subscriptions.list()
+        except CloudError as exc:
+            self.fail("Failed to list all items - {0}".format(str(exc)))
+
+        results = []
+        for item in response:
+            # If the name matches, return result regardless of anything else.
+            # If name is not defined and either state is Enabled or all is true, return result.
+            if ( self.name and self.name.lower() == item.display_name.lower() ):
+                results.append(self.to_dict(item) )
+            elif ( not self.name and ( self.all or item.state == "Enabled" ) ):
+                results.append(self.to_dict(item) )
+
+        return results
+
+    def to_dict(self, subscription_object):
+        return dict(
+            display_name=subscription_object.display_name,
+            fqid=subscription_object.id,
+            state=subscription_object.state,
+            subscription_id=subscription_object.subscription_id,
+            tags=subscription_object.tags,
+            tenant_id=subscription_object.tenant_id
+        )
+
+def main():
+    AzureRMSubscriptionInfo()
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
     all: True
 
 - name: Get facts for subscriptions containing tags provided.
-    azure_rm_subscription_info:
+  azure_rm_subscription_info:
     tags:
         - testing
         - foo:bar

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -54,7 +54,7 @@ extends_documentation_fragment:
     - azure.azcollection.azure
 
 author:
-    - Paul Aiton ( @paultaiton )
+    - Paul Aiton (@paultaiton)
 '''
 
 EXAMPLES = '''
@@ -215,8 +215,10 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
             tenant_id=subscription_object.tenant_id
         )
 
+
 def main():
     AzureRMSubscriptionInfo()
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -28,19 +28,22 @@ options:
     id:
         description:
             - Limit results to a specific subscription by id.
-            - Cannot be used together with name.
+            - Mutually exclusive with I(name).
+        type: str
     name:
         description:
             - Limit results to a specific subscription by name.
-            - Cannot be used together with id.
+            - Mutually exclusive with I(id).
         aliases:
             - subscription_name
+        type: str
     all:
         description:
             - If true, will return all subscriptions.
             - If false will omit disabled subscriptions (default).
-            - Option has no effect when searching by id or name.
+            - Option has no effect when searching by id or name, and will be silently ignored.
         default: False
+        type: bool
 
 extends_documentation_fragment:
     - azure.azcollection.azure

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -198,10 +198,10 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         for item in response:
             # If the name matches, return result regardless of anything else.
             # If name is not defined and either state is Enabled or all is true, and tags match, return result.
-            if ( self.name and self.name.lower() == item.display_name.lower() ):
-                results.append( self.to_dict( item ) )
-            elif ( not self.name and ( self.all or item.state == "Enabled" ) and self.has_tags( item.tags, self.tags ) ):
-                results.append( self.to_dict( item ) )
+            if self.name and self.name.lower() == item.display_name.lower():
+                results.append(self.to_dict(item))
+            elif not self.name and (self.all or item.state == "Enabled") and self.has_tags(item.tags, self.tags):
+                results.append(self.to_dict(item))
 
         return results
 

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -200,7 +200,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
             # If name is not defined and either state is Enabled or all is true, and tags match, return result.
             if ( self.name and self.name.lower() == item.display_name.lower() ):
                 results.append( self.to_dict( item ) )
-            elif ( not self.name and ( self.all or item.state == "Enabled" ) and self.has_tags( item.tags, self.tags) ):
+            elif ( not self.name and ( self.all or item.state == "Enabled" ) and self.has_tags( item.tags, self.tags ) ):
                 results.append( self.to_dict( item ) )
 
         return results

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -133,7 +133,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
     def __init__(self):
 
         self.module_arg_spec = dict(
-            name=dict(type='str'),
+            name=dict(type='str', aliases=['subscription_name']),
             id=dict(type='str'),
             tags=dict(type='list',  elements='dict'),
             all=dict(type='bool')

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -135,7 +135,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             id=dict(type='str'),
-            tags=dict(type='list'),
+            tags=dict(type='list',  elements='dict'),
             all=dict(type='bool')
         )
 

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -149,9 +149,12 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         self.tags = None
         self.all = False
 
+        mutually_exclusive = [['name', 'id']]
+
         super(AzureRMSubscriptionInfo, self).__init__(self.module_arg_spec,
-                                                       supports_tags=False,
-                                                       facts_module=True)
+                                                        supports_tags=False,
+                                                        mutually_exclusive=mutually_exclusive,
+                                                        facts_module=True)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -135,7 +135,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str', aliases=['subscription_name']),
             id=dict(type='str'),
-            tags=dict(type='list',  elements='dict'),
+            tags=dict(type='list', elements='dict'),
             all=dict(type='bool')
         )
 

--- a/plugins/modules/azure_rm_subscription_info.py
+++ b/plugins/modules/azure_rm_subscription_info.py
@@ -152,9 +152,9 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         mutually_exclusive = [['name', 'id']]
 
         super(AzureRMSubscriptionInfo, self).__init__(self.module_arg_spec,
-                                                        supports_tags=False,
-                                                        mutually_exclusive=mutually_exclusive,
-                                                        facts_module=True)
+                                                      supports_tags=False,
+                                                      mutually_exclusive=mutually_exclusive,
+                                                      facts_module=True)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -197,11 +197,11 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
         results = []
         for item in response:
             # If the name matches, return result regardless of anything else.
-            # If name is not defined and either state is Enabled or all is true, return result.
+            # If name is not defined and either state is Enabled or all is true, and tags match, return result.
             if ( self.name and self.name.lower() == item.display_name.lower() ):
-                results.append(self.to_dict(item) )
-            elif ( not self.name and ( self.all or item.state == "Enabled" ) and self.has_tags(item.tags, self.tags) ):
-                results.append(self.to_dict(item) )
+                results.append( self.to_dict( item ) )
+            elif ( not self.name and ( self.all or item.state == "Enabled" ) and self.has_tags( item.tags, self.tags) ):
+                results.append( self.to_dict( item ) )
 
         return results
 

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -64,6 +64,7 @@ parameters:
     - "azure_rm_storageaccount"
     - "azure_rm_storageblob"
     - "azure_rm_subnet"
+    - "azure_rm_subscription"
     - "azure_rm_trafficmanagerprofile"
     - "azure_rm_virtualmachine"
     - "azure_rm_virtualmachineextension"

--- a/tests/integration/targets/azure_rm_subscription/aliases
+++ b/tests/integration/targets/azure_rm_subscription/aliases
@@ -1,0 +1,5 @@
+# Paul Aiton's note for pull request:
+#   I don't know what this file does, will someone who does please review for correctness?
+cloud/azure
+shippable/azure/group2
+destructive

--- a/tests/integration/targets/azure_rm_subscription/aliases
+++ b/tests/integration/targets/azure_rm_subscription/aliases
@@ -1,5 +1,3 @@
-# Paul Aiton's note for pull request:
-#   I don't know what this file does, will someone who does please review for correctness?
 cloud/azure
 shippable/azure/group2
 destructive

--- a/tests/integration/targets/azure_rm_subscription/meta/main.yml
+++ b/tests/integration/targets/azure_rm_subscription/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_subscription/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_subscription/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Get list of all subscriptions
+  azure.azcollection.azure_rm_subscription_info:
+    all: True
+  register: az_all_subscriptions
+
+- name: Get a subscription by id
+  azure.azcollection.azure_rm_subscription_info:
+    id: "{{ az_all_subscriptions.subscriptions[0].subscription_id }}"
+
+- name: Get a subscription by name
+  azure.azcollection.azure_rm_subscription_info:
+    name: "{{ az_all_subscriptions.subscriptions[0].display_name }}"
+
+- name: Test invalid name id combo
+  azure.azcollection.azure_rm_subscription_info:
+    name: "{{ az_all_subscriptions.subscriptions[0].display_name }}"
+    id: "{{ az_all_subscriptions.subscriptions[0].subscription_id }}"
+  register: invalid_name
+  ignore_errors: yes  
+
+- name: Assert task failed
+  assert: 
+    that: 
+      - "invalid_name['failed'] == True"

--- a/tests/integration/targets/azure_rm_subscription/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_subscription/tasks/main.yml
@@ -1,18 +1,18 @@
 - name: Get list of all subscriptions
-  azure.azcollection.azure_rm_subscription_info:
+  azure_rm_subscription_info:
     all: True
   register: az_all_subscriptions
 
 - name: Get a subscription by id
-  azure.azcollection.azure_rm_subscription_info:
+  azure_rm_subscription_info:
     id: "{{ az_all_subscriptions.subscriptions[0].subscription_id }}"
 
 - name: Get a subscription by name
-  azure.azcollection.azure_rm_subscription_info:
+  azure_rm_subscription_info:
     name: "{{ az_all_subscriptions.subscriptions[0].display_name }}"
 
 - name: Test invalid name id combo
-  azure.azcollection.azure_rm_subscription_info:
+  azure_rm_subscription_info:
     name: "{{ az_all_subscriptions.subscriptions[0].display_name }}"
     id: "{{ az_all_subscriptions.subscriptions[0].subscription_id }}"
   register: invalid_name

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -278,6 +278,7 @@ plugins/modules/azure_rm_subnet_info.py validate-modules:required_if-requirement
 plugins/modules/azure_rm_subnet_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_subscription_info.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_subscription_info.py validate-modules:required_if-unknown-key
+plugins/modules/azure_rm_subscription_info.py validate-modules:doc-elements-mismatch
 plugins/modules/azure_rm_virtualmachine.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_virtualmachine.py validate-modules:doc-elements-mismatch
 plugins/modules/azure_rm_virtualmachine.py validate-modules:doc-required-mismatch

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -276,6 +276,8 @@ plugins/modules/azure_rm_subnet.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_subnet_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_subnet_info.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_subnet_info.py validate-modules:required_if-unknown-key
+plugins/modules/azure_rm_subscription_info.py validate-modules:required_if-requirements-unknown
+plugins/modules/azure_rm_subscription_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_virtualmachine.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_virtualmachine.py validate-modules:doc-elements-mismatch
 plugins/modules/azure_rm_virtualmachine.py validate-modules:doc-required-mismatch

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -276,6 +276,9 @@ plugins/modules/azure_rm_subnet.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_subnet_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_subnet_info.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_subnet_info.py validate-modules:required_if-unknown-key
+plugins/modules/azure_rm_subscription_info.py validate-modules:required_if-requirements-unknown
+plugins/modules/azure_rm_subscription_info.py validate-modules:required_if-unknown-key
+plugins/modules/azure_rm_subscription_info.py validate-modules:doc-elements-mismatch
 plugins/modules/azure_rm_virtualmachine.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_virtualmachine.py validate-modules:doc-elements-mismatch
 plugins/modules/azure_rm_virtualmachine.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
Create module for azure_rm_subscription_info

##### SUMMARY

There does not exist an easy way to fetch Azure Subscription information from within Ansible. This PR creates a new azure_rm_subscription_info module that allows for querying of subscriptions based on id, name, or to fetch a list of all subscriptions.


##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
azure_rm_subscription_info

##### ADDITIONAL INFORMATION

This new module being strictly informational is straightforward. However I had to add some conditional logic in azure_rm_common to suppress the passing of "subscription_id" to the SubscriptionClient instantiation. I tried to do it in a client agnostic manner, but I'm not aware of any others that also require it.

I have included some simplistic integration tests, however one of the files, 'aliases', I am unfamiliar with and will need some assistance with to validate that the contents that I copied from another is sufficient.
