### PR TITLE
Fix azure_rm_securitygroup doc

### DIFF
--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -83,6 +83,7 @@ options:
                     - Default tags such as C(VirtualNetwork), C(AzureLoadBalancer) and C(Internet) can also be used.
                     - If this is an ingress rule, specifies where network traffic originates from.
                     - It can accept string type or a list of string type.
+                    - Asterisk C(*) and default tags can only be specified as single string type, not as a list of string.
                 default: "*"
             destination_address_prefix:
                 description:
@@ -91,6 +92,7 @@ options:
                     - Asterisk C(*) can also be used to match all source IPs.
                     - Default tags such as C(VirtualNetwork), C(AzureLoadBalancer) and C(Internet) can also be used.
                     - It can accept string type or a list of string type.
+                    - Asterisk C(*) and default tags can only be specified as single string type, not as a list of string.
                 default: "*"
             source_application_security_groups:
                 description:


### PR DESCRIPTION
##### SUMMARY

Clarify documentation for source/destination prefix for NSG rules

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- azure_rm_securitygroup

##### ADDITIONAL INFORMATION

NSG rules parameters `destination_address_prefix` and `source_address_prefix` only accept default tags (`*`, `Internet`, etc) as strings, not as elements of a list. This appears to be by design as only one default tag prefix can be specified.

This documentation update reflects this restriction, raised in #639