### PR TITLE
New module azure_rm_managementgroup_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 /tests/output/
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
 /tests/output/
-.vscode/settings.json

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -234,7 +234,7 @@ try:
     from azure.mgmt.web.version import VERSION as web_client_version
     from azure.mgmt.network import NetworkManagementClient
     from azure.mgmt.resource.resources import ResourceManagementClient
-    from azure.mgmt.managementgroups import ManagementGroupsAPI
+    from azure.mgmt.managementgroups import ManagementGroupsAPI as ManagementGroupsClient
     from azure.mgmt.resource.subscriptions import SubscriptionClient
     from azure.mgmt.storage import StorageManagementClient
     from azure.mgmt.compute import ComputeManagementClient

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -95,7 +95,7 @@ AZURE_API_PROFILES = {
             snapshots='2018-10-01',
             virtual_machine_run_commands='2018-10-01'
         ),
-        'ManagementGroupsAPI': '2020-05-01',
+        'ManagementGroupsClient': '2020-05-01',
         'NetworkManagementClient': '2019-06-01',
         'ResourceManagementClient': '2017-05-10',
         'StorageManagementClient': '2019-06-01',
@@ -1003,7 +1003,7 @@ class AzureRMModuleBase(object):
     def management_groups_client(self):
         self.log('Getting Management Groups client...')
         if not self._management_group_client:
