### PR TITLE
Correct idempotency for `azure_rm_appserviceplan` and premium SKU plans

### DIFF
--- a/plugins/modules/azure_rm_appserviceplan.py
+++ b/plugins/modules/azure_rm_appserviceplan.py
@@ -265,7 +265,7 @@ class AzureRMAppServicePlans(AzureRMModuleBase):
                     self.tags = newtags
 
                 # check if sku changed
-                if self.sku and _normalize_sku(self.sku) != old_response['sku']['size']:
+                if self.sku and _normalize_sku(self.sku) != _normalize_sku(old_response['sku']['size']):
                     to_be_updated = True
 
                 # check if number_of_workers changed

--- a/tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml
@@ -1,8 +1,14 @@
 - name: Prepare facts
   set_fact:
+    resource_prefix: "{{ resource_group_secondary | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+  run_once: yes
+
+- name: Prepare facts
+  set_fact:
     linux_plan_resource_group: "{{ resource_group_secondary }}"
     win_plan_name: "{{ (resource_prefix | replace('-','x'))[-8:] }}winplan"
     linux_plan_name: "{{ (resource_prefix | replace('-','x'))[-8:] }}linplan"
+  run_once: yes
 
 - name: create a windows plan
   azure_rm_appserviceplan:
@@ -13,7 +19,7 @@
 
 - name: assert app service was created
   assert:
-    that: 
+    that:
       - output.changed
       - output.id
 
@@ -28,7 +34,7 @@
 
 - name: assert app service was created
   assert:
-    that: 
+    that:
       - output.changed
       - output.id
 
@@ -53,7 +59,7 @@
     number_of_workers: 1
   register: output
 
-- name: assert app service was created
+- name: assert app service is not updated
   assert:
     that: not output.changed
 
@@ -82,3 +88,29 @@
   assert:
     that:
       - output.changed
+
+- name: create premium linux plan
+  azure_rm_appserviceplan:
+    resource_group: "{{ linux_plan_resource_group }}"
+    name: "{{ linux_plan_name }}-premium"
+    sku: P1v2
+    is_linux: true
+  register: output
+
+- name: assert app service was created
+  assert:
+    that:
+      - output.changed
+      - output.id
+
+- name: create premium linux plan idempotent
+  azure_rm_appserviceplan:
+    resource_group: "{{ linux_plan_resource_group }}"
+    name: "{{ linux_plan_name }}-premium"
+    sku: P1v2
+    is_linux: true
+  register: output
+
+- name: assert app service is not updated
+  assert:
+    that: not output.changed


### PR DESCRIPTION
##### SUMMARY
This PR corrects idempotency for `azure_rm_appserviceplan` with premium SKU plans.

Fixes https://github.com/ansible-collections/azure/issues/692.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_appserviceplan

##### ADDITIONAL INFORMATION

I have corrected and added a test to verify. The tests can be ran as follows:

```yaml
---
- name: "Playbook for testing."
  hosts: "localhost"
  connection: "local"
  gather_facts: false
  vars:
    resource_group: "automated-testing"
    resource_group_secondary: "automated-testing-secondary"
  collections:
    - azure.azcollection

  tasks:
    - name: "Include tests"
      include_tasks: "tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml"
```
