### PR TITLE
Remove version 5.6, Update to version 5.7

### DIFF
--- a/plugins/modules/azure_rm_mysqlserver.py
+++ b/plugins/modules/azure_rm_mysqlserver.py
@@ -87,7 +87,6 @@ options:
             - Server version.
         type: str
         choices:
-            - 5.6
             - 5.7
             - 8.0
     enforce_ssl:
@@ -142,7 +141,7 @@ EXAMPLES = '''
         geo_redundant_backup: Disabled
         storage_autogrow: Disabled
       enforce_ssl: True
-      version: 5.6
+      version: 5.7
       admin_username: cloudsa
       admin_password: password
 '''
@@ -159,7 +158,7 @@ version:
         - Server version. Possible values include C(5.6), C(5.7), C(8.0).
     returned: always
     type: str
-    sample: 5.6
+    sample: 5.7
 state:
     description:
         - A state of a server that is visible to user. Possible values include C(Ready), C(Dropping), C(Disabled).
@@ -233,7 +232,7 @@ class AzureRMMySqlServers(AzureRMModuleBase):
             ),
             version=dict(
                 type='str',
-                choices=['5.6', '5.7', '8.0']
+                choices=['5.7', '8.0']
             ),
             enforce_ssl=dict(
                 type='bool',

--- a/tests/integration/targets/azure_rm_mysqlserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlserver/tasks/main.yml
@@ -16,7 +16,7 @@
       backup_retention_days: 7
       geo_redundant_backup: Disabled
       storage_autogrow: Disabled
-    version: 5.6
+    version: 5.7
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Password123!
@@ -40,7 +40,7 @@
       backup_retention_days: 7
       geo_redundant_backup: Disabled
       storage_autogrow: Disabled
-    version: 5.6
+    version: 5.7
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Password123!
@@ -64,7 +64,7 @@
       backup_retention_days: 7
       geo_redundant_backup: Disabled
       storage_autogrow: Disabled
-    version: 5.6
+    version: 5.7
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Password123!
@@ -88,7 +88,7 @@
       backup_retention_days: 7
       geo_redundant_backup: Disabled
       storage_autogrow: Disabled
-    version: 5.6
+    version: 5.7
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Password123!
@@ -124,7 +124,7 @@
       backup_retention_days: 7
       geo_redundant_backup: Disabled
       storage_autogrow: Disabled
-    version: 5.6
+    version: 5.7
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Password123!
@@ -144,7 +144,7 @@
       backup_retention_days: 7
       geo_redundant_backup: Disabled
       storage_autogrow: Disabled
-    version: 5.6
+    version: 5.7
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Password123!


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove version 5.6, Update to version 5.7. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
MySQL v5.6 is retired on Single Server as of Febuary 2021. Starting from September 1st 2021, you will not be able to create new v5.6 servers on Azure Database for MySQL - Single Server deployment option. However, you will be able to perform point-in-time recoveries and create read replicas for your existing servers
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
