### PR TITLE
Align `azure_rm_securitygroup_info` return to match `azure_rm_securitygroup`

### DIFF
--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -388,7 +388,7 @@ state:
                     "source_address_prefix": "174.109.158.0/24",
                     "source_port_range": "*"
                 }
-                ]
+            ]
         subnets:
             description:
                 - A collection of references to subnets.

--- a/plugins/modules/azure_rm_securitygroup_info.py
+++ b/plugins/modules/azure_rm_securitygroup_info.py
@@ -84,125 +84,152 @@ securitygroups:
             returned: always
             type: str
             sample: "secgroup001"
-        properties:
+        default_rules:
             description:
-                - List of security group's properties.
+                - The default security rules of network security group.
             returned: always
-            type: dict
-            sample: {
-                    "defaultSecurityRules": [
-                      {
-                      "etag": 'W/"d036f4d7-d977-429a-a8c6-879bc2523399"',
-                      "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/secgroup001/defaultSecurityRules/AllowVnetInBound",
-                      "name": "AllowVnetInBound",
-                      "properties": {
+            type: list
+            sample: [
+                    {
                         "access": "Allow",
                         "description": "Allow inbound traffic from all VMs in VNET",
-                        "destinationAddressPrefix": "VirtualNetwork",
-                        "destinationPortRange": "*",
+                        "destination_address_prefix": "VirtualNetwork",
+                        "destination_port_range": "*",
                         "direction": "Inbound",
+                        "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/defaultSecurityRules/AllowVnetInBound",
+                        "name": "AllowVnetInBound",
                         "priority": 65000,
                         "protocol": "*",
-                        "provisioningState": "Succeeded",
-                        "sourceAddressPrefix": "VirtualNetwork",
-                        "sourcePortRange": "*"
-                                    }
-                         },
-                         {
-                         "etag": 'W/"d036f4d7-d977-429a-a8c6-879bc2523399"',
-                         "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/secgroup001/defaultSecurityRules/AllowAzureLoadBalancerInBound",
-                         "name": "AllowAzureLoadBalancerInBound",
-                         "properties": {
-                           "access": "Allow",
-                           "description": "Allow inbound traffic from azure load balancer",
-                           "destinationAddressPrefix": "*",
-                           "destinationPortRange": "*",
-                           "direction": "Inbound",
-                           "priority": 65001,
-                           "protocol": "*",
-                           "provisioningState": "Succeeded",
-                           "sourceAddressPrefix": "AzureLoadBalancer",
-                           "sourcePortRange": "*"
-                                     }
-                         },
-                         {
-                         "etag": 'W/"d036f4d7-d977-429a-a8c6-879bc2523399"',
-                         "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/secgroup001/defaultSecurityRules/DenyAllInBound",
-                         "name": "DenyAllInBound",
-                         "properties": {
-                          "access": "Deny",
-                          "description": "Deny all inbound traffic",
-                          "destinationAddressPrefix": "*",
-                          "destinationPortRange": "*",
-                          "direction": "Inbound",
-                          "priority": 65500,
-                          "protocol": "*",
-                          "provisioningState": "Succeeded",
-                          "sourceAddressPrefix": "*",
-                          "sourcePortRange": "*"
-                                       }
-                        },
-                        {
-                        "etag": 'W/"d036f4d7-d977-429a-a8c6-879bc2523399"',
-                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/secgroup001/defaultSecurityRules/AllowVnetOutBound",
+                        "provisioning_state": "Succeeded",
+                        "source_address_prefix": "VirtualNetwork",
+                        "source_port_range": "*"
+                    },
+                    {
+                        "access": "Allow",
+                        "description": "Allow inbound traffic from azure load balancer",
+                        "destination_address_prefix": "*",
+                        "destination_port_range": "*",
+                        "direction": "Inbound",
+                        "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                        "name": "AllowAzureLoadBalancerInBound",
+                        "priority": 65001,
+                        "protocol": "*",
+                        "provisioning_state": "Succeeded",
+                        "source_address_prefix": "AzureLoadBalancer",
+                        "source_port_range": "*"
+                    },
+                    {
+                        "access": "Deny",
+                        "description": "Deny all inbound traffic",
+                        "destination_address_prefix": "*",
+                        "destination_port_range": "*",
+                        "direction": "Inbound",
+                        "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/defaultSecurityRules/DenyAllInBound",
+                        "name": "DenyAllInBound",
+                        "priority": 65500,
+                        "protocol": "*",
+                        "provisioning_state": "Succeeded",
+                        "source_address_prefix": "*",
+                        "source_port_range": "*"
+                    },
+                    {
+                        "access": "Allow",
+                        "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                        "destination_address_prefix": "VirtualNetwork",
+                        "destination_port_range": "*",
+                        "direction": "Outbound",
+                        "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/defaultSecurityRules/AllowVnetOutBound",
                         "name": "AllowVnetOutBound",
-                        "properties": {
-                          "access": "Allow",
-                          "description": "Allow outbound traffic from all VMs to all VMs in VNET",
-                          "destinationAddressPrefix": "VirtualNetwork",
-                          "destinationPortRange": "*",
-                          "direction": "Outbound",
-                          "priority": 65000,
-                          "protocol": "*",
-                          "provisioningState": "Succeeded",
-                          "sourceAddressPrefix": "VirtualNetwork",
-                          "sourcePortRange": "*"
-                                      }
-                        },
-                        {
-                        "etag": 'W/"d036f4d7-d977-429a-a8c6-879bc2523399"',
-                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/secgroup001/defaultSecurityRules/AllowInternetOutBound",
+                        "priority": 65000,
+                        "protocol": "*",
+                        "provisioning_state": "Succeeded",
+                        "source_address_prefix": "VirtualNetwork",
+                        "source_port_range": "*"
+                    },
+                    {
+                        "access": "Allow",
+                        "description": "Allow outbound traffic from all VMs to Internet",
+                        "destination_address_prefix": "Internet",
+                        "destination_port_range": "*",
+                        "direction": "Outbound",
+                        "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/defaultSecurityRules/AllowInternetOutBound",
                         "name": "AllowInternetOutBound",
-                        "properties": {
-                          "access": "Allow",
-                          "description": "Allow outbound traffic from all VMs to Internet",
-                          "destinationAddressPrefix": "Internet",
-                          "destinationPortRange": "*",
-                          "direction": "Outbound",
-                          "priority": 65001,
-                          "protocol": "*",
-                          "provisioningState": "Succeeded",
-                          "sourceAddressPrefix": "*",
-                          "sourcePortRange": "*"
-                                     }
-                        },
-                        {
-                        "etag": 'W/"d036f4d7-d977-429a-a8c6-879bc2523399"',
-                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/secgroup001/defaultSecurityRules/DenyAllOutBound",
+                        "priority": 65001,
+                        "protocol": "*",
+                        "provisioning_state": "Succeeded",
+                        "source_address_prefix": "*",
+                        "source_port_range": "*"
+                    },
+                    {
+                        "access": "Deny",
+                        "description": "Deny all outbound traffic",
+                        "destination_address_prefix": "*",
+                        "destination_port_range": "*",
+                        "direction": "Outbound",
+                        "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/defaultSecurityRules/DenyAllOutBound",
                         "name": "DenyAllOutBound",
-                        "properties": {
-                          "access": "Deny",
-                          "description": "Deny all outbound traffic",
-                          "destinationAddressPrefix": "*",
-                          "destinationPortRange": "*",
-                          "direction": "Outbound",
-                          "priority": 65500,
-                          "protocol": "*",
-                          "provisioningState": "Succeeded",
-                          "sourceAddressPrefix": "*",
-                          "sourcePortRange": "*"
-                                       }
-                         }
-                         ],
-                    "networkInterfaces": [
-                      {
-                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkInterfaces/nic004"
-                      }
-                                    ],
-                    "provisioningState": "Succeeded",
-                    "resourceGuid": "ebd00afa-5dc8-446f-810a-50dd6f671588",
-                    "securityRules": []
-            }
+                        "priority": 65500,
+                        "protocol": "*",
+                        "provisioning_state": "Succeeded",
+                        "source_address_prefix": "*",
+                        "source_port_range": "*"
+                    }
+                ]
+        network_interfaces:
+            description:
+                - A collection of references to network interfaces.
+            returned: always
+            type: list
+            sample: []
+        rules:
+            description:
+                - A collection of security rules of the network security group.
+            returned: always
+            type: list
+            sample: [
+                {
+                    "access": "Deny",
+                    "description": null,
+                    "destination_address_prefix": "*",
+                    "destination_port_range": "22",
+                    "direction": "Inbound",
+                    "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/securityRules/DenySSH",
+                    "name": "DenySSH",
+                    "priority": 100,
+                    "protocol": "Tcp",
+                    "provisioning_state": "Succeeded",
+                    "source_address_prefix": "*",
+                    "source_port_range": "*"
+                },
+                {
+                    "access": "Allow",
+                    "description": null,
+                    "destination_address_prefix": "*",
+                    "destination_port_range": "22",
+                    "direction": "Inbound",
+                    "etag": 'W/"edf48d56-b315-40ca-a85d-dbcb47f2da7d"',
+                    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroup/myResourceGroup/providers/Microsoft.Network/networkSecurityGroups/mysecgroup/securityRules/AllowSSH",
+                    "name": "AllowSSH",
+                    "priority": 101,
+                    "protocol": "Tcp",
+                    "provisioning_state": "Succeeded",
+                    "source_address_prefix": "174.109.158.0/24",
+                    "source_port_range": "*"
+                }
+            ]
+        subnets:
+            description:
+                - A collection of references to subnets.
+            returned: always
+            type: list
+            sample: []
         tags:
             description:
                 - Tags to assign to the security group.
