### PR TITLE
Add managed disks list to dynamic inventory hostvars

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -595,11 +595,18 @@ class AzureHost(object):
             osDisk = storageProfile.get('osDisk')
             new_hostvars['os_disk'] = dict(
                 name=osDisk.get('name'),
-                operating_system_type=osDisk.get('osType').lower() if osDisk.get('osType') else None
+                operating_system_type=osDisk.get('osType').lower() if osDisk.get('osType') else None,
+                id=osDisk.get('managedDisk', {}).get('id')
             )
+            new_hostvars['data_disks'] = [
+                dict(
+                    name=dataDisk.get('name'),
+                    lun=dataDisk.get('lun'),
+                    id=dataDisk.get('managedDisk', {}).get('id')
+                ) for dataDisk in storageProfile.get('dataDisks', [])
+            ]
 
         self._hostvars = new_hostvars
-
         return self._hostvars
 
     def _on_instanceview_response(self, vm_instanceview_model):

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -576,6 +576,7 @@ class AzureHost(object):
         # set image and os_disk
         new_hostvars['image'] = {}
         new_hostvars['os_disk'] = {}
+        new_hostvars['data_disks'] = []
         storageProfile = self._vm_model['properties'].get('storageProfile')
         if storageProfile:
             imageReference = storageProfile.get('imageReference')


### PR DESCRIPTION
##### SUMMARY

Address https://github.com/ansible-collections/azure/issues/678 by adding managed disks list to dynamic inventory facts

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- azure_rm (dynamic inventory)

##### ADDITIONAL INFORMATION

Add a new `data_disks` field in the inventory hostvars, listing the attached disks with their LUN, name, and azure ID.
This also adds the disk ID for the OS disk.

```paste below
          data_disks:
          - id: /subscriptions/XXXXXX/resourceGroups/myRG-eastus2/providers/Microsoft.Compute/disks/nbr23vm-data1
            lun: 0
            name: nbr23vm-data1
```