### PR TITLE
Clarify doc for installing collection and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Documentation of individual modules is [available in the Ansible docs site](http
 
 ## Installation
 
-To install Azure dependencies:
-
-```bash
-pip install -r requirements-azure.txt
-```
-
 To install Azure collection hosted in Galaxy:
 
 ```bash
 ansible-galaxy collection install azure.azcollection
+```
+
+Install dependencies required by the collection (adjust path to collection if necessary):
+
+```bash
+pip install -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt
 ```
 
 To upgrade to the latest version of Azure collection:


### PR DESCRIPTION
##### SUMMARY
This PR clarifies the documentation for how the collection and its dependencies are installed. The collection should be installed first, and dependencies installed from the installed collection. See https://github.com/ansible-collections/azure/issues/715#issuecomment-1001807637 for detail.

Resolves https://github.com/ansible-collections/azure/issues/715.

##### ISSUE TYPE
- Docs Pull Request
