### PR TITLE
Correct cosmosdb info module when loading by resource group

### DIFF
--- a/plugins/modules/azure_rm_cosmosdbaccount_info.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount_info.py
@@ -399,6 +399,8 @@ class AzureRMCosmosDBAccountInfo(AzureRMModuleBase):
         if self.name is not None:
             self.results['accounts'] = self.get()
         elif self.resource_group is not None:
+            self.results['accounts'] = self.list_by_resource_group()
+        else:
             self.results['accounts'] = self.list_all()
         return self.results
 

--- a/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Prepare random number
   set_fact:
-    dbname: "cosmos{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    dbname: "cosmos-{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    db2name: "cosmos2-{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
     vnname: "vn{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
     subnetname: "subnet{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
   run_once: yes
@@ -115,20 +116,45 @@
     that:
       - output.changed
 
+- name: Create second instance of Database Account
+  azure_rm_cosmosdbaccount:
+    resource_group: "{{ resource_group_secondary }}"
+    name: "{{ db2name }}"
+    location: eastus
+    kind: global_document_db
+    geo_rep_locations:
+      - name: eastus
+        failover_priority: 0
+      - name: eastus2
+        failover_priority: 1
+    database_account_offer_type: Standard
+    is_virtual_network_filter_enabled: yes
+    virtual_network_rules:
+      - subnet:
+          resource_group: "{{ resource_group }}"
+          virtual_network_name: "{{ vnname }}"
+          subnet_name: "{{ subnetname }}"
+        ignore_missing_vnet_service_endpoint: yes
+  register: output
+- name: Assert the resource instance is well created
+  assert:
+    that:
+      - output.changed
+
 - name: Get facts of single account
   azure_rm_cosmosdbaccount_info:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
   register: output
-
 - name: Assert that facts are returned
   assert:
     that:
       - output.changed == False
+      - output.accounts | length == 1
       - output.accounts[0]['id'] != None
-      - output.accounts[0]['resource_group'] != None
-      - output.accounts[0]['name'] != None
-      - output.accounts[0]['location'] != None
+      - output.accounts[0]['resource_group'] == resource_group
+      - output.accounts[0]['name'] == dbname
+      - output.accounts[0]['location'] == 'eastasia'
       - output.accounts[0]['kind'] != None
       - output.accounts[0]['consistency_policy'] != None
       - output.accounts[0]['failover_policies'] != None
@@ -153,7 +179,6 @@
     name: "{{ dbname }}"
     retrieve_keys: all
   register: output
-
 - name: Assert that facts are returned
   assert:
     that:
@@ -170,7 +195,6 @@
     retrieve_keys: readonly
     retrieve_connection_strings: yes
   register: output
-
 - name: Assert that facts are returned
   assert:
     that:
@@ -181,20 +205,19 @@
       - output.accounts[0]['secondary_readonly_master_key'] != None
       - output.accounts[0]['connection_strings'] | length > 0
 
-- name: List acounts by resource group
+- name: List accounts by resource group
   azure_rm_cosmosdbaccount_info:
     resource_group: "{{ resource_group }}"
-    name: "{{ dbname }}"
   register: output
-
 - name: Assert that facts are returned
   assert:
     that:
       - output.changed == False
+      - output.accounts | length == 1
       - output.accounts[0]['id'] != None
-      - output.accounts[0]['resource_group'] != None
-      - output.accounts[0]['name'] != None
-      - output.accounts[0]['location'] != None
+      - output.accounts[0]['resource_group'] == resource_group
+      - output.accounts[0]['name'] == dbname
+      - output.accounts[0]['location'] == 'eastasia'
       - output.accounts[0]['kind'] != None
       - output.accounts[0]['consistency_policy'] != None
       - output.accounts[0]['failover_policies'] != None
@@ -213,6 +236,17 @@
       - output.accounts[0]['provisioning_state'] != None
       - output.accounts[0]['tags'] != None
 
+- name: List all accounts
+  azure_rm_cosmosdbaccount_info:
+  register: output
+- name: Assert that facts are returned
+  assert:
+    that:
+      - output.changed == False
+      - output.accounts | length >= 2
+      - dbname in (output.accounts | map(attribute='name'))
+      - db2name in (output.accounts | map(attribute='name'))
+
 - name: Delete instance of Database Account -- check mode
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
@@ -229,6 +263,17 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
+    state: absent
+  register: output
+- name: Assert the state has changed
+  assert:
+    that:
+      - output.changed
+
+- name: Delete second instance of Database Account
+  azure_rm_cosmosdbaccount:
+    resource_group: "{{ resource_group_secondary }}"
+    name: "{{ db2name }}"
     state: absent
   register: output
 - name: Assert the state has changed


### PR DESCRIPTION
##### SUMMARY
This PR corrects the info module for cosmosdb to correctly filter by resource group.

Fixes https://github.com/ansible-collections/azure/issues/708

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_cosmosdbaccount_info

##### ADDITIONAL INFORMATION

The following playbook can be used to validate the test cases for the azure_rm_cosmosdbaccount_info module.

```paste below
---
- name: "Playbook for testing."
  hosts: "localhost"
  connection: "local"
  gather_facts: false
  vars:
    resource_group: "automated-testing"
    resource_group_secondary: "automated-testing-secondary"
  collections:
    - azure.azcollection

  tasks:
    - name: "Include tests"
      include_tasks: "tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml"
```
