### PR TITLE
Unrestrict the virtual network of multiple DNS servers when I(purge_a…

### DIFF
--- a/plugins/modules/azure_rm_virtualnetwork.py
+++ b/plugins/modules/azure_rm_virtualnetwork.py
@@ -256,9 +256,6 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
                 if not CIDR_PATTERN.match(prefix):
                     self.fail("Parameter error: invalid address prefix value {0}".format(prefix))
 
-            if self.dns_servers and len(self.dns_servers) > 2:
-                self.fail("Parameter error: You can provide a maximum of 2 DNS servers.")
-
         changed = False
         results = dict()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Unrestrict the virtual network of multiple DNS servers when I(purge_address_prefixes=true). fixes #461 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualnetwork.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