@@ -227,7 +254,61 @@ except Exception:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 
-AZURE_OBJECT_CLASS = 'NetworkSecurityGroup'
+def create_rule_dict_from_obj(rule):
+    return dict(
+        id=rule.id,
+        name=rule.name,
+        description=rule.description,
+        protocol=rule.protocol,
+        source_port_range=rule.source_port_range,
+        destination_port_range=rule.destination_port_range,
+        source_address_prefix=rule.source_address_prefix,
+        destination_address_prefix=rule.destination_address_prefix,
+        source_port_ranges=rule.source_port_ranges,
+        destination_port_ranges=rule.destination_port_ranges,
+        source_address_prefixes=rule.source_address_prefixes,
+        destination_address_prefixes=rule.destination_address_prefixes,
+        source_application_security_groups=[p.id for p in rule.source_application_security_groups] if rule.source_application_security_groups else None,
+        destination_application_security_groups=[
+            p.id for p in rule.destination_application_security_groups] if rule.destination_application_security_groups else None,
+        access=rule.access,
+        priority=rule.priority,
+        direction=rule.direction,
+        provisioning_state=rule.provisioning_state,
+        etag=rule.etag
+    )
+
+
+def create_network_security_group_dict(nsg):
+    result = dict(
+        etag=nsg.etag,
+        id=nsg.id,
+        location=nsg.location,
+        name=nsg.name,
+        tags=nsg.tags,
+        type=nsg.type,
+    )
+    result['rules'] = []
+    if nsg.security_rules:
+        for rule in nsg.security_rules:
+            result['rules'].append(create_rule_dict_from_obj(rule))
+
+    result['default_rules'] = []
+    if nsg.default_security_rules:
+        for rule in nsg.default_security_rules:
+            result['default_rules'].append(create_rule_dict_from_obj(rule))
+
+    result['network_interfaces'] = []
+    if nsg.network_interfaces:
+        for interface in nsg.network_interfaces:
+            result['network_interfaces'].append(interface.id)
+
+    result['subnets'] = []
+    if nsg.subnets:
+        for subnet in nsg.subnets:
+            result['subnets'].append(subnet.id)
+
+    return result
 
 
 class AzureRMSecurityGroupInfo(AzureRMModuleBase):
