### PR TITLE
Add bindep.txt file for ansible-builder

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+python38-packaging [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
Rather then installing packaging from pypi, we can use the distro
version for execution environment builds.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>