### PR TITLE
Update plugin choices to FQCN

### DIFF
--- a/plugins/doc_fragments/azure_rm.py
+++ b/plugins/doc_fragments/azure_rm.py
@@ -16,7 +16,7 @@ options:
     plugin:
         description: marks this as an instance of the 'azure_rm' plugin
         required: true
-        choices: ['azure_rm']
+        choices: ['azure.azcollection.azure_rm']
     include_vm_resource_groups:
         description: A list of resource group names to search for virtual machines. '\*' will include all resource
             groups in the subscription.


### PR DESCRIPTION
##### SUMMARY
This is required by the change in Ansible core https://github.com/ansible/ansible/commit/1202dd000f10b0e8959019484f1c3b3f9628fc67#diff-25bf290f4a4aeb2a7adceda321671603c1023a7585b8634afea0e37d3064628eR547-R548

Without this change, the inventory plugin always errors.

To the extent of my testing, this does not harm backward compatibility.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION
Error before this:

```
[WARNING]:  * Failed to parse /home/alancoding/repos/ansible/azure_rm.yml with auto plugin: Invalid value
"azure.azcollection.azure_rm" for configuration option "plugin_type: inventory plugin:
ansible_collections.azure.azcollection.plugins.inventory.azure_rm setting: plugin ", valid values are:
['azure_rm']
  File "/home/alancoding/repos/ansible/lib/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/alancoding/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/usr/share/ansible/collections/ansible_collections/azure/azcollection/plugins/inventory/azure_rm.py", line 197, in parse
    self._read_config_data(path)
  File "/home/alancoding/repos/ansible/lib/ansible/plugins/inventory/__init__.py", line 234, in _read_config_data
    self.set_options(direct=config, var_options=self._vars)
  File "/home/alancoding/repos/ansible/lib/ansible/plugins/__init__.py", line 75, in set_options
    self._options = C.config.get_plugin_options(get_plugin_class(self), self._load_name, keys=task_keys, variables=var_options, direct=direct)
  File "/home/alancoding/repos/ansible/lib/ansible/config/manager.py", line 362, in get_plugin_options
    options[option] = self.get_config_value(option, plugin_type=plugin_type, plugin_name=name, keys=keys, variables=variables, direct=direct)
  File "/home/alancoding/repos/ansible/lib/ansible/config/manager.py", line 435, in get_config_value
    value, _drop = self.get_config_value_and_origin(config, cfile=cfile, plugin_type=plugin_type, plugin_name=plugin_name,
  File "/home/alancoding/repos/ansible/lib/ansible/config/manager.py", line 547, in get_config_value_and_origin
    raise AnsibleOptionsError('Invalid value "%s" for configuration option "%s", valid values are: %s' %
```

Behavior after this:

correctly parses inventory