@@ -286,9 +367,7 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
             pass
 
         if item and self.has_tags(item.tags, self.tags):
-            grp = self.serialize_obj(item, AZURE_OBJECT_CLASS)
-            grp['name'] = item.name
-            result = [grp]
+            result = [create_network_security_group_dict(item)]
 
         return result
 
@@ -302,9 +381,7 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
         results = []
         for item in response:
             if self.has_tags(item.tags, self.tags):
-                grp = self.serialize_obj(item, AZURE_OBJECT_CLASS)
-                grp['name'] = item.name
-                results.append(grp)
+                results.append(create_network_security_group_dict(item))
         return results
 
 

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -319,3 +319,15 @@
   assert:
     that:
       - output.securitygroups | length == 0
+
+- name: Clean up Application security group 2
+  azure_rm_applicationsecuritygroup:
+    resource_group: "{{ resource_group }}"
+    name: "{{ asg_name1 }}"
+    state: absent
+
+- name: Clean up Application security group 2
+  azure_rm_applicationsecuritygroup:
+    resource_group: "{{ resource_group_secondary }}"
+    name: "{{ asg_name2 }}"
+    state: absent

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -44,7 +44,13 @@
   register: output
 - name: assert resource retrieved
   assert:
-    that: output.securitygroups | length == 1
+    that:
+      - output.securitygroups | length == 1
+      - output.securitygroups[0].default_rules | length > 0
+      - output.securitygroups[0].name == '{{ secgroupname }}'
+      - output.securitygroups[0].network_interfaces | length == 0
+      - output.securitygroups[0].rules | length == 2
+      - output.securitygroups[0].subnets | length == 0
 
 - name: Add/Update rules on existing security group
   azure_rm_securitygroup:
