### PR TITLE
Manageddisk info managed by

### DIFF
--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -195,7 +195,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
         if self.managed_by:
             result = [disk for disk in result if disk.managed_by == self.managed_by]
         if self.tags:
-            result = [disk for disk in result if self.has_tags(result.tags, self.tags)]
+            result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
         result = [self.managed_disk_to_dict(disk) for disk in result]
         return result
 
@@ -209,7 +209,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
         if self.managed_by:
             result = [disk for disk in result if disk.managed_by == self.managed_by]
         if self.tags:
-            result = [disk for disk in result if self.has_tags(result.tags, self.tags)]
+            result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
         result = [self.managed_disk_to_dict(disk) for disk in result]
         return result
 
@@ -223,7 +223,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
         if self.managed_by:
             result = [disk for disk in result if disk.managed_by == self.managed_by]
         if self.tags:
-            result = [disk for disk in result if self.has_tags(result.tags, self.tags)]
+            result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
         result = [self.managed_disk_to_dict(disk) for disk in result]
         return result
 

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -189,7 +189,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
 
         try:
             results = [self.compute_client.disks.get(self.resource_group,
-                                                    self.name)]
+                                                     self.name)]
             if self.managed_by:
                 results = [disk for disk in results if disk.managed_by == self.managed_by]
             if self.tags:

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -146,7 +146,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
         self.module_arg_spec = dict(
             resource_group=dict(type='str'),
             name=dict(type='str'),
-            tags=dict(type='str'),
+            tags=dict(type='list'),
             managed_by=dict(type='str')
         )
 

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -45,6 +45,7 @@ options:
     managed_by:
         description:
             - Limit results to disks managed by the given VM fqid.
+        type: str
 
 extends_documentation_fragment:
     - azure.azcollection.azure
@@ -184,52 +185,52 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
 
     def get_disk(self):
         """Get a single managed disk"""
-        result = []
+        results = []
 
         try:
-            result = [self.compute_client.disks.get(self.resource_group,
+            results = [self.compute_client.disks.get(self.resource_group,
                                                     self.name)]
             if self.managed_by:
-                result = [disk for disk in result if disk.managed_by == self.managed_by]
+                results = [disk for disk in results if disk.managed_by == self.managed_by]
             if self.tags:
-                result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
-            result = [self.managed_disk_to_dict(disk) for disk in result]
+                results = [disk for disk in results if self.has_tags(disk.tags, self.tags)]
+            results = [self.managed_disk_to_dict(disk) for disk in results]
         except CloudError:
             self.log('Could not find disk {0} in resource group {1}'.format(self.name, self.resource_group))
 
-        return result
+        return results
 
     def list_disks(self):
         """Get all managed disks"""
-        result = []
+        results = []
 
         try:
-            result = self.compute_client.disks.list()
+            results = self.compute_client.disks.list()
             if self.managed_by:
-                result = [disk for disk in result if disk.managed_by == self.managed_by]
+                results = [disk for disk in results if disk.managed_by == self.managed_by]
             if self.tags:
-                result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
-            result = [self.managed_disk_to_dict(disk) for disk in result]
+                results = [disk for disk in results if self.has_tags(disk.tags, self.tags)]
+            results = [self.managed_disk_to_dict(disk) for disk in results]
         except CloudError as exc:
             self.fail('Failed to list all items - {0}'.format(str(exc)))
 
-        return result
+        return results
 
     def list_disks_by_resource_group(self):
         """Get managed disks in a resource group"""
-        result = []
+        results = []
 
         try:
-            result = self.compute_client.disks.list_by_resource_group(resource_group_name=self.resource_group)
+            results = self.compute_client.disks.list_by_resource_group(resource_group_name=self.resource_group)
             if self.managed_by:
-                result = [disk for disk in result if disk.managed_by == self.managed_by]
+                results = [disk for disk in results if disk.managed_by == self.managed_by]
             if self.tags:
-                result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
-            result = [self.managed_disk_to_dict(disk) for disk in result]
+                results = [disk for disk in results if self.has_tags(disk.tags, self.tags)]
+            results = [self.managed_disk_to_dict(disk) for disk in results]
         except CloudError as exc:
             self.fail('Failed to list items by resource group - {0}'.format(str(exc)))
 
-        return result
+        return results
 
     def managed_disk_to_dict(self, managed_disk):
         create_data = managed_disk.creation_data

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -189,42 +189,46 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
         try:
             result = [self.compute_client.disks.get(self.resource_group,
                                                     self.name)]
+            if self.managed_by:
+                result = [disk for disk in result if disk.managed_by == self.managed_by]
+            if self.tags:
+                result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
+            result = [self.managed_disk_to_dict(disk) for disk in result]
         except CloudError:
             self.log('Could not find disk {0} in resource group {1}'.format(self.name, self.resource_group))
 
-        if self.managed_by:
-            result = [disk for disk in result if disk.managed_by == self.managed_by]
-        if self.tags:
-            result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
-        result = [self.managed_disk_to_dict(disk) for disk in result]
         return result
 
     def list_disks(self):
         """Get all managed disks"""
+        result = []
+
         try:
             result = self.compute_client.disks.list()
+            if self.managed_by:
+                result = [disk for disk in result if disk.managed_by == self.managed_by]
+            if self.tags:
+                result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
+            result = [self.managed_disk_to_dict(disk) for disk in result]
         except CloudError as exc:
             self.fail('Failed to list all items - {0}'.format(str(exc)))
 
-        if self.managed_by:
-            result = [disk for disk in result if disk.managed_by == self.managed_by]
-        if self.tags:
-            result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
-        result = [self.managed_disk_to_dict(disk) for disk in result]
         return result
 
     def list_disks_by_resource_group(self):
         """Get managed disks in a resource group"""
+        result = []
+
         try:
             result = self.compute_client.disks.list_by_resource_group(resource_group_name=self.resource_group)
+            if self.managed_by:
+                result = [disk for disk in result if disk.managed_by == self.managed_by]
+            if self.tags:
+                result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
+            result = [self.managed_disk_to_dict(disk) for disk in result]
         except CloudError as exc:
             self.fail('Failed to list items by resource group - {0}'.format(str(exc)))
 
-        if self.managed_by:
-            result = [disk for disk in result if disk.managed_by == self.managed_by]
-        if self.tags:
-            result = [disk for disk in result if self.has_tags(disk.tags, self.tags)]
-        result = [self.managed_disk_to_dict(disk) for disk in result]
         return result
 
     def managed_disk_to_dict(self, managed_disk):

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: azure_rm_manageddisk_info
 
@@ -56,7 +56,7 @@ author:
     - Paul Aiton (@paultaiton)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Get facts for one managed disk
   azure_rm_manageddisk_info:
     name: Testing
@@ -75,7 +75,7 @@ EXAMPLES = '''
     - testing
 '''
 
-RETURN = '''
+RETURN = r'''
 azure_managed_disk:
     description:
         - List of managed disk dicts.

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -149,6 +149,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
             tags=dict(type='str'),
             managed_by=dict(type='str')
         )
+
         self.results = dict(
             ansible_info=dict(
                 azure_managed_disk=[]
@@ -187,7 +188,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
 
         try:
             result = [self.compute_client.disks.get(self.resource_group,
-                                                      self.name)]
+                                                    self.name)]
         except CloudError:
             self.log('Could not find disk {0} in resource group {1}'.format(self.name, self.resource_group))
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -197,7 +197,7 @@ plugins/modules/azure_rm_keyvaultsecret_info.py validate-modules:required_if-unk
 plugins/modules/azure_rm_manageddisk.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_manageddisk.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_manageddisk.py validate-modules:required_if-unknown-key
-plugins/modules/azure_rm_manageddisk_info.py validate-modules:doc-type-does-not-match-spec
+plugins/modules/azure_rm_manageddisk_info.py validate-modules:parameter-list-no-elements
 plugins/modules/azure_rm_manageddisk_info.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_manageddisk_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_manageddisk_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -197,7 +197,7 @@ plugins/modules/azure_rm_keyvaultsecret_info.py validate-modules:required_if-unk
 plugins/modules/azure_rm_manageddisk.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_manageddisk.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_manageddisk.py validate-modules:required_if-unknown-key
-plugins/modules/azure_rm_manageddisk_info.py validate-modules:doc-type-does-not-match-spec
+plugins/modules/azure_rm_manageddisk_info.py validate-modules:parameter-list-no-elements
 plugins/modules/azure_rm_manageddisk_info.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_manageddisk_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_manageddisk_info.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -51,7 +51,6 @@ plugins/modules/azure_rm_keyvault.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_keyvaultkey.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_keyvaultsecret.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_manageddisk.py validate-modules:parameter-type-not-in-doc
-plugins/modules/azure_rm_manageddisk_info.py validate-modules:doc-type-does-not-match-spec
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-missing-type
 plugins/modules/azure_rm_networkinterface.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_networkinterface_info.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed some bugs with azure_rm_manageddisk_info, and added a new managed_by parameter that will filter for only disks managed by a given VM fqid. Made code more concise and more explicit, changed ambiguous function names to more descriptive.

Fixed tag string type problem (should be list,) as well as failures when tags was not a defined parameter.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_manageddisk_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
