### PR TITLE
enable_floating_ip is for SQL AlwaysOn not SNAT

### DIFF
--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -206,7 +206,7 @@ options:
                     - This element is only used when the protocol is set to TCP.
             enable_floating_ip:
                 description:
-                    - Configures SNAT for the VMs in the backend pool to use the publicIP address specified in the frontend of the load balancing rule.
+                    - Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group.
     inbound_nat_rules:
         description:
             - Collection of inbound NAT Rules used by a load balancer.


### PR DESCRIPTION
##### SUMMARY
`enable_floating_ip` is documented in the module source as an SNAT setting however it is for SQL AlwaysOn. This text has ended up on `docs.ansible.com` and does not describe the behaviour of the setting.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer

##### ADDITIONAL INFORMATION
The `enable_floating_ip` setting is described here: https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.network.models.loadbalancingrule.enablefloatingip?view=azure-dotnet

However text from `DisableOutboundSnat` (an unsupported setting) has somehow made it into the description field for the module.

I'd like to add support for the Snat setting so correcting this doc entry before proceeding with that change.