@@ -75,6 +81,16 @@
     that:
       - "{{ output.state.rules | length }} == 4"
       - output.state.rules[0].source_address_prefix == '174.108.158.0/24'
+
+- name: Gather facts after update
+  azure_rm_securitygroup_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+  register: output
+- name: assert rules updated
+  assert:
+    that:
+      - output.securitygroups[0].rules | length == 4
 
 - name: Test idempotence
   azure_rm_securitygroup:

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -9,226 +9,227 @@
 
 - name: Create security group
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      tags:
-          testing: testing
-          delete: on-exit
-          foo: bar
-      purge_rules: yes
-      rules:
-          - name: DenySSH
-            protocol: Tcp
-            destination_port_range: 22
-            access: Deny
-            priority: 100
-            direction: Inbound
-          - name: AllowSSH
-            protocol: Tcp
-            source_address_prefix: 174.109.158.0/24
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-            direction: Inbound
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    tags:
+      testing: testing
+      delete: on-exit
+      foo: bar
+    purge_rules: yes
+    rules:
+      - name: DenySSH
+        protocol: Tcp
+        destination_port_range: 22
+        access: Deny
+        priority: 100
+        direction: Inbound
+      - name: AllowSSH
+        protocol: Tcp
+        source_address_prefix: 174.109.158.0/24
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+        direction: Inbound
   register: output
-
-- assert: { that: "{{ output.state.rules | length }} == 2" }
+- name: assert resource created
+  assert:
+    that: "{{ output.state.rules | length }} == 2"
 
 - name: Gather facts by tags
   azure_rm_securitygroup_info:
-      resource_group: "{{ resource_group }}"
-      tags:
-        - testing
-        - foo:bar
+    resource_group: "{{ resource_group }}"
+    tags:
+      - testing
+      - foo:bar
   register: output