-            self._management_group_client = self.get_mgmt_svc_client(ManagementGroupsAPI,
+            self._management_group_client = self.get_mgmt_svc_client(ManagementGroupsClient,
                                                                      base_url=self._cloud_environment.endpoints.resource_manager,
                                                                      suppress_subscription_id=True,
                                                                      api_version='2020-05-01')

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -95,6 +95,7 @@ AZURE_API_PROFILES = {
             snapshots='2018-10-01',
             virtual_machine_run_commands='2018-10-01'
         ),
+        'ManagementGroupsAPI': '2020-05-01',
         'NetworkManagementClient': '2019-06-01',
         'ResourceManagementClient': '2017-05-10',
         'StorageManagementClient': '2019-06-01',
@@ -233,6 +234,7 @@ try:
     from azure.mgmt.web.version import VERSION as web_client_version
     from azure.mgmt.network import NetworkManagementClient
     from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.managementgroups import ManagementGroupsAPI
     from azure.mgmt.resource.subscriptions import SubscriptionClient
     from azure.mgmt.storage import StorageManagementClient
     from azure.mgmt.compute import ComputeManagementClient
@@ -402,6 +404,7 @@ class AzureRMModuleBase(object):
         self._network_client = None
         self._storage_client = None
         self._subscription_client = None
+        self._management_group_client = None
         self._resource_client = None
         self._compute_client = None
         self._dns_client = None
@@ -990,6 +993,16 @@ class AzureRMModuleBase(object):
     @property
     def subscription_models(self):
         return SubscriptionClient.models("2019-11-01")
+
+    @property
+    def management_groups_client(self):
+        self.log('Getting Management Groups client...')
+        if not self._management_group_client:
+            self._management_group_client = self.get_mgmt_svc_client(ManagementGroupsAPI,
+                                                                     base_url=self._cloud_environment.endpoints.resource_manager,
+                                                                     suppress_subscription_id=True,
+                                                                     api_version='2020-05-01')
+        return self._management_group_client
 
     @property
     def network_client(self):

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -5,13 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from msrestazure.tools import parse_resource_id
 __metaclass__ = type
-
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 
 DOCUMENTATION = '''

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2020 Paul Aiton, < @paultaiton >
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_managementgroup_info
+
+version_added: "1.2.0"
+
+short_description: Get Azure Management Group facts
+
+description:
+    - Get facts for a specific Management Group or all Management Groups.
+
+options:
+    id:
+        description:
+            - Limit results to a specific management group by id.
+            - Mutually exclusive with I(name).
+        type: str
+    name:
+        description:
+            - Limit results to a specific management group by name.
+            - Mutually exclusive with I(id).
+        aliases:
+            - management_group_name
+        type: str
+    tags:
+        description:
+            - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
+            - Option has no effect when searching by id or name, and will be silently ignored.
+        type: list
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Paul Aiton (@paultaiton)
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+management_groups:
+    description:
+        - List of Management Group dicts.
+    returned: always
+    type: list
+    contains:
+        display_name:
+            description: Management Group display name.
+            returned: always
+            type: str
+            sample: "My Management Group"
+        fqid:
+            description: Management Group fully qualified id.
+            returned: always
+            type: str
+            sample: "/providers/Microsoft.Management/managementGroups/group-name"
+        name:
+            description: Management Group display name.
+            returned: always
+            type: str
+            sample: group-name
+        tenant_id:
+            description: Management Group tenant id
+            returned: always
+            type: str
+            sample: "00000000-0000-0000-0000-000000000000"
+        type:
+            description: Management Group type
+            returned: always
+            type: str
+            sample: "/providers/Microsoft.Management/managementGroups"
+'''
+
+try:
+    from msrestazure.azure_exceptions import CloudError
+except Exception:
+    # This is handled in azure_rm_common
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+AZURE_OBJECT_CLASS = 'Subscription'
+
+
+class AzureRMSubscriptionInfo(AzureRMModuleBase):
+
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            name=dict(type='str', aliases=['subscription_name']),
+            id=dict(type='str')
+        )
+
+        self.results = dict(
+            changed=False,
+            subscriptions=[]
+        )
+
+        self.name = None
+        self.id = None
+        self.tags = None
+        self.all = False
+
+        mutually_exclusive = [['name', 'id']]
+
+        super(AzureRMSubscriptionInfo, self).__init__(self.module_arg_spec,
+                                                      supports_tags=False,
+                                                      mutually_exclusive=mutually_exclusive,
+                                                      facts_module=True)
+
+    def exec_module(self, **kwargs):
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.id and self.name:
+            self.fail("Parameter error: cannot search subscriptions by both name and id.")
+
+        result = []
+
+        if self.id:
+            result = self.get_item()
+        else:
+            result = self.list_items()
+
+        self.results['subscriptions'] = result
+        return self.results
+
+    def get_item(self):
+        self.log('Get properties for {0}'.format(self.id))
+        item = None
+        result = []
+
+        try:
+            item = self.subscription_client.subscriptions.get(self.id)
+        except CloudError:
+            pass
+
+        result = self.to_dict(item)
+
+        return result
+
+    def list_items(self):
+        self.log('List all items')
+        try:
+            response = self.subscription_client.subscriptions.list()
+        except CloudError as exc:
+            self.fail("Failed to list all items - {0}".format(str(exc)))
+
+        results = []
+        for item in response:
+            # If the name matches, return result regardless of anything else.
+            # If name is not defined and either state is Enabled or all is true, and tags match, return result.
+            if self.name and self.name.lower() == item.display_name.lower():
+                results.append(self.to_dict(item))
+            elif not self.name and (self.all or item.state == "Enabled") and self.has_tags(item.tags, self.tags):
+                results.append(self.to_dict(item))
+
+        return results
+
+    def to_dict(self, subscription_object):
+        return dict(
+            display_name=subscription_object.display_name,
+            fqid=subscription_object.id,
+            state=subscription_object.state,
+            subscription_id=subscription_object.subscription_id,
+            tags=subscription_object.tags,
+            tenant_id=subscription_object.tenant_id
+        )
+
+
+def main():
+    AzureRMSubscriptionInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -125,13 +125,13 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
         management_group_list = []
         subscription_list = []
         if management_group.get('children'):
-            for child in management_group.children:
-                if child.type == '/providers/Microsoft.Management/managementGroups':
+            for child in management_group.get('children', []):
+                if child.get('type') == '/providers/Microsoft.Management/managementGroups':
                     management_group_list.append(child)
