### PR TITLE
Update azure_rm_storageaccount.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 /tests/output/
+tests/integration/cloud-config-azure.ini

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -86,6 +86,7 @@ options:
     https_only:
         description:
             - Allows https traffic only to storage service when set to C(true).
+            - Allows update storage account property when set to C(False).
             - Default value is C(True).
         type: bool
     minimum_tls_version:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -85,25 +85,24 @@ options:
             - force
     https_only:
         description:
-            - Allows https traffic only to storage service when set to C(true).
-            - Allows update storage account property when set to C(False).
-        default: True
+            - Allows https traffic only to storage service when set to C(True).
+            - If omitted, new account creation will default to True, while exiting accounts will not be change.
         type: bool
     minimum_tls_version:
         description:
             - The minimum required version of Transport Layer Security (TLS) for requests to a storage account.
+            - If omitted, new account creation will default to TLS1_0, while exiting accounts will not be change.
         choices:
             - TLS1_0
             - TLS1_1
             - TLS1_2
-        default: 'TLS1_0'
         version_added: "1.0.0"
     allow_blob_public_access:
         description:
             - Allows blob containers in account to be set for anonymous public access.
             - If set to false, no containers in this account will be able to allow anonymous public access.
+            - If omitted, new account creation will default to True, while exiting accounts will not be change.
         type: bool
-        default: True
         version_added: "1.1.0"
     network_acls:
         description:
