### PR TITLE
azure_rm_virtualmachine: suppress no_log warning on ssh_password_enabled parameter

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -838,7 +838,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             max_price=dict(type='float', default=-1),
             admin_username=dict(type='str'),
             admin_password=dict(type='str', no_log=True),
-            ssh_password_enabled=dict(type='bool', default=True),
+            ssh_password_enabled=dict(type='bool', default=True, no_log=False),
             ssh_public_keys=dict(type='list'),
             image=dict(type='raw'),
             availability_set=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY

azure_rm_virtualmachine is issuing a warning about ssh_password_enabled not being set to `no_log=true`. This patch explicitly sets no_log to `false` for this benign parameter.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- azure_rm_virtualmachine
- 
##### ADDITIONAL INFORMATION

The warning being displayed by the module prior to this patch:

```
[WARNING]: Module did not set no_log for ssh_password_enabled
```

`ssh_password_enabled` is only a boolean and does not contain secret information or credentials. Ansible's heuristics are assuming wrong.