### PR TITLE
Fix azure_rm_roleassignment idempotence error

### DIFF
--- a/plugins/modules/azure_rm_roleassignment.py
+++ b/plugins/modules/azure_rm_roleassignment.py
@@ -25,7 +25,7 @@ options:
     name:
         description:
             - Unique name of role assignment.
-            - The role assignment name must be a GUID.
+            - The role assignment name must be a GUID, sample as "3ce0cbb0-58c4-4e6d-a16d-99d86a78b3ca".
         require: true
     assignee_object_id:
         description:

--- a/plugins/modules/azure_rm_roleassignment.py
+++ b/plugins/modules/azure_rm_roleassignment.py
@@ -25,6 +25,8 @@ options:
     name:
         description:
             - Unique name of role assignment.
+            - The role assignment name must be a GUID.
+        require: true
     assignee_object_id:
         description:
             - The object id of assignee. This maps to the ID inside the Active Directory.
@@ -114,7 +116,8 @@ class AzureRMRoleAssignment(AzureRMModuleBase):
     def __init__(self):
         self.module_arg_spec = dict(
             name=dict(
-                type='str'
+                type='str',
+                require='true'
             ),
             scope=dict(
                 type='str'
@@ -166,9 +169,6 @@ class AzureRMRoleAssignment(AzureRMModuleBase):
 
         # build cope
         self.scope = self.build_scope()
-
-        if self.name is None:
-            self.name = str(uuid.uuid4())
 
         # get existing role assignment
         old_response = self.get_roleassignment()

--- a/plugins/modules/azure_rm_roleassignment.py
+++ b/plugins/modules/azure_rm_roleassignment.py
@@ -26,7 +26,7 @@ options:
         description:
             - Unique name of role assignment.
             - The role assignment name must be a GUID, sample as "3ce0cbb0-58c4-4e6d-a16d-99d86a78b3ca".
-        require: true
+        required: True
     assignee_object_id:
         description:
             - The object id of assignee. This maps to the ID inside the Active Directory.
@@ -84,8 +84,6 @@ id:
     sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleAssignments/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 '''
 
-import uuid
-
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
     from msrestazure.azure_exceptions import CloudError
@@ -117,7 +115,7 @@ class AzureRMRoleAssignment(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(
                 type='str',
-                require='true'
+                required=True
             ),
             scope=dict(
                 type='str'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When executing azure_rm_roleassignment, if a role assignment already exists, the module throws a fatal error and aborts playbook operation.  This PR to fix idempotent fail. ---#266
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_roleassignment
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
