### PR TITLE
azure_rm_availabilityset:  fix checkmode support

### DIFF
--- a/plugins/modules/azure_rm_availabilityset.py
+++ b/plugins/modules/azure_rm_availabilityset.py
@@ -286,6 +286,7 @@ class AzureRMAvailabilitySet(AzureRMModuleBase):
                     self.faildeploy('sku')
 
             if self.check_mode:
+                self.results['changed'] = to_be_updated
                 return self.results
 
             if to_be_updated:

--- a/plugins/modules/azure_rm_availabilityset.py
+++ b/plugins/modules/azure_rm_availabilityset.py
@@ -294,8 +294,11 @@ class AzureRMAvailabilitySet(AzureRMModuleBase):
                 self.results['changed'] = True
 
         elif self.state == 'absent':
-            self.delete_availabilityset()
-            self.results['changed'] = True
+            response = self.get_availabilityset()
+            if response:
+                if not self.check_mode:
+                    self.delete_availabilityset()
+                self.results['changed'] = True
 
         return self.results
 

--- a/tests/integration/targets/azure_rm_availabilityset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_availabilityset/tasks/main.yml
@@ -1,3 +1,15 @@
+- name: Create an availability set with default options - Check Mode
+  azure_rm_availabilityset:
+    name: myavailabilityset1
+    resource_group: "{{ resource_group }}"
+    tags:
+      tag1: testtag
+  register: results
+  check_mode: yes
+
+- assert:
+    that: results.changed
+
 - name: Create an availability set with default options
   azure_rm_availabilityset:
     name: myavailabilityset1
@@ -113,7 +125,7 @@
 
 - assert:
     that: 
-      - not results.changed
+      - results.changed
       - results.state.tags.checktest1 == 'modified1'
 
 #

--- a/tests/integration/targets/azure_rm_availabilityset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_availabilityset/tasks/main.yml
@@ -146,12 +146,33 @@
       - results.ansible_info.azure_availabilitysets[0].sku == 'Aligned'
       - results.ansible_info.azure_availabilitysets[0].properties.proximityPlacementGroup.id.split('/')[-1] == ppgroup_name
 
+- name: Delete an availability set - Check Mode
+  azure_rm_availabilityset:
+    name: myavailabilityset1
+    resource_group: "{{ resource_group }}"
+    state: absent
+  check_mode: yes
+  register: results
+- assert:
+    that:
+      - results.changed
 
 - name: Delete an availability set
   azure_rm_availabilityset:
     name: myavailabilityset1
     resource_group: "{{ resource_group }}"
     state: absent
+
+- name: Delete an availability set already deleted - Check Mode
+  azure_rm_availabilityset:
+    name: myavailabilityset1
+    resource_group: "{{ resource_group }}"
+    state: absent
+  check_mode: yes
+  register: results
+- assert:
+    that:
+      - not results.changed
 
 - name: Delete an availability set
   azure_rm_availabilityset:


### PR DESCRIPTION
##### SUMMARY

- Fix "changed" status in check_mode when creating / updating resource (changed used to always return "false", now it returns true if resources need to be created / updated).
- Fix check_mode for `state: absent`: currently it does NOT respect check_mode if state is `absent`. As a result, the resource will get deleted even in check_mode.
- Fix `state: absent` always returning `changed: true` even if no resource was deleted.

Several new integration tests have been added to validate these cases.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- azure_rm_availabilityset