### PR TITLE
azure_rm_virtualnetworkpeering: Fix unable to remove non-existing pee…

### DIFF
--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -275,7 +275,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
                 response = self.delete_vnet_peering()
 
             else:
-                self.fail("Azure Virtual Network Peering {0} does not exist in resource group {1}".format(self.name, self.resource_group))
+                self.log("Azure Virtual Network Peering {0} does not exist in resource group {1}".format(self.name, self.resource_group))
 
         if to_be_updated:
             self.results['changed'] = True


### PR DESCRIPTION
…ring (#399)

##### SUMMARY

In case the virtual network peering does not exist when the specified state is
'absent', the code was triggering a failure. This patch changes the fail call
into log so that now the module is idempotent with 'state: absent'.

Fixes: #399

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

azure_rm_virtualnetworkpeering

##### ADDITIONAL INFORMATION

Successfully tested with the following playbook:
```paste below
- hosts: localhost
  become: no
  gather_facts: no
  tasks:
    - name: Remove Azure vnet peering
      azure_rm_virtualnetworkpeering:
        name: "/VNET_PEERING_{{ azure_resource_group }}"
        virtual_network: "{{ azure_remote_virtual_network_name }}"
        resource_group: "{{ azure_remote_virtual_network_resource_group_name }}"
        client_id: "{{ azure_client_id }}"
        secret: "{{ azure_client_secret }}"
        subscription_id: "{{ azure_remote_virtual_network_subscription_id }}"
        tenant: "{{ azure_tenant_id }}"
        cloud_environment: "{{ azure_cloud_environment }}"
        state: absent
      loop: [1, 2]
```

Output:
```
$ ansible-playbook -i inventory remove-vnet-peering.yml
PLAY [localhost] ************************************************************************************************************************************************************************

TASK [Remove Azure vnet peering] ********************************************************************************************************************************************************
ok: [localhost] => (item=1)
ok: [localhost] => (item=2)

PLAY RECAP ******************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