-
-- assert:
-      that: output.securitygroups | length == 1
+- name: assert resource retrieved
+  assert:
+    that: output.securitygroups | length == 1
 
 - name: Add/Update rules on existing security group
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      rules:
-          - name: AllowSSH
-            protocol: Tcp
-            source_address_prefix: 174.108.158.0/24
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-          - name: AllowSSHFromHome
-            protocol: Tcp
-            source_address_prefix: 174.109.158.0/24
-            destination_port_range: 22-23
-            priority: 102
-          - name: AllowHTTPandHTTPS
-            protocol: Tcp
-            source_address_prefix: 174.109.158.0/24
-            destination_port_range:
-              - 80
-              - 443
-            priority: 103
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    rules:
+      - name: AllowSSH
+        protocol: Tcp
+        source_address_prefix: 174.108.158.0/24
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+      - name: AllowSSHFromHome
+        protocol: Tcp
+        source_address_prefix: 174.109.158.0/24
+        destination_port_range: 22-23
+        priority: 102
+      - name: AllowHTTPandHTTPS
+        protocol: Tcp
+        source_address_prefix: 174.109.158.0/24
+        destination_port_range:
+          - 80
+          - 443
+        priority: 103
   register: output
-
-- assert:
-      that:
-          - "{{ output.state.rules | length }} == 4"
-          - output.state.rules[0].source_address_prefix == '174.108.158.0/24'
+- name: assert resource updated
+  assert:
+    that:
+      - "{{ output.state.rules | length }} == 4"
+      - output.state.rules[0].source_address_prefix == '174.108.158.0/24'
 
 - name: Test idempotence
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      rules:
-          - name: AllowSSH
-            protocol: Tcp
-            source_address_prefix: 174.108.158.0/24
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-          - name: AllowSSHFromHome
-            protocol: Tcp
-            source_address_prefix: 174.109.158.0/24
-            destination_port_range: 22-23
-            priority: 102
-          - name: AllowHTTPandHTTPS
-            protocol: Tcp
-            source_address_prefix: 174.109.158.0/24
-            destination_port_range:
-              - 80
-              - 443
-            priority: 103
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    rules:
+      - name: AllowSSH
+        protocol: Tcp
+        source_address_prefix: 174.108.158.0/24
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+      - name: AllowSSHFromHome
+        protocol: Tcp
+        source_address_prefix: 174.109.158.0/24
+        destination_port_range: 22-23
+        priority: 102
+      - name: AllowHTTPandHTTPS
+        protocol: Tcp
+        source_address_prefix: 174.109.158.0/24
+        destination_port_range:
+          - 80
+          - 443
+        priority: 103
   register: output
-
-- assert:
-      that: not output.changed
+- name: assert resource not updated
+  assert:
+    that: not output.changed
 
 - name: Update tags
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      tags:
-          testing: testing
-          delete: never
-          baz: bar
-      append_tags: false
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    tags:
+      testing: testing
+      delete: never
+      baz: bar
+    append_tags: false
   register: output
-
-- assert:
-      that:
-          - output.state.tags | length == 3
-          - output.state.tags.delete == 'never'
+- name: assert resource updated
+  assert:
+    that:
+      - output.state.tags | length == 3
+      - output.state.tags.delete == 'never'
 
 - name: Purge tags
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      append_tags: false
-      tags:
-          testing: testing
-          delete: on-exit
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    append_tags: false
+    tags:
+      testing: testing
+      delete: on-exit
   register: output
-
-- assert:
-      that:
-          - output.state.tags | length == 2
-          - output.state.tags.delete == 'on-exit'
+- name: assert resource updated
+  assert:
+    that:
+      - output.state.tags | length == 2
+      - output.state.tags.delete == 'on-exit'
 
 - name: Gather facts for one accounts
   azure_rm_securitygroup_info:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
   register: output
