### PR TITLE
Update azure_rm_manageddisk Doc to reflect return value

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -199,10 +199,8 @@ state:
         os_type:
             description:
                 - Type of Operating System.
-            choices:
-                - linux
-                - windows
             type: str
+            sample: linux
         disk_size_gb:
             description:
                 - Size in GB of the managed disk to be created.

--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -163,16 +163,59 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-id:
-    description:
-        - The managed disk resource ID.
-    returned: always
-    type: dict
 state:
     description:
         - Current state of the managed disk.
     returned: always
     type: dict
+    contains:
+        id:
+            description:
+                - Resource id.
+            type: str
+        name:
+            description:
+                - Name of the managed disk.
+            type: str
+        location:
+            description:
+                - Valid Azure location.
+            type: str
+        storage_account_type:
+            description:
+                - Type of storage for the managed disk.
+                - See U(https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types) for more information about this type.
+            type: str
+            sample: Standard_LRS
+        create_option:
+            description:
+                - Create option of the disk.
+            type: str
+            sample: copy
+        source_uri:
+            description:
+                - URI to a valid VHD file to be used or the resource ID of the managed disk to copy.
+            type: str
+        os_type:
+            description:
+                - Type of Operating System.
+            choices:
+                - linux
+                - windows
+            type: str
+        disk_size_gb:
+            description:
+                - Size in GB of the managed disk to be created.
+            type: str
+        managed_by:
+            description:
+                - Name of an existing virtual machine with which the disk is or will be associated, this VM should be in the same resource group.
+            type: str
+        tags:
+            description:
+                - Tags to assign to the managed disk.
+            type: dict
+            sample: { "tag": "value" }
 changed:
     description:
         - Whether or not the resource has changed.


### PR DESCRIPTION
##### SUMMARY

The azure_rm_manageddisk documentation for the module's return value is incorrect. This fixes the documentation to match reality.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- azure_rm_manageddisk

##### ADDITIONAL INFORMATION

The azure_rm_manageddisk documentation mentions a return dict of this shape:
```
{
 'id': diskid
 'state': disk_state
 'changed': true
}
```

However, the 'id' field is not present in the return value and must be fetched from the 'state' field. This PR removes 'id' as a field from the description, and adds a list of the fields present in 'state'.

The tests already reflect this, no update needed.
