### PR TITLE
Dissociate routetable from subnet

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -294,7 +294,6 @@ state:
 '''  # NOQA
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, CIDR_PATTERN, azure_id_to_dict, format_resource_id
-
 try:
     from msrestazure.azure_exceptions import CloudError
 except ImportError:
@@ -482,10 +481,16 @@ class AzureRMSubnet(AzureRMModuleBase):
                     changed = True
                     results['network_security_group']['id'] = nsg.get('id')
                     results['network_security_group']['name'] = nsg.get('name')
-                if self.route_table is not None and self.route_table != results['route_table'].get('id'):
-                    changed = True
-                    results['route_table']['id'] = self.route_table
-                    self.log("CHANGED: subnet {0} route_table to {1}".format(self.name, route_table.get('name')))
+                if self.route_table is not None:
+                    if self.route_table != results['route_table'].get('id'):
+                        changed = True
+                        results['route_table']['id'] = self.route_table
+                        self.log("CHANGED: subnet {0} route_table to {1}".format(self.name, route_table.get('name')))
+                else:
+                    if results['route_table'].get('id') is not None:
+                        changed = True
+                        results['route_table']['id'] = None
+                        self.log("CHANGED: subnet {0} will dissociate to route_table {1}".format(self.name, route_table.get('name')))
 
                 if self.service_endpoints or self.service_endpoints == []:
                     oldd = {}

--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -294,6 +294,7 @@ state:
 '''  # NOQA
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, CIDR_PATTERN, azure_id_to_dict, format_resource_id
+
 try:
     from msrestazure.azure_exceptions import CloudError
 except ImportError:

--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -66,6 +66,7 @@ options:
             - The reference of the RouteTable resource.
             - Can be the name or resource ID of the route table.
             - Can be a dict containing the I(name) and I(resource_group) of the route table.
+            - If this option is not configured, the existing route table is disconnected from the subnet.
     service_endpoints:
         description:
             - An array of service endpoints.

--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -66,7 +66,7 @@ options:
             - The reference of the RouteTable resource.
             - Can be the name or resource ID of the route table.
             - Can be a dict containing the I(name) and I(resource_group) of the route table.
-            - If this option is not configured, the existing route table is disconnected from the subnet.
+            - Without this configuration, the associated route table will be dissociate. If there is no associated route table, it has no impact.
     service_endpoints:
         description:
             - An array of service endpoints.

--- a/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
@@ -120,10 +120,10 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group_secondary }}"
     name: "{{ db2name }}"
-    location: eastus
+    location: westus
     kind: global_document_db
     geo_rep_locations:
-      - name: eastus
+      - name: southcentralus
         failover_priority: 0
       - name: eastus2
         failover_priority: 1

--- a/tests/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -138,6 +138,7 @@
     virtual_network_name: My_Virtual_Network
     resource_group: "{{ resource_group }}"
     address_prefix_cidr: "10.1.0.0/16"
+    route_table: "{{ route_table.id }}"
     security_group: "{{ nsg.state.id }}"
   register: output
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Dissociate routetable from subnet. If this option is not configured, the existing route table is disconnected from the subnet.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_subnet.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
