### PR TITLE
azure_rm_sqldatabase: parse datetime module arguments

### DIFF
--- a/plugins/modules/azure_rm_sqldatabase.py
+++ b/plugins/modules/azure_rm_sqldatabase.py
@@ -224,9 +224,9 @@ status:
 
 import time
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
-import dateutil.parser
 
 try:
+    import dateutil.parser
     from msrestazure.azure_exceptions import CloudError
     from msrest.polling import LROPoller
     from azure.mgmt.sql import SqlManagementClient

--- a/plugins/modules/azure_rm_sqldatabase.py
+++ b/plugins/modules/azure_rm_sqldatabase.py
@@ -224,6 +224,7 @@ status:
 
 import time
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
+import dateutil.parser
 
 try:
     from msrestazure.azure_exceptions import CloudError
@@ -308,10 +309,10 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
                 type='str'
             ),
             source_database_deletion_date=dict(
-                type='datetime'
+                type='str'
             ),
             restore_point_in_time=dict(
-                type='datetime'
+                type='str'
             ),
             recovery_services_recovery_point_resource_id=dict(
                 type='str'
@@ -393,9 +394,15 @@ class AzureRMSqlDatabase(AzureRMModuleBase):
                 elif key == "source_database_id":
                     self.parameters["source_database_id"] = kwargs[key]
                 elif key == "source_database_deletion_date":
-                    self.parameters["source_database_deletion_date"] = kwargs[key]
+                    try:
+                        self.parameters["source_database_deletion_date"] = dateutil.parser.parse(kwargs[key])
+                    except dateutil.parser._parser.ParserError:
+                        self.fail("Error parsing date from source_database_deletion_date: {0}".format(kwargs[key]))
                 elif key == "restore_point_in_time":
-                    self.parameters["restore_point_in_time"] = kwargs[key]
+                    try:
+                        self.parameters["restore_point_in_time"] = dateutil.parser.parse(kwargs[key])
+                    except dateutil.parser._parser.ParserError:
+                        self.fail("Error parsing date from restore_point_in_time: {0}".format(kwargs[key]))
                 elif key == "recovery_services_recovery_point_resource_id":
                     self.parameters["recovery_services_recovery_point_resource_id"] = kwargs[key]
                 elif key == "edition":

--- a/plugins/modules/azure_rm_sqldatabase_info.py
+++ b/plugins/modules/azure_rm_sqldatabase_info.py
@@ -141,6 +141,12 @@ databases:
             returned: always
             type: bool
             sample: true
+        earliest_restore_date:
+            description:
+                - The earliest restore point available for the SQL Database.
+            returned: always
+            type: str
+            sample: '2021-09-01T00:59:59.000Z'
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
@@ -270,7 +276,8 @@ class AzureRMSqlDatabaseInfo(AzureRMModuleBase):
             'kind': d.get('kind', None),
             'collation': d.get('collation', None),
             'status': d.get('status', None),
-            'zone_redundant': d.get('zone_redundant', None)
+            'zone_redundant': d.get('zone_redundant', None),
+            'earliest_restore_date': d.get('earliest_restore_date', None)
         }
         return d
 

--- a/tests/integration/targets/azure_rm_sqlserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_sqlserver/tasks/main.yml
@@ -143,6 +143,48 @@
       - output.changed == false
       - output.status == 'Online'
 
+# test database point in time restore
+- name: Gather facts SQL Database and wait for restore point
+  azure_rm_sqldatabase_info:
+    resource_group: "{{ resource_group }}"
+    server_name: sqlsrv{{ random_postfix }}
+    name: database{{ random_postfix }}
+  register: output
+  until: output.databases[0].earliest_restore_date != None
+  retries: 10
+  delay: 20
+- name: Assert that it can be restored from
+  assert:
+    that:
+      - output.databases[0].id != None
+      - output.databases[0].earliest_restore_date != None
+
+- name: Create second SQL Database, restoring from the previous Database
+  azure_rm_sqldatabase:
+    resource_group: "{{ resource_group }}"
+    create_mode: point_in_time_restore
+    restore_point_in_time: "{{ output.databases[0].earliest_restore_date }}"
+    source_database_id: "{{ output.databases[0].id }}"
+    server_name: sqlsrv{{ random_postfix }}
+    name: database{{ random_postfix }}PITR
+  register: output
+- name: Assert the state has changed
+  assert:
+    that:
+      - output.changed
+
+- name: Delete instance of SQL Database Point in time recovery
+  azure_rm_sqldatabase:
+    resource_group: "{{ resource_group }}"
+    server_name: sqlsrv{{ random_postfix }}
+    name: database{{ random_postfix }}PITR
+    state: absent
+  register: output
+- name: Assert the state has changed
+  assert:
+    that:
+      - output.changed
+
 # test database facter:
 - name: Create second SQL Database
   azure_rm_sqldatabase:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -270,7 +270,6 @@ plugins/modules/azure_rm_servicebussaspolicy.py validate-modules:doc-required-mi
 plugins/modules/azure_rm_snapshot.py validate-modules:doc-required-mismatch
 plugins/modules/azure_rm_snapshot.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_sqldatabase.py validate-modules:parameter-type-not-in-doc
-plugins/modules/azure_rm_sqldatabase.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_sqldatabase_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_sqldatabase_info.py validate-modules:parameter-list-no-elements
 plugins/modules/azure_rm_sqlfirewallrule.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -271,7 +271,6 @@ plugins/modules/azure_rm_servicebussaspolicy.py validate-modules:doc-required-mi
 plugins/modules/azure_rm_snapshot.py validate-modules:doc-required-mismatch
 plugins/modules/azure_rm_snapshot.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_sqldatabase.py validate-modules:parameter-type-not-in-doc
-plugins/modules/azure_rm_sqldatabase.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_sqldatabase_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_sqldatabase_info.py validate-modules:parameter-list-no-elements
 plugins/modules/azure_rm_sqlfirewallrule.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -273,7 +273,6 @@ plugins/modules/azure_rm_servicebussaspolicy.py validate-modules:doc-required-mi
 plugins/modules/azure_rm_snapshot.py validate-modules:doc-required-mismatch
 plugins/modules/azure_rm_snapshot.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_sqldatabase.py validate-modules:parameter-type-not-in-doc
-plugins/modules/azure_rm_sqldatabase.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/azure_rm_sqldatabase_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/azure_rm_sqldatabase_info.py validate-modules:parameter-list-no-elements
 plugins/modules/azure_rm_sqlfirewallrule.py validate-modules:parameter-type-not-in-doc

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -18,6 +18,7 @@ else
     sudo apt install software-properties-common
     sudo add-apt-repository ppa:deadsnakes/ppa
     sudo apt install python"$2" -y
+    sudo apt install python3-dateutil
     sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python"$2" 1
 fi
 


### PR DESCRIPTION
##### SUMMARY

In `azure_rm_sqldatabase`, the arguments `restore_point_in_time` and `source_database_deletion_date` are dates.
This bugfix parses the string passed as argument, and creates the datetime object required.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- azure_rm_sqldatabase

##### ADDITIONAL INFORMATION

Currently the module expects `datetime` objtects to be passed directly as module arguments from the playbook. However, it appears that `argument_spec` does not handle `datetime` as an input type: https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec

To correct this, this fix changed the type of `restore_point_in_time` and `source_database_deletion_date` to `str`, and calls dateutil.parse on the string to get the datetime object expected by the azure sdk.

This fixes https://github.com/ansible-collections/azure/issues/619