@@ -457,9 +456,9 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             tags=dict(type='dict'),
             kind=dict(type='str', default='Storage', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
             access_tier=dict(type='str', choices=['Hot', 'Cool']),
-            https_only=dict(type='bool', default=True),
-            minimum_tls_version=dict(type='str', default='TLS1_0', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
-            allow_blob_public_access=dict(type='bool', default=True),
+            https_only=dict(type='bool'),
+            minimum_tls_version=dict(type='str', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
+            allow_blob_public_access=dict(type='bool'),
             network_acls=dict(type='dict'),
             blob_cors=dict(type='list', options=cors_rule_spec, elements='dict')
         )

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -706,16 +706,16 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                     self.fail("Failed to update account type: {0}".format(str(exc)))
 
         if self.allow_blob_public_access is not None and self.allow_blob_public_access != self.account_dict.get('allow_blob_public_access'):
-                self.results['changed'] = True
-                self.account_dict['allow_blob_public_access'] = self.allow_blob_public_access
-                if not self.check_mode:
-                    try:
-                        parameters = self.storage_models.StorageAccountUpdateParameters(allow_blob_public_access=self.allow_blob_public_access)
-                        self.storage_client.storage_accounts.update(self.resource_group,
-                                                                    self.name,
-                                                                    parameters)
-                    except Exception as exc:
-                        self.fail("Failed to update account type: {0}".format(str(exc)))
+            self.results['changed'] = True
+            self.account_dict['allow_blob_public_access'] = self.allow_blob_public_access
+            if not self.check_mode:
+                try:
+                    parameters = self.storage_models.StorageAccountUpdateParameters(allow_blob_public_access=self.allow_blob_public_access)
+                    self.storage_client.storage_accounts.update(self.resource_group,
+                                                                self.name,
+                                                                parameters)
+                except Exception as exc:
+                    self.fail("Failed to update account type: {0}".format(str(exc)))
 
         if self.account_type:
             if self.account_type != self.account_dict['sku_name']:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -681,7 +681,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                     self.results['changed'] = True
                     self.update_network_rule_set()
 
-        if self.https_only is not None and self.https_only != self.account_dict.get('https_only'):
+        if self.https_only is not None and bool(self.https_only) != bool(self.account_dict.get('https_only')):
             self.results['changed'] = True
             self.account_dict['https_only'] = self.https_only
             if not self.check_mode:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -86,12 +86,12 @@ options:
     https_only:
         description:
             - Allows https traffic only to storage service when set to C(True).
-            - If omitted, new account creation will default to True, while exiting accounts will not be change.
+            - If omitted, new account creation will default to True, while existing accounts will not be change.
         type: bool
     minimum_tls_version:
         description:
             - The minimum required version of Transport Layer Security (TLS) for requests to a storage account.
-            - If omitted, new account creation will default to TLS1_0, while exiting accounts will not be change.
+            - If omitted, new account creation will default to null which is currently interpreted to TLS1_0. Existing accounts will not be modified.
         choices:
             - TLS1_0
             - TLS1_1
@@ -101,7 +101,7 @@ options:
         description:
             - Allows blob containers in account to be set for anonymous public access.
             - If set to false, no containers in this account will be able to allow anonymous public access.
-            - If omitted, new account creation will default to True, while exiting accounts will not be change.
+            - If omitted, new account creation will default to null which is currently interpreted to True. Existing accounts will not be modified.
         type: bool
         version_added: "1.1.0"
     network_acls:
@@ -681,7 +681,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                     self.results['changed'] = True
                     self.update_network_rule_set()
 
-        if self.https_only is not None and bool(self.https_only) != bool(self.account_dict.get('https_only')):
+        if self.https_only is not None and self.https_only != self.account_dict.get('https_only'):
             self.results['changed'] = True
             self.account_dict['https_only'] = self.https_only
             if not self.check_mode:
@@ -705,8 +705,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                 except Exception as exc:
                     self.fail("Failed to update account type: {0}".format(str(exc)))
 
-        if self.allow_blob_public_access is not None:
-            if bool(self.allow_blob_public_access) != bool(self.account_dict.get('allow_blob_public_access')):
+        if self.allow_blob_public_access is not None and self.allow_blob_public_access != self.account_dict.get('allow_blob_public_access'):
                 self.results['changed'] = True
                 self.account_dict['allow_blob_public_access'] = self.allow_blob_public_access
                 if not self.check_mode:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -87,7 +87,7 @@ options:
         description:
             - Allows https traffic only to storage service when set to C(true).
             - Allows update storage account property when set to C(False).
-            - Default value is C(True).
+        default: True
         type: bool
     minimum_tls_version:
         description:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -823,7 +823,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             if self.blob_cors:
                 account_dict['blob_cors'] = self.blob_cors
             return account_dict
-        if bool(self.https_only):
+        if not bool(self.https_only):
             self.https_only = False
         if bool(self.minimum_tls_version):
             self.minimum_tls_version = 'TLS1_0'

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -86,8 +86,7 @@ options:
     https_only:
         description:
             - Allows https traffic only to storage service when set to C(true).
-            - Allows update storage account property when set to C(False).
-            - Default value is C(False).
+            - Default value is C(True).
         type: bool
     minimum_tls_version:
         description:
@@ -457,7 +456,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             tags=dict(type='dict'),
             kind=dict(type='str', default='Storage', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
             access_tier=dict(type='str', choices=['Hot', 'Cool']),
-            https_only=dict(type='bool'),
+            https_only=dict(type='bool', default=True),
             minimum_tls_version=dict(type='str', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
             allow_blob_public_access=dict(type='bool'),
             network_acls=dict(type='dict'),
@@ -823,8 +822,6 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             if self.blob_cors:
                 account_dict['blob_cors'] = self.blob_cors
             return account_dict
-        if not bool(self.https_only):
-            self.https_only = False
         if bool(self.minimum_tls_version):
             self.minimum_tls_version = 'TLS1_0'
         if bool(self.allow_blob_public_access):

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -92,18 +92,18 @@ options:
     minimum_tls_version:
         description:
             - The minimum required version of Transport Layer Security (TLS) for requests to a storage account.
-            - Default value is C(TLS1_0).
         choices:
             - TLS1_0
             - TLS1_1
             - TLS1_2
+        default: 'TLS1_0'
         version_added: "1.0.0"
     allow_blob_public_access:
         description:
             - Allows blob containers in account to be set for anonymous public access.
             - If set to false, no containers in this account will be able to allow anonymous public access.
-            - Default value is C(True).
         type: bool
+        default: True
         version_added: "1.1.0"
     network_acls:
         description:
@@ -458,8 +458,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             kind=dict(type='str', default='Storage', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
             access_tier=dict(type='str', choices=['Hot', 'Cool']),
             https_only=dict(type='bool', default=True),
-            minimum_tls_version=dict(type='str', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
-            allow_blob_public_access=dict(type='bool'),
+            minimum_tls_version=dict(type='str', default='TLS1_0', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
+            allow_blob_public_access=dict(type='bool', default=True),
             network_acls=dict(type='dict'),
             blob_cors=dict(type='list', options=cors_rule_spec, elements='dict')
         )
@@ -823,10 +823,6 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             if self.blob_cors:
                 account_dict['blob_cors'] = self.blob_cors
             return account_dict
-        if bool(self.minimum_tls_version):
-            self.minimum_tls_version = 'TLS1_0'
-        if bool(self.allow_blob_public_access):
-            self.allow_blob_public_access = True
         sku = self.storage_models.Sku(name=self.storage_models.SkuName(self.account_type))
         sku.tier = self.storage_models.SkuTier.standard if 'Standard' in self.account_type else \
             self.storage_models.SkuTier.premium

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -1,211 +1,327 @@
- - name: Create storage account name
-   set_fact:
-       storage_account: "sa{{ resource_group | hash('md5') | truncate(22, True, '') }}"
+- name: Set Storage Account Names
+  set_fact:
+    storage_account_name_default: "sa{{ resource_group | hash('md5') | truncate(22, True, '') }}"
+    storage_account_name_explicit: "sa{{ resource_group | hash('sha1') | truncate(22, True, '') }}"
 
- - name: Test invalid account name
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}" 
-       name: "invalid_char$"
-   register: invalid_name     
-   ignore_errors: yes  
+- name: Test invalid account name
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "invalid_char$"
+    account_type: Standard_LRS
+  register: output
+  ignore_errors: yes  
 
- - name: Assert task failed
-   assert: { that: "invalid_name['failed'] == True" }
+- name: Check intentional name failure.
+  assert: 
+    that: 
+      - output.failed
+      - output.msg is regex('AccountNameInvalid')
 
- - name: Delete storage account
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}" 
-       name: "{{ storage_account }}"
-       state: absent
-       force_delete_nonempty: True
+- name: Delete storage accounts to prepare fresh deployment
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ item }}"
+    state: absent
+    force_delete_nonempty: True
+  loop:
+    - "{{ storage_account_name_default }}"
+    - "{{ storage_account_name_explicit }}"
 
- - name: Create new storage account
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}" 
-       name: "{{ storage_account }}"
-       account_type: Standard_LRS
-       append_tags: no
-       blob_cors:
-          - allowed_origins:
-              - http://www.example.com/
-            allowed_methods:
-              - GET
-              - POST
-            allowed_headers:
-              - x-ms-meta-data*
-              - x-ms-meta-target*
-              - x-ms-meta-abc
-            exposed_headers:
-              - x-ms-meta-*
-            max_age_in_seconds: 200
-       tags:
-           test: test
-           galaxy: galaxy
-       https_only: no
-       network_acls:
-         bypass: AzureServices
-         default_action: Deny
-         ip_rules:
-           - value: '9.9.9.9'
-             action: Allow
-   register: output
+- name: Create new storage account with defaults (omitted parameters)
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ storage_account_name_default }}"
+    account_type: Standard_LRS
+  register: defaults_output
 
