### PR TITLE
Fix an issue identifying a creation/deletion error

### DIFF
--- a/plugins/modules/azure_rm_openshiftmanagedcluster.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster.py
@@ -757,8 +757,8 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                                               30)
         except CloudError as exc:
             self.log('Error attempting to create the OpenShiftManagedCluster instance.')
-            self.fail('Error creating the OpenShiftManagedCluster instance: {0}'.format(str(self.body)))
-            self.fail('Error creating the OpenShiftManagedCluster instance: {0}'.format(str(exc)))
+            self.fail('Error creating the OpenShiftManagedCluster instance: {0}'
+                      '\n{1}'.format(str(self.body), str(exc)))
         try:
             response = json.loads(response.text)
         except Exception:
@@ -780,7 +780,7 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                                               30)
         except CloudError as e:
             self.log('Error attempting to delete the OpenShiftManagedCluster instance.')
-            # self.fail('Error deleting the OpenShiftManagedCluster instance: {0}'.format(str(e)))
+            self.fail('Error deleting the OpenShiftManagedCluster instance: {0}'.format(str(e)))
 
         return True
 


### PR DESCRIPTION
##### SUMMARY

OpenShiftManagedCluster creation bails out at the first self.fail which shows the body but doesn't show the actual exception. Deletion doesn't even raise an error and passes through silently

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_openshiftmanagedcluster

##### ADDITIONAL INFORMATION

Before this change the only error you would see:

```
msg: |-                                                                         
Error creating the OpenShiftManagedCluster instance: {...post data...}
```

With this change it gets more helpful

```
msg: |-                                                                         
Error creating the OpenShiftManagedCluster instance: {...post data...}
Azure Error: InvalidParameter
Message: The provided pull secret is invalid.
Target: properties.clusterProfile.pullSecret 
```
