### PR TITLE
Azure rm virtualmachineimage info latest

### DIFF
--- a/plugins/modules/azure_rm_virtualmachineimage_info.py
+++ b/plugins/modules/azure_rm_virtualmachineimage_info.py
@@ -177,15 +177,24 @@ class AzureRMVirtualMachineImageInfo(AzureRMModuleBase):
     def get_item(self):
         item = None
         result = []
+        versions = None
 
         try:
-            item = self.compute_client.virtual_machine_images.get(self.location,
+            versions = self.compute_client.virtual_machine_images.list(self.location,
                                                                   self.publisher,
                                                                   self.offer,
                                                                   self.sku,
-                                                                  self.version)
+                                                                  top=1,
+                                                                  orderby='name desc')
         except CloudError:
             pass
+
+        if self.version == 'latest':
+            item = versions[-1]
+        else:
+            for version in versions:
+                if version.name == self.version:
+                    item = version
 
         if item:
             result = [self.serialize_obj(item, 'VirtualMachineImage', enum_modules=AZURE_ENUM_MODULES)]

--- a/plugins/modules/azure_rm_virtualmachineimage_info.py
+++ b/plugins/modules/azure_rm_virtualmachineimage_info.py
@@ -181,11 +181,11 @@ class AzureRMVirtualMachineImageInfo(AzureRMModuleBase):
 
         try:
             versions = self.compute_client.virtual_machine_images.list(self.location,
-                                                                  self.publisher,
-                                                                  self.offer,
-                                                                  self.sku,
-                                                                  top=1,
-                                                                  orderby='name desc')
+                                                                       self.publisher,
+                                                                       self.offer,
+                                                                       self.sku,
+                                                                       top=1,
+                                                                       orderby='name desc')
         except CloudError:
             pass
 

--- a/tests/integration/targets/azure_rm_virtualmachineimage_info/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachineimage_info/tasks/main.yml
@@ -41,3 +41,15 @@
 
 - assert:
       that: output['vmimages'] | length > 0
+
+- name: Get facts for a specific image's latest version
+  azure_rm_virtualmachineimage_info:
+    location: "{{ location }}"
+    publisher: OpenLogic
+    offer: CentOS
+    sku: '7.5'
+    version: 'latest'
+  register: output
+
+- assert:
+      that: output['vmimages'] | length == 1


### PR DESCRIPTION
##### SUMMARY

Add support of `version: latest` in `azure_rm_virtualmachineimage_info`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- azure_rm_virtualmachineimage_info

##### ADDITIONAL INFORMATION

Add support to get information about the latest version of a virtualmachine image, as below:

```yaml
    - name: Get facts for a specific image's latest version
      azure_rm_virtualmachineimage_info:
        location: "{{ location }}"
        publisher: OpenLogic
        offer: CentOS
        sku: '7.5'
        version: 'latest'
      register: output
```

A new test case has been added to validate, and ran successfully locally.

Cheers!