- - name: Assert status succeeded and results include an Id value 
-   assert:
-     that:
-       - output.changed
-       - output.state.id is defined
-       - output.state.blob_cors | length == 1
-       - not output.state.https_only
-       - output.state.network_acls.bypass == "AzureServices"
-       - output.state.network_acls.default_action == "Deny"
-       - output.state.network_acls.ip_rules | length == 1
+- name: Assert status succeeded and results match expectations
+  assert:
+    that:
+      - defaults_output.changed
+      - defaults_output.state.name == storage_account_name_default
+      - defaults_output.state.id is defined
+      - defaults_output.state.https_only
+      - defaults_output.state.access_tier == None
+      - defaults_output.state.allow_blob_public_access == None
+      - defaults_output.state.minimum_tls_version == None
 
- - name: Create new storage account (idempotence)
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}" 
-       name: "{{ storage_account }}"
-       account_type: Standard_LRS
-       append_tags: no
-       blob_cors:
-          - allowed_origins:
-              - http://www.example.com/
-            allowed_methods:
-              - GET
-              - POST
-            allowed_headers:
-              - x-ms-meta-data*
-              - x-ms-meta-target*
-              - x-ms-meta-abc
-            exposed_headers:
-              - x-ms-meta-*
-            max_age_in_seconds: 200
-       tags:
-           test: test
-           galaxy: galaxy
-       https_only: no
-       network_acls:
-         bypass: AzureServices
-         default_action: Deny
-         ip_rules:
-           - value: '9.9.9.9'
-             action: Allow
-   register: output
-  
- - assert:
-     that:
-        - not output.changed
+- name: Create new storage account with explicit parameters
+  azure_rm_storageaccount:
+    access_tier: Hot
+    account_type: Premium_LRS
+    allow_blob_public_access: False
+    append_tags: no
+    blob_cors:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+        allowed_headers:
+          - x-ms-meta-data*
+          - x-ms-meta-target*
+          - x-ms-meta-abc
+        exposed_headers:
+          - x-ms-meta-*
+        max_age_in_seconds: 200
+    https_only: False
+    kind: StorageV2
+    location: eastus
+    minimum_tls_version: 'TLS1_2'
+    name: "{{ storage_account_name_explicit }}"
+    network_acls:
+      bypass: AzureServices
+      default_action: Deny
+      ip_rules:
+        - value: '9.9.9.9'
+          action: Allow
+    resource_group: "{{ resource_group }}" 
+    tags:
+      test: test
+      galaxy: galaxy
+  register: explicit_output
 
