### PR TITLE
Add support for Azure AD with User Password

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1493,7 +1493,6 @@ class AzureRMAuth(object):
             tenant = self.credentials.get('tenant')
             if not tenant:
                 tenant = 'common'  # SDK default
-            
             graph_resource = self._cloud_environment.endpoints.active_directory_graph_resource_id
             rm_resource = self._cloud_environment.endpoints.resource_manager
             self.azure_credentials = UserPassCredentials(self.credentials['ad_user'],

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1493,11 +1493,14 @@ class AzureRMAuth(object):
             tenant = self.credentials.get('tenant')
             if not tenant:
                 tenant = 'common'  # SDK default
-
+            
+            graph_resource = self._cloud_environment.endpoints.active_directory_graph_resource_id
+            rm_resource = self._cloud_environment.endpoints.resource_manager
             self.azure_credentials = UserPassCredentials(self.credentials['ad_user'],
                                                          self.credentials['password'],
                                                          tenant=tenant,
                                                          cloud_environment=self._cloud_environment,
+                                                         resource=graph_resource if self.is_ad_resource else rm_resource,
                                                          verify=self._cert_validation_mode == 'validate')
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "


### PR DESCRIPTION

##### SUMMARY
I struggled with this for the better part of a half of a day, hopefully this can be pulled in to save someone the trouble I went through.

Issue is that when using a service principal azure AD operations will work as the auth flow is configured for that eventuality. When using username password, it is NOT. This fixes that issue. 

I would guess that a test should be written for this case so that it is dealt with in the future, but I am probably not the person to add a test to your setup.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
This is part of the module utils common auth.

##### ADDITIONAL INFORMATION
The, fairly unhelpful error that showed up BEFORE the change:
```
"msg": "failed to get ad group info Access Token missing or malformed."
```
After the patch things work as expected with username password auth.