### PR TITLE
Add managed disk ID to returned facts for data disks for azure_rm_virtualmachine_info

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -136,6 +136,12 @@ vms:
                     returned: always
                     type: str
                     sample: Standard_LRS
+                managed_disk_id:
+                    description:
+                        - Managed data disk ID.
+                    returned: always
+                    type: str
+                    sample: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/Microsoft.Compute/disks/diskName
         id:
             description:
                 - Resource ID.
@@ -439,6 +445,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
                 'name': disks[disk_index].get('name'),
                 'disk_size_gb': disks[disk_index].get('diskSizeGB'),
                 'managed_disk_type': disks[disk_index].get('managedDisk', {}).get('storageAccountType'),
+                'managed_disk_id': disks[disk_index].get('managedDisk', {}).get('id'),
                 'caching': disks[disk_index].get('caching')
             })
 


### PR DESCRIPTION
##### SUMMARY

As mentionned in https://github.com/ansible-collections/azure/issues/679#issuecomment-965888562, azure_rm_virtualmachine_info does not give the disk ID for attached disks.
This PR adds the disk ID to the data_disk list returned by `azure_rm_virtualmachine_info`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine_info