### PR TITLE
Allow module-level subscription id to be used for cross-subscription resource management

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -886,6 +886,10 @@ class AzureRMModuleBase(object):
             # most things are resource_manager, don't make everyone specify
             base_url = self.azure_auth._cloud_environment.endpoints.resource_manager
 
+        mgmt_subscription_id = self.azure_auth.subscription_id
+        if self.module.params.get('subscription_id'):
+            mgmt_subscription_id = self.module.params.get('subscription_id')
+
         # Some management clients do not take a subscription ID as parameters.
         if suppress_subscription_id:
             if is_track2:
@@ -894,9 +898,9 @@ class AzureRMModuleBase(object):
                 client_kwargs = dict(credentials=self.azure_auth.azure_credentials, base_url=base_url)
         else:
             if is_track2:
-                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, subscription_id=self.azure_auth.subscription_id, base_url=base_url)
+                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, subscription_id=mgmt_subscription_id, base_url=base_url)
             else:
-                client_kwargs = dict(credentials=self.azure_auth.azure_credentials, subscription_id=self.azure_auth.subscription_id, base_url=base_url)
+                client_kwargs = dict(credentials=self.azure_auth.azure_credentials, subscription_id=mgmt_subscription_id, base_url=base_url)
 
         api_profile_dict = {}
 


### PR DESCRIPTION
##### SUMMARY

This change allows the module defined parameter of `subscription_id` to be used for management clients (e.g. when retrieving resources). It does NOT change how authentication to Azure operates.

This is helpful when using a credentials file for authentication. The credentials file uses subscription A (authentication), but a playbook needs to retrieve resources which are in subscription B. Adding support for using the module-provided `subscription_id` parameter allows for playbooks to operate under a single set of credentials but supports cross-subscription resource loading (providing the credentials have access to other subscription).

Example:

Credentials file:
```
[default]
subscription_id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
client_id=xxx
tenant=xxx
secret=xxx
```

At runtime, a playbook wants to use resources in a different subscription:
```yaml
- name: "Get container registry detail in different subscription"
  azure.azcollection.azure_rm_containerregistry_info:
    name: "my-container-registry"
    resource_group: "my-resource-group"
    retrieve_credentials: true
    subscription_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
```

Before this change, registries for subscription A would be retrieved instead of those in subscription B.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Any/all.

##### ADDITIONAL INFORMATION

I am unsure if it's possible to add test coverage for this, but I am using in our environment successfully. The use case is we have a container registry in one subscription which holds all our Docker images. We deploy webapps using the Docker images to multiple subscriptions and need Ansible to support cross-subscription resource loading.
