### PR TITLE
Fix manageddisk unmount documentation

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -152,6 +152,7 @@ EXAMPLES = '''
         name: mymanageddisk
         location: eastus
         resource_group: myResourceGroup
+        managed_by: ''
         disk_size_gb: 4
 
     - name: Delete managed disk


### PR DESCRIPTION
##### SUMMARY

Fix manageddisk unmount documentation.
To unmount a disk, `managed_by` needs to be set to `''`. Simply not setting `managed_by` does not accomplish the desired effect of unmounting.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

azure_rm_manageddisk