- - name: Gather facts by tags
-   azure_rm_storageaccount_info:
-       resource_group: "{{ resource_group }}"
-       tags:
-         - test
-         - galaxy
-   register: output
+- name: Assert status succeeded and correct parameter results
+  assert:
+    that:
+      - explicit_output.changed
+      - explicit_output.state.id is defined
+      - explicit_output.state.blob_cors | length == 1
+      - not explicit_output.state.https_only
+      - not explicit_output.state.allow_blob_public_access
+      - explicit_output.state.minimum_tls_version == 'TLS1_2'
+      - explicit_output.state.network_acls.bypass == "AzureServices"
+      - explicit_output.state.network_acls.default_action == "Deny"
+      - explicit_output.state.network_acls.ip_rules | length == 1
 
- - assert:
-       that: output.storageaccounts | length >= 1
+- name: Update existing storage account (idempotence)
+  azure_rm_storageaccount:
+    access_tier: Hot
+    account_type: Premium_LRS
+    allow_blob_public_access: False
+    append_tags: no
+    blob_cors:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+        allowed_headers:
+          - x-ms-meta-data*
+          - x-ms-meta-target*
+          - x-ms-meta-abc
+        exposed_headers:
+          - x-ms-meta-*
+        max_age_in_seconds: 200
+    https_only: False
+    kind: StorageV2
+    location: eastus
+    minimum_tls_version: 'TLS1_2'
+    name: "{{ storage_account_name_explicit }}"
+    network_acls:
+      bypass: AzureServices
+      default_action: Deny
+      ip_rules:
+        - value: '9.9.9.9'
+          action: Allow
+    resource_group: "{{ resource_group }}" 
+    tags:
+      test: test
+      galaxy: galaxy
+  register: output
 
- - name: Change account type 
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}" 
-       name: "{{ storage_account }}"
-       account_type: Premium_LRS
-   register: change_account
-   ignore_errors: yes 
+- name: Assert that properties have not changed
+  assert:
+    that:
+      - not output.changed
+      - output.state.access_tier == explicit_output.state.access_tier
+      - output.state.allow_blob_public_access == explicit_output.state.allow_blob_public_access
+      - output.state.blob_cors == explicit_output.state.blob_cors
+      - output.state.custom_domain == explicit_output.state.custom_domain
+      - output.state.https_only == explicit_output.state.https_only
+      - output.state.id == explicit_output.state.id
+      - output.state.location == explicit_output.state.location
+      - output.state.minimum_tls_version == explicit_output.state.minimum_tls_version
+      - output.state.name == explicit_output.state.name
+      - output.state.network_acls == explicit_output.state.network_acls
+      - output.state.primary_endpoints == explicit_output.state.primary_endpoints
+      - output.state.primary_location == explicit_output.state.primary_location
+      - output.state.secondary_endpoints == explicit_output.state.secondary_endpoints
+      - output.state.secondary_location == explicit_output.state.secondary_location
+      - output.state.sku_name == explicit_output.state.sku_name
+      - output.state.sku_tier == explicit_output.state.sku_tier
+      - output.state.tags == explicit_output.state.tags
 
