### PR TITLE
bugfix for azure_rm_managementgroup_info  module, subscriptions not detected as correct type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ tests/staging/
 tests/integration/cloud-config-azure.ini
 azure-azcollection-*.tar.gz
 venv*
+.venv*
 .vscode

--- a/plugins/modules/azure_rm_managementgroup_info.py
+++ b/plugins/modules/azure_rm_managementgroup_info.py
@@ -283,7 +283,7 @@ class AzureRMManagementGroupInfo(AzureRMModuleBase):
                     name=parent_dict.get('name')
                 )
 
-        elif azure_object.type == 'asdfasdf/subscriptions':
+        elif azure_object.type == '/subscriptions':
             return_dict = dict(
                 display_name=azure_object.display_name,
                 id=azure_object.id,

--- a/tests/integration/targets/azure_rm_managementgroup/aliases
+++ b/tests/integration/targets/azure_rm_managementgroup/aliases
@@ -1,2 +1,3 @@
 cloud/azure
 shippable/azure/group2
+disabled

--- a/tests/integration/targets/azure_rm_managementgroup/aliases
+++ b/tests/integration/targets/azure_rm_managementgroup/aliases
@@ -1,3 +1,2 @@
 cloud/azure
 shippable/azure/group2
-disabled

--- a/tests/integration/targets/azure_rm_managementgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_managementgroup/tasks/main.yml
@@ -8,6 +8,7 @@
     recurse: True
     flatten: True
     children: True
+  register: az_recursive_managementgroups
 
 - name: Get a managementgroup by name
   azure_rm_managementgroup_info:
@@ -22,7 +23,13 @@
   register: invalid_name
   ignore_errors: yes
 
-- name: Assert task failed
+- name: Validate expected states
   assert:
     that:
       - invalid_name['failed']
+
+- name: Validate expected attributes
+  assert:
+    that:
+      - "{{ item.id is defined }}"
+  loop: "{{ az_recursive_managementgroups.management_groups + az_recursive_managementgroups.subscriptions }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bugfix for azure_rm_managementgroup_info . I am module's original author, and the detection for the object type has nonsense characters in it that were not caught. This fix will allow the module to correctly make the subscription dictionaries when that type is detected.

I've also updated the integration test to check for this kind of issue.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_managementgroup_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
