### PR TITLE
Add additional parameters for webapp site config

### DIFF
--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -699,7 +699,6 @@ class AzureRMWebApps(AzureRMModuleBase):
             if self.https_only is not None:
                 self.site.https_only = self.https_only
 
-            if self.client_affinity_enabled is not None:
                 self.site.client_affinity_enabled = self.client_affinity_enabled
 
             # check if the web app already present in the resource group

--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -699,7 +699,7 @@ class AzureRMWebApps(AzureRMModuleBase):
             if self.https_only is not None:
                 self.site.https_only = self.https_only
 
-                self.site.client_affinity_enabled = self.client_affinity_enabled
+            self.site.client_affinity_enabled = self.client_affinity_enabled
 
             # check if the web app already present in the resource group
             if not old_response:

--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -112,6 +112,29 @@ options:
             - Repository type of deployment source, for example C(LocalGit), C(GitHub).
             - List of supported values maintained at U(https://docs.microsoft.com/en-us/rest/api/appservice/webapps/createorupdate#scmtype).
 
+    always_on:
+        description:
+            - Keeps the app loaded even when there's no traffic.
+        type: bool
+
+    min_tls_version:
+        description:
+            - The minimum TLS encryption version required for the app.
+        type: str
+        choices:
+            - 1.0
+            - 1.1
+            - 1.2
+
+    ftps_state:
+        description:
+            - The state of the FTP/FTPS service.
+        type: str
+        choices:
+            - AllAllowed
+            - FtpsOnly
+            - Disabled
+
     deployment_source:
         description:
             - Deployment source for git.
@@ -446,6 +469,17 @@ class AzureRMWebApps(AzureRMModuleBase):
             scm_type=dict(
                 type='str',
             ),
+            always_on=dict(
+                type='bool',
+            ),
+            min_tls_version=dict(
+                type='str',
+                choices=['1.0', '1.1', '1.2'],
+            ),
+            ftps_state=dict(
+                type='str',
+                choices=['AllAllowed', 'FtpsOnly', 'Disabled'],
+            ),
             deployment_source=dict(
                 type='dict',
                 options=deployment_source_spec
@@ -537,7 +571,10 @@ class AzureRMWebApps(AzureRMModuleBase):
                                                  "java_version",
                                                  "php_version",
                                                  "python_version",
-                                                 "scm_type"]
+                                                 "scm_type",
+                                                 "always_on",
+                                                 "min_tls_version",
+                                                 "ftps_state"]
 
         # updatable_properties
         self.updatable_properties = ["client_affinity_enabled",
@@ -561,7 +598,7 @@ class AzureRMWebApps(AzureRMModuleBase):
             if hasattr(self, key):
                 setattr(self, key, kwargs[key])
             elif kwargs[key] is not None:
-                if key == "scm_type":
+                if key in ["scm_type", "always_on", "min_tls_version", "ftps_state"]:
                     self.site_config[key] = kwargs[key]
 
         old_response = None
@@ -662,7 +699,7 @@ class AzureRMWebApps(AzureRMModuleBase):
             if self.https_only is not None:
                 self.site.https_only = self.https_only
 
-            if self.client_affinity_enabled:
+            if self.client_affinity_enabled is not None:
                 self.site.client_affinity_enabled = self.client_affinity_enabled
 
             # check if the web app already present in the resource group
@@ -808,10 +845,10 @@ class AzureRMWebApps(AzureRMModuleBase):
 
     # compare xxx_version
     def is_site_config_changed(self, existing_config):
-        for fx_version in self.site_config_updatable_properties:
-            if self.site_config.get(fx_version):
-                if not getattr(existing_config, fx_version) or \
-                        getattr(existing_config, fx_version).upper() != self.site_config.get(fx_version).upper():
+        for updatable_property in self.site_config_updatable_properties:
+            if self.site_config.get(updatable_property):
+                if not getattr(existing_config, updatable_property) or \
+                        str(getattr(existing_config, updatable_property)).upper() != str(self.site_config.get(updatable_property)).upper():
                     return True
 
         return False

--- a/plugins/modules/azure_rm_webapp_info.py
+++ b/plugins/modules/azure_rm_webapp_info.py
@@ -128,6 +128,24 @@ webapps:
                         "version": "5.6"
                     }
                     ]
+        always_on:
+            description:
+                - If the app is kept loaded even when there's no traffic.
+            returned: always
+            type: bool
+            sample: true
+        min_tls_version:
+            description:
+                - The minimum TLS encryption version required for the app.
+            returned: always
+            type: str
+            sample: 1.2
+        ftps_state:
+            description:
+                - The state of the FTP/FTPS service.
+            returned: always
+            type: str
+            sample: FtpsOnly
         availability_state:
             description:
                 - Availability of this web app.
@@ -457,6 +475,10 @@ class AzureRMWebAppInfo(AzureRMModuleBase):
                 tmp = configuration.get('linux_fx_version').split("|")
                 if len(tmp) == 2:
                     curated_output['frameworks'].append({'name': tmp[0].lower(), 'version': tmp[1]})