-                    new_groups, new_subscriptions = self.flatten(child)
-                    management_group_list + new_groups
-                    subscription_list + new_subscriptions
-                elif child.type == '/subscriptions':
+                    new_groups, new_subscriptions = self.flatten_group(child)
+                    management_group_list += new_groups
+                    subscription_list += new_subscriptions
+                elif child.get('type') == '/subscriptions':
                     subscription_list.append(child)
         return management_group_list, subscription_list
 
@@ -153,8 +153,8 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
                 new_subscriptions = []
                 self.results['management_groups'].append(group)
                 new_groups, new_subscriptions = self.flatten_group(group)
-                self.results['management_groups'] + new_groups
-                self.results['subscriptions'] + new_subscriptions
+                self.results['management_groups'] += new_groups
+                self.results['subscriptions'] += new_subscriptions
         else:
             self.results['management_groups'] = response
 

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -170,7 +170,7 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
             children=dict(type='bool', default=False),
             flatten=dict(type='bool', default=False),
             id=dict(type='str'),
-            name=dict(type='str'， aliases=['management_group_name']),
+            name=dict(type='str', aliases=['management_group_name']),
             recurse=dict(type='bool', default=False)
         )
 

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -170,7 +170,7 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
             children=dict(type='bool', default=False),
             flatten=dict(type='bool', default=False),
             id=dict(type='str'),
-            name=dict(type='str'),
+            name=dict(type='str'， aliases=['management_group_name']),
             recurse=dict(type='bool', default=False)
         )
 

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -232,7 +232,7 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
                                                                            expand=expand,
                                                                            recurse=self.recurse)
         except CloudError:
-            self.log('No Management group {} found.'.format(mg_name))
+            self.log('No Management group {0} found.'.format(mg_name))
             response = None
 
         return self.to_dict(response)

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -96,13 +96,8 @@ except Exception:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 
-AZURE_OBJECT_CLASS = 'Subscription'
-
-
 class AzureRMSubscriptionInfo(AzureRMModuleBase):
-
     def __init__(self):
-
         self.module_arg_spec = dict(
             name=dict(type='str', aliases=['subscription_name']),
             id=dict(type='str')
@@ -110,7 +105,7 @@ class AzureRMSubscriptionInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            subscriptions=[]
+            management_groups=[]
         )
 
         self.name = None

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -174,28 +174,32 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
 
     def to_dict(self, azure_object):
         if azure_object.type == '/providers/Microsoft.Management/managementGroups':
