### PR TITLE
Fix azure_rm_manageddisk caching comparison

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -481,7 +481,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             correspondence = next((d for d in vm.storage_profile.data_disks if d.name.lower() == disk.get('name').lower()), None)
             if correspondence and correspondence.caching.name != self.attach_caching:
                 resp = True
-                if correspondence.caching.name == 'none' and self.attach_caching == '':
+                if correspondence.caching.name == 'none' and (self.attach_caching == '' or self.attach_caching is None):
                     resp = False
         return resp
 


### PR DESCRIPTION
##### SUMMARY

Fix faulty comparison in is_attach_caching_option_different which returned True when caching was "None", and caused disks to be detached / reattached by mistake.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- azure_rm_manageddisk

##### ADDITIONAL INFORMATION

The following code displays the issue. It runs the same action twice, but the result will show as "changed" for both.
This is because the `attach_caching` is None, but the comparison in the module is incorrect, leading the module to believe it needs to update the caching parameter.
As a result, the disk gets detached from the VM and reattached, which could have unexpected consequences and possibly lead to issues.

```yaml
    - name: Create data disk and attach to "testvm" virtualmachine
      azure.azcollection.azure_rm_manageddisk:
        resource_group: "{{ resource_group }}"
        name: 'testvm-data'
        location: eastus
        disk_size_gb: 64
        managed_by: testvm
        storage_account_type: Standard_LRS

    - name: Same action again
      azure.azcollection.azure_rm_manageddisk:
        resource_group: "{{ resource_group }}"
        name: 'testvm-data'
        location: eastus
        disk_size_gb: 64
        managed_by: testvm
        storage_account_type: Standard_LRS
```

The proposed patch fixes it, and the second run shows as unchanged, respecting indempotency.

Cheers!