### PR TITLE
Fixed issue #331 removed static commercial cloud references

### DIFF
--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -201,8 +201,8 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
                 client_id=self.credentials['client_id'],
                 secret=self.credentials['secret'],
                 tenant=tenant,
-                cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                cloud_environment=self.azure_auth._cloud_environment,
+                resource = f"https://{self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()}")
 
             token = authcredential.token
             return token['token_type'], token['access_token']

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -336,8 +336,8 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
                 client_id=self.credentials['client_id'],
                 secret=self.credentials['secret'],
                 tenant=tenant,
-                cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                cloud_environment=self.azure_auth._cloud_environment,
+                resource = f"https://{self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()}")
 
             token = authcredential.token
             return token['token_type'], token['access_token']

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -194,8 +194,8 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 client_id=self.credentials['client_id'],
                 secret=self.credentials['secret'],
                 tenant=tenant,
-                cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                cloud_environment=self.azure_auth._cloud_environment,
+                resource = f"https://{self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()}")
 
             token = authcredential.token
             return token['token_type'], token['access_token']

--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -293,8 +293,8 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
                 client_id=self.credentials['client_id'],
                 secret=self.credentials['secret'],
                 tenant=tenant,
-                cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                cloud_environment=self.azure_auth._cloud_environment,
+                resource = f"https://{self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()}")
 
             token = authcredential.token
             return token['token_type'], token['access_token']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed references to azure cloud environment statically assigned to Azure Commercial
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_keyvaultkey
azure_rm_keyvaultkeyinfo
azure_rm_keyvaultsecret
azure_rm_keyvaultsecret_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
