### PR TITLE
Add availability zones to azure_rm_virtualmachine_info module

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -234,6 +234,10 @@ vms:
             returned: always
             type: str
             sample: Standard_D4
+        zones:
+            description:
+                - A list of Availability Zones for your VM.
+            type: list
         power_state:
             description:
                 - Power state of the virtual machine.
@@ -386,6 +390,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
         new_result['state'] = 'present'
         new_result['location'] = vm.location
         new_result['vm_size'] = result['properties']['hardwareProfile']['vmSize']
+        new_result['zones'] = result['zones']
         os_profile = result['properties'].get('osProfile')
         if os_profile is not None:
             new_result['admin_username'] = os_profile.get('adminUsername')

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -390,7 +390,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
         new_result['state'] = 'present'
         new_result['location'] = vm.location
         new_result['vm_size'] = result['properties']['hardwareProfile']['vmSize']
-        new_result['zones'] = result['zones']
+        new_result['zones'] = result.get('zones', None)
         os_profile = result['properties'].get('osProfile')
         if os_profile is not None:
             new_result['admin_username'] = os_profile.get('adminUsername')


### PR DESCRIPTION
##### SUMMARY
Adds availability zone info to the `azure_rm_virtualmachine_info` module
fixes #522

This is, in a way, an extension of https://github.com/ansible-collections/azure/pull/243.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine_info

##### ADDITIONAL INFORMATION
With this PR, output looks like:
```diff
TASK [test : debug] **************************************************************************************************************
task path: /ansible/roles/test/tasks/main.yml:27
 ok: [...] => {
     "vm_info": {
         "changed": false,
         "failed": false,
         "vms": [
             {
                 "admin_username": "...",
                 "boot_diagnostics": {
                     "console_screenshot_uri": "...",
                     "enabled": true,
                     "serial_console_log_uri": "...",
                     "storage_uri": "..."
                 },
                 "data_disks": [
                     {
                         "caching": "ReadWrite",
                         "disk_size_gb": 128,
                         "lun": 0,
                         "managed_disk_type": "Premium_LRS"
                     }
                 ],
                 "id": "...",
                 "image": {
                     "id": "..."
                 },
                 "location": "...",
                 "name": "...",
                 "network_interface_names": [
                     "..."
                 ],
                 "os_disk_caching": "ReadWrite",
                 "os_type": "Linux",
                 "power_state": "running",
                 "resource_group": "...",
                 "state": "present",
                 "tags": {
                   ...
                 },
-                "vm_size": "..."
+                "vm_size": "...",
+                "zones": [
+                    "2"
+                ]
             }
         ]
     }
 }
```