- - name: Assert account type change failed 
-   assert: { that: "change_account['failed'] == True" }
+- name: Update existing storage account with parameters omitted
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ storage_account_name_explicit }}"
+  register: output
 
- - name: Change account type and add custom domain
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}"
-       name: "{{ storage_account }}"
-       account_type: Standard_GRS
-       custom_domain: { name: ansible.com, use_sub_domain: no }
-   register: change_account
-   ignore_errors: yes
+- name: Assert that properties have not changed
+  assert:
+    that:
+      - not output.changed
+      - output.state.access_tier == explicit_output.state.access_tier
+      - output.state.allow_blob_public_access == explicit_output.state.allow_blob_public_access
+      - output.state.blob_cors == explicit_output.state.blob_cors
+      - output.state.custom_domain == explicit_output.state.custom_domain
+      - output.state.https_only == explicit_output.state.https_only
+      - output.state.id == explicit_output.state.id
+      - output.state.location == explicit_output.state.location
+      - output.state.minimum_tls_version == explicit_output.state.minimum_tls_version
+      - output.state.name == explicit_output.state.name
+      - output.state.network_acls == explicit_output.state.network_acls
+      - output.state.primary_endpoints == explicit_output.state.primary_endpoints
+      - output.state.primary_location == explicit_output.state.primary_location
+      - output.state.secondary_endpoints == explicit_output.state.secondary_endpoints
+      - output.state.secondary_location == explicit_output.state.secondary_location
+      - output.state.sku_name == explicit_output.state.sku_name
+      - output.state.sku_tier == explicit_output.state.sku_tier
+      - output.state.tags == explicit_output.state.tags
 
- - name: Assert CNAME failure
-   assert: { that: "'custom domain name could not be verified' in  change_account['msg']" }
+- name: Update existing storage account with parameters defined
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ storage_account_name_default }}"
+    allow_blob_public_access: False
+    append_tags: no
+    blob_cors:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+        allowed_headers:
+          - x-ms-meta-data*
+          - x-ms-meta-target*
+          - x-ms-meta-abc
+        exposed_headers:
+          - x-ms-meta-*
+        max_age_in_seconds: 200
+    https_only: False
+    kind: StorageV2
+    minimum_tls_version: 'TLS1_1'
+    network_acls:
+      bypass: AzureServices
+      default_action: Deny
+      ip_rules:
+        - value: '9.9.9.9'
+          action: Allow
+    tags:
+      test: test
+      galaxy: galaxy
+  register: output
 
- - name: Update account tags
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}"
-       name: "{{ storage_account }}"
-       append_tags: no
-       tags:
-           testing: testing
-           delete: never
-   register: output
+- name: Assert account change success
+  assert:
+    that:
+      - output.changed
+      - output.state.allow_blob_public_access == False
+      - output.state.allow_blob_public_access != None
+      - output.state.https_only == False
+      - output.state.https_only != None
+      - output.state.minimum_tls_version == 'TLS1_1'
+      - output.state.name == storage_account_name_default
+      - output.state.tags == explicit_output.state.tags
+      # These tests should be valid, but is currently broken due to 'output' not containing blob_cors and network_acls.ip_rules
+      # - output.state.blob_cors == explicit_output.state.blob_cors
+      # - output.state.network_acls == explicit_output.state.network_acls
 
- - assert:
-       that:
-           - "output.state.tags | length == 2"
-           - "output.state.tags.testing == 'testing'"
-           - "output.state.tags.delete == 'never'"
+- name: Change existing account type (invalid)
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ storage_account_name_default }}"
+    account_type: Premium_LRS
+  register: output
+  ignore_errors: yes 
 
- - name: Update account minimum tls version
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}"
-       name: "{{ storage_account }}"
-       minimum_tls_version: "TLS1_2" 
-   register: output
+- name: Assert account type change failed 
+  assert:
+    that:
+      - output.failed
+      - output.msg is regex('Storage account of type .* cannot be changed')
 
