### PR TITLE
Fix os_type comparison in azure_rm_manageddisk with existing disk

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -442,7 +442,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             if not found_disk['disk_size_gb'] == new_disk['disk_size_gb']:
                 resp = True
         if new_disk.get('os_type'):
-            if not found_disk['os_type'] == new_disk['os_type']:
+            if not self.compute_models.OperatingSystemTypes(found_disk['os_type'].capitalize()) == new_disk['os_type']:
                 resp = True
         if new_disk.get('sku'):
             if not found_disk['storage_account_type'] == new_disk['sku'].name:

--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -438,7 +438,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             if not found_disk['disk_size_gb'] == new_disk['disk_size_gb']:
                 resp = True
         if new_disk.get('os_type'):
-            if not self.compute_models.OperatingSystemTypes(found_disk['os_type'].capitalize()) == new_disk['os_type']:
+            if found_disk['os_type'] is None or not self.compute_models.OperatingSystemTypes(found_disk['os_type'].capitalize()) == new_disk['os_type']:
                 resp = True
         if new_disk.get('sku'):
             if not found_disk['storage_account_type'] == new_disk['sku'].name:

--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -413,11 +413,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             creation_data['create_option'] = self.compute_models.DiskCreateOption.copy
             creation_data['source_resource_id'] = self.source_uri
         if self.os_type:
-            typecon = {
-                'linux': self.compute_models.OperatingSystemTypes.linux,
-                'windows': self.compute_models.OperatingSystemTypes.windows
-            }
-            disk_params['os_type'] = typecon[self.os_type]
+            disk_params['os_type'] = self.compute_models.OperatingSystemTypes(self.os_type.capitalize())
         else:
             disk_params['os_type'] = None
         disk_params['creation_data'] = creation_data


### PR DESCRIPTION
##### SUMMARY

Fix os_type comparison in azure_rm_manageddisk always returning true.

The current comparison was happening between a string (eg `linux`) and a OperatingSystemTypes variable (eg `OperatingSystemTypes.linux`), always returning `True`.
This impacts the value of the `changed` variable, signaling a change when none was done.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- azure_rm_manageddisk