### PR TITLE
converted computer_name to use dictionary .get method.

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -517,7 +517,7 @@ class AzureHost(object):
             id=self._vm_model['id'],
             location=self._vm_model['location'],
             name=self._vm_model['name'],
-            computer_name=self._vm_model['properties']['osProfile'].get('computerName'),
+            computer_name=self._vm_model['properties'].get('osProfile', {}).get('computerName'),
             availability_zone=av_zone,
             powerstate=self._powerstate,
             provisioning_state=self._vm_model['properties']['provisioningState'].lower(),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #367 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm inventory
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #367 for issue. This PR converts the lookup to using the dictionary .get method so that a missing key will default to None.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