+
+            curated_output['always_on'] = configuration.get('always_on')
+            curated_output['ftps_state'] = configuration.get('ftps_state')
+            curated_output['min_tls_version'] = configuration.get('min_tls_version')
 
         # curated app_settings
         if app_settings and app_settings.get('properties', None):

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -1,7 +1,13 @@
+- name: Prepare facts
+  set_fact:
+    resource_prefix: "{{ resource_group_secondary | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+  run_once: yes
+
 - name: Fix resource prefix
   set_fact:
     linux_app_plan_resource_group: "{{ resource_group_secondary }}"
     win_app_name: "{{ (resource_prefix | replace('-','x'))[-8:] }}{{ 1000 | random}}winapp"
+    linux_app_name: "{{ (resource_prefix | replace('-','x'))[-8:] }}{{ 1000 | random}}linuxapp"
     win_plan_name: "{{ (resource_prefix | replace('-','x'))[-8:] }}winplan"
     linux_plan_name: "{{ (resource_group_secondary | replace('-','x'))[-8:] }}linplan"
     slot1_name: "stage1"
@@ -343,6 +349,81 @@
   assert:
     that:
       - facts.webapps[0].ftp_publish_url != ''
+
+- name: Create a web app with various site config params
+  azure_rm_webapp:
+    resource_group: "{{ resource_group }}"
+    name: "{{ linux_app_name }}-siteconfig"
+    plan:
+      resource_group: "{{ linux_app_plan_resource_group }}"
+      name: "{{ linux_app_name }}-siteconfig-plan"
+      is_linux: true
+      sku: S1
+    frameworks:
+      - name: java
+        version: "8"
+        settings:
+          java_container: "tomcat"
+          java_container_version: "8.5"
+    client_affinity_enabled: false
+    https_only: true
+    always_on: true
+    min_tls_version: "1.2"
+    ftps_state: "Disabled"
+  register: output
+- name: Assert the web app was created
+  assert:
+    that: output.changed
+
+- name: Create a web app with various site config params - idempotent
+  azure_rm_webapp:
+    resource_group: "{{ resource_group }}"
+    name: "{{ linux_app_name }}-siteconfig"
+    plan:
+      resource_group: "{{ linux_app_plan_resource_group }}"
+      name: "{{ linux_app_name }}-siteconfig-plan"
+      is_linux: true
+      sku: S1
+    frameworks:
+      - name: java
+        version: "8"
+        settings:
+          java_container: "tomcat"
+          java_container_version: "8.5"
+    client_affinity_enabled: false
+    https_only: true
+    always_on: true
+    min_tls_version: "1.2"
+    ftps_state: "Disabled"
+  register: output
+- name: Assert the web app not changed
+  assert:
+    that: not output.changed
+
+- name: Update web app with various site config params - single change
+  azure_rm_webapp:
+    resource_group: "{{ resource_group }}"
+    name: "{{ linux_app_name }}-siteconfig"
+    plan:
+      resource_group: "{{ linux_app_plan_resource_group }}"
+      name: "{{ linux_app_name }}-siteconfig-plan"
+      is_linux: true
+      sku: S1
+    frameworks:
+      - name: java
+        version: "8"
+        settings:
+          java_container: "tomcat"
+          java_container_version: "8.5"
+    client_affinity_enabled: false
+    https_only: true
+    always_on: true
+    min_tls_version: "1.2"
+    ftps_state: "FtpsOnly"
+  register: output
+- name: Assert the web app was updated
+  assert:
+    that: output.changed
 
 - name: Create a webapp slot (Check mode)
   azure_rm_webappslot:

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -400,6 +400,18 @@
   assert:
     that: not output.changed
 
+- name: Get facts for site config params
+  azure_rm_webapp_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ linux_app_name }}-siteconfig"
+  register: facts
+- name: Assert site config params meet expectations
+  assert:
+    that:
+      - facts.webapps[0].always_on
+      - facts.webapps[0].min_tls_version == '1.2'
+      - facts.webapps[0].ftps_state == 'Disabled'
+
 - name: Update web app with various site config params - single change
   azure_rm_webapp:
     resource_group: "{{ resource_group }}"
@@ -424,6 +436,18 @@
 - name: Assert the web app was updated
   assert:
     that: output.changed
+
+- name: Get facts for site config params
+  azure_rm_webapp_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ linux_app_name }}-siteconfig"
+  register: facts
+- name: Assert site config params meet expectations
+  assert:
+    that:
+      - facts.webapps[0].always_on
+      - facts.webapps[0].min_tls_version == '1.2'
+      - facts.webapps[0].ftps_state == 'FtpsOnly'
 
 - name: Create a webapp slot (Check mode)
   azure_rm_webappslot:


### PR DESCRIPTION
##### SUMMARY
This PR updates the `azure_rm_webapp` module to support the following parameters:

* `always_on`: Keeps the app loaded even when there's no traffic.
* `min_tls_version`: The minimum TLS encryption version required for the app.
* `ftps_state`: The state of the FTP/FTPS service.

This PR also has a small change which fixes https://github.com/ansible-collections/azure/issues/421.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_webapp
azure_rm_webapp_info

##### ADDITIONAL INFORMATION

Please see updated test case for detail and validation.