### PR TITLE
Fix doc on returned field name

### DIFF
--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -86,7 +86,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-keyvaults:
+secrets:
     description:
         - List of secrets in Azure Key Vault.
     returned: always


### PR DESCRIPTION
Documentation stated return was "keyvaults" while it seems to be "secrets"

##### SUMMARY
Documentation incorrectly states return field name

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
azure_rm_keyvaultsecret_info

##### ADDITIONAL INFORMATION