-
-- assert:
-      that:
-          - output.securitygroups | length == 1
+- name: assert resource retrieved
+  assert:
+    that:
+      - output.securitygroups | length == 1
 
 - name: Gather facts for all accounts
   azure_rm_securitygroup_info:
-      resource_group: "{{ resource_group }}"
-      tags:
-        - testing:testing
+    resource_group: "{{ resource_group }}"
+    tags:
+      - testing:testing
   register: output_groups
-
-- assert:
-      that:
-          - output_groups.securitygroups | length > 0
+- name: assert resource retrieved
+  assert:
+    that:
+      - output_groups.securitygroups | length > 0
 
 - name: Create security group with source_address_prefixes
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      tags:
-          testing: testing
-          delete: on-exit
-          foo: bar
-      purge_rules: yes
-      rules:
-          - name: AllowSSH
-            protocol: Tcp
-            source_address_prefix:
-            - 52.100.120.240
-            - 53.100.250.190
-            - 54.110.200.200
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-            direction: Inbound
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    tags:
+      testing: testing
+      delete: on-exit
+      foo: bar
+    purge_rules: yes
+    rules:
+      - name: AllowSSH
+        protocol: Tcp
+        source_address_prefix:
+          - 52.100.120.240
+          - 53.100.250.190
+          - 54.110.200.200
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+        direction: Inbound
   register: output
-
-- assert:
+- name: assert resource created
+  assert:
     that:
-    - "{{ output.state.rules | length }} == 1"
-    - "{{ output.state.rules[0].source_address_prefixes | length }} == 3"
-    - not output.state.rules[0].source_address_prefix
+      - "{{ output.state.rules | length }} == 1"
+      - "{{ output.state.rules[0].source_address_prefixes | length }} == 3"
+      - not output.state.rules[0].source_address_prefix
 
 - name: Create security group with source_address_prefixes(idempontent)
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      tags:
-          testing: testing
-          delete: on-exit
-          foo: bar
-      purge_rules: yes
-      rules:
-          - name: AllowSSH
-            protocol: Tcp
-            source_address_prefix:
-            - 52.100.120.240
-            - 53.100.250.190
-            - 54.110.200.200
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-            direction: Inbound
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    tags:
+      testing: testing
+      delete: on-exit
+      foo: bar
+    purge_rules: yes
+    rules:
+      - name: AllowSSH
+        protocol: Tcp
+        source_address_prefix:
+          - 52.100.120.240
+          - 53.100.250.190
+          - 54.110.200.200
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+        direction: Inbound
   register: output
-
-- assert:
-      that: not output.changed
+- name: assert resource not updated
+  assert:
+    that: not output.changed
 
 - name: Add a single one group
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ secgroupname }}"
-      tags:
-          testing: testing
-          delete: on-exit
-          foo: bar
-      rules:
-          - name: DenySSH
-            protocol: Tcp
-            source_address_prefix:
-            - 54.120.120.240
-            destination_port_range: 22
-            access: Deny
-            priority: 102
-            direction: Inbound
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    tags:
+      testing: testing
+      delete: on-exit
+      foo: bar
+    rules:
+      - name: DenySSH
+        protocol: Tcp
+        source_address_prefix:
+          - 54.120.120.240
+        destination_port_range: 22
+        access: Deny
+        priority: 102
+        direction: Inbound
   register: output
-
-- assert:
-     that:
+- name: assert resource updated
+  assert:
+    that:
       - output.changed
       - "{{ output.state.rules | length }} == 2"
 
@@ -237,7 +238,7 @@
     resource_group: "{{ resource_group }}"
     name: "{{ asg_name1 }}"
     tags:
-        testing: testing
+      testing: testing
   register: asg1
 
 - name: Create Application security group 2
@@ -245,76 +246,76 @@
     resource_group: "{{ resource_group_secondary }}"
     name: "{{ asg_name2 }}"
     tags:
-        testing: testing
+      testing: testing
   register: asg2
 
 - name: Create security group with application security group
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ sg_name1 }}"
-      purge_rules: yes
-      rules:
-          - name: AsgToAsg
-            protocol: Tcp
-            source_application_security_groups:
-                - "{{ asg1.id }}"
-            destination_application_security_groups:
-                - resource_group: "{{ resource_group_secondary }}"
-                  name: "{{ asg_name2 }}"
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-            direction: Inbound
+    resource_group: "{{ resource_group }}"
+    name: "{{ sg_name1 }}"
+    purge_rules: yes
+    rules:
+      - name: AsgToAsg
+        protocol: Tcp
+        source_application_security_groups:
+          - "{{ asg1.id }}"
+        destination_application_security_groups:
+          - resource_group: "{{ resource_group_secondary }}"
+            name: "{{ asg_name2 }}"
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+        direction: Inbound
   register: output
-
-- assert:
+- name: assert resource retrieved
+  assert:
     that:
       - output.changed
 
 - name: Create security group with application security group - Idempotent
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ sg_name1 }}"
-      purge_rules: yes
-      rules:
-          - name: AsgToAsg
-            protocol: Tcp
-            source_application_security_groups:
-                - "{{ asg_name1 }}"
-            destination_application_security_groups:
-                - resource_group: "{{ resource_group_secondary }}"
-                  name: "{{ asg_name2 }}"
-            destination_port_range: 22
-            access: Allow
-            priority: 101
-            direction: Inbound
+    resource_group: "{{ resource_group }}"
+    name: "{{ sg_name1 }}"
+    purge_rules: yes
+    rules:
+      - name: AsgToAsg
+        protocol: Tcp
+        source_application_security_groups:
+          - "{{ asg_name1 }}"
+        destination_application_security_groups:
+          - resource_group: "{{ resource_group_secondary }}"
+            name: "{{ asg_name2 }}"
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+        direction: Inbound
   register: output
-
-- assert:
+- name: assert resource not updated
+  assert:
     that:
       - not output.changed
 
 
 - name: Delete security group
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ sg_name1 }}"
-      state: absent
+    resource_group: "{{ resource_group }}"
+    name: "{{ sg_name1 }}"
+    state: absent
 
 - name: Delete all security groups
   azure_rm_securitygroup:
-      resource_group: "{{ resource_group }}"
-      name: "{{ item.name }}"
-      state: absent
+    resource_group: "{{ resource_group }}"
+    name: "{{ item.name }}"
+    state: absent
   with_items: "{{ output_groups.securitygroups }}"
 
 - name: Should have no security groups remaining
   azure_rm_securitygroup_info:
-      resource_group: "{{ resource_group }}"
-      tags:
-        - testing:testing
+    resource_group: "{{ resource_group }}"
+    tags:
+      - testing:testing
   register: output
-
-- assert:
-      that:
-          - output.securitygroups | length == 0
+- name: assert resources removed
+  assert:
+    that:
+      - output.securitygroups | length == 0


### PR DESCRIPTION
##### SUMMARY
This PR updates the return values of `azure_rm_securitygroup_info` to match the return values of `azure_rm_securitygroup`.

Because of the update, this should be considered a breaking change, as the previously used `properties` field is no longer returned.

Fixes https://github.com/ansible-collections/azure/issues/636. Note that there is no test coverage for the fix because there is no module to create NSG flow logs. **Flow logs will need to be manually configured on an NSG** in order to test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_securitygroup_info

##### ADDITIONAL INFORMATION

A playbook which tests the info module:

```yaml
---
- name: "Playbook for testing."
  hosts: "localhost"
  connection: "local"
  gather_facts: false
  vars:
    resource_group: "automated-testing"
    resource_group_secondary: "automated-testing-secondary"
  collections:
    - azure.azcollection

  tasks:
    - name: "Include tests"
      include_tasks: "tests/integration/targets/azure_rm_securitygroup/tasks/main.yml"
```