-            mg_dict = dict(
+            return_dict = dict(
                 display_name=azure_object.display_name,
                 id=azure_object.id,
                 name=azure_object.name,
                 type=azure_object.type
             )
             if self.children and azure_object.as_dict().get('children'):
-                mg_dict['children'] = [self.to_dict(item) for item in azure_object.children]  # if item.type == '/providers/Microsoft.Management/managementGroups']
+                return_dict['children'] = [self.to_dict(item) for item in azure_object.children]  # if item.type == '/providers/Microsoft.Management/managementGroups']
         elif azure_object.type == '/subscriptions':
-            mg_dict = dict(
+            return_dict = dict(
                 display_name=azure_object.display_name,
                 id=azure_object.id,
                 subscription_id=azure_object.name,
                 type=azure_object.type
             )
         else:
-            mg_dict = dict()
+            # This should never happen. The code here will prevent a problem,
+            # but there should be logic to take care of a new child type of management groups.
+            return_dict = dict(
+                state='You should report this as a bug.'
+            )
 
         if azure_object.as_dict().get('tenant_id'):
-            mg_dict['tenant_id'] = azure_object.tenant_id
+            return_dict['tenant_id'] = azure_object.tenant_id
 
-        return mg_dict
+        return return_dict
 
     def flatten(self, azure_object):
         return [azure_object]

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -48,6 +48,7 @@ parameters:
     - "azure_rm_loadbalancer"
     - "azure_rm_loganalyticsworkspace"
     - "azure_rm_manageddisk"
+    - "azure_rm_managementgroup"
     - "azure_rm_mariadbserver"
     - "azure_rm_monitorlogprofile"
     - "azure_rm_mysqlserver"

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -16,6 +16,7 @@ azure-mgmt-keyvault==1.1.0
 azure-mgmt-marketplaceordering==0.1.0
 azure-mgmt-monitor==0.5.2
 azure-mgmt-managedservices==1.0.0
+azure-mgmt-managementgroups==0.2.0
 azure-mgmt-network==10.2.0
 azure-mgmt-nspkg==2.0.0
 azure-mgmt-privatedns==0.1.0

--- a/tests/integration/targets/azure_rm_managementgroup/aliases
+++ b/tests/integration/targets/azure_rm_managementgroup/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+shippable/azure/group2
+destructive

--- a/tests/integration/targets/azure_rm_managementgroup/aliases
+++ b/tests/integration/targets/azure_rm_managementgroup/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 shippable/azure/group2
-destructive
+disabled

--- a/tests/integration/targets/azure_rm_managementgroup/meta/main.yml
+++ b/tests/integration/targets/azure_rm_managementgroup/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_managementgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_managementgroup/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Get list of all managementgroups
+  azure_rm_managementgroup_info:
+  register: az_all_managementgroups
+
+- name: Get a managementgroup by id
+  azure_rm_managementgroup_info:
+    id: "{{ az_all_managementgroups.management_groups[0].id }}"
+    recurse: True
+    flatten: True
+    children: True
+
+- name: Get a managementgroup by name
+  azure_rm_managementgroup_info:
+    name: "{{ az_all_managementgroups.management_groups[0].name }}"
+    recurse: True
+    flatten: True
+
+- name: Test invalid name id combo
+  azure_rm_managementgroup_info:
+    name: "{{ az_all_managementgroups.management_groups[0].name }}"
+    id: "{{ az_all_managementgroups.management_groups[0].id }}"
+  register: invalid_name
+  ignore_errors: yes
+
+- name: Assert task failed
+  assert:
+    that:
+      - invalid_name['failed']

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -206,8 +206,6 @@ plugins/modules/azure_rm_manageddisk_info.py validate-modules:return-syntax-erro
 plugins/modules/azure_rm_managementgroup.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-unknown-key
-plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-requirements-unknown
-plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-missing-type
 plugins/modules/azure_rm_networkinterface.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-elements-mismatch

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -206,6 +206,8 @@ plugins/modules/azure_rm_manageddisk_info.py validate-modules:return-syntax-erro
 plugins/modules/azure_rm_managementgroup.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-unknown-key
+plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-requirements-unknown
+plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-missing-type
 plugins/modules/azure_rm_networkinterface.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-elements-mismatch

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -207,7 +207,7 @@ plugins/modules/azure_rm_managementgroup.py validate-modules:invalid-ansiblemodu
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-requirements-unknown
-plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-unknown-keyp
+plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-unknown-key
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-missing-type
 plugins/modules/azure_rm_networkinterface.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-elements-mismatch

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -206,6 +206,8 @@ plugins/modules/azure_rm_manageddisk_info.py validate-modules:return-syntax-erro
 plugins/modules/azure_rm_managementgroup.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-requirements-unknown
 plugins/modules/azure_rm_managementgroup.py validate-modules:required_if-unknown-key
+plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-requirements-unknown
+plugins/modules/azure_rm_managementgroup_info.py validate-modules:required_if-unknown-keyp
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-missing-type
 plugins/modules/azure_rm_networkinterface.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_networkinterface.py validate-modules:doc-elements-mismatch


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
info module for management groups.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_managementgroup_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This is a read only info module for querying Azure RM and gather details about management groups.

I have added integration test tasks, but I'm not sure what kind of role assignments exist for the test accounts, and can't be 100% certain they will work. It requires at least 1 management group exists which the principal has reader access to.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