- - name: Assert status succeeded and results include an Id value 
-   assert:
-     that:
-       - output.changed
-       - output.state.minimum_tls_version == "TLS1_2"
+- name: Unverified custom domain failure
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ storage_account_name_default }}"
+    custom_domain:
+      name: ansible.com
+      use_sub_domain: no
+  ignore_errors: yes  
+  register: output
 
- - name: Update account blob public access
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}"
-       name: "{{ storage_account }}"
-       allow_blob_public_access: true
-   register: output
+- name: Assert CNAME failure
+  assert: 
+    that: 
+      - output.failed
+      - output.msg is regex('custom domain name could not be verified')
 
- - name: Assert status succeeded and results include an Id value 
-   assert:
-     that:
-       - output.changed
-       - output.state.allow_blob_public_access == true
+- name: Gather facts by tags
+  azure_rm_storageaccount_info:
+    resource_group: "{{ resource_group }}"
+    tags:
+      - test
+      - galaxy
+  register: output
 
- - name: Gather facts
-   azure_rm_storageaccount_info:
-       resource_group: "{{ resource_group }}"
-       name: "{{ storage_account }}"
-       show_connection_string: True
-       show_blob_cors: True
-   register: output
+- assert:
+      that: output.storageaccounts | length >= 1
 
- - assert:
-       that:
-           - "output.storageaccounts | length == 1"
-           - not output.storageaccounts[0].custom_domain
-           - output.storageaccounts[0].account_type == "Standard_GRS"
-           - output.storageaccounts[0].primary_endpoints.blob.connectionstring
-           - output.storageaccounts[0].blob_cors
-           - output.storageaccounts[0].minimum_tls_version == "TLS1_2" 
-           - output.storageaccounts[0].allow_blob_public_access == true
-           #- output.storageaccounts[0].https_only
-           #- output.storageaccounts[0].network_acls.bypass == "AzureServices"
-           #- output.storageaccounts[0].network_acls.default_action == "Deny"
-           #- output.storageaccounts[0].network_acls.ip_rules | length == 1
+- name: Update account tags
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account_name_explicit }}"
+    append_tags: no
+    tags:
+      testing: testing
+      delete: never
+  register: output
 
- - name: Gather facts
-   azure_rm_storageaccount_info:
-       resource_group: "{{ resource_group }}"
-   register: output
+- assert:
+    that:
+      - "output.state.tags | length == 2"
+      - "output.state.tags.testing == 'testing'"
+      - "output.state.tags.delete == 'never'"
 
- - assert:
-       that:
-           - "output.storageaccounts | length > 0"
+- name: Gather facts connection string and blob_cors
+  azure_rm_storageaccount_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account_name_explicit }}"
+    show_connection_string: True
+    show_blob_cors: True
+  register: output
 
- - name: Delete acccount
-   azure_rm_storageaccount:
-       resource_group: "{{ resource_group }}" 
-       name: "{{ storage_account }}"
-       state: absent
-       force_delete_nonempty: True
+- assert:
+    that:
+      - "output.storageaccounts | length == 1"
+      - not output.storageaccounts[0].custom_domain
+      - output.storageaccounts[0].account_type == "Premium_LRS"
+      - output.storageaccounts[0].primary_endpoints.blob.connectionstring
+      - output.storageaccounts[0].blob_cors
+      - output.storageaccounts[0].minimum_tls_version == "TLS1_2" 
+      - not output.storageaccounts[0].allow_blob_public_access
+      - not output.storageaccounts[0].https_only
+      - output.storageaccounts[0].network_acls.bypass == "AzureServices"
+      - output.storageaccounts[0].network_acls.default_action == "Deny"
+      - output.storageaccounts[0].network_acls.ip_rules | length == 1
+
+- name: List storage accounts by resource group.
+  azure_rm_storageaccount_info:
+    resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - "output.storageaccounts | length >= 2"
+
+- name: Delete storage accounts
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}" 
+    name: "{{ item }}"
+    state: absent
+    force_delete_nonempty: True
+  loop:
+    - "{{ storage_account_name_default }}"
+    - "{{ storage_account_name_explicit }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix passing minimum_tls_version, allow_blob_public_access, and https_only on new storage account creation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #457 
Fixes #325 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_storageaccount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is a bugfix in the creation of new storage account, and update of tests to catch this bug in future regressions.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
