### PR TITLE
Fixes for issue #732

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -521,6 +521,11 @@ class AzureHost(object):
             av_zone = self._vm_model['zones']
 
         new_hostvars = dict(
+            network_interface=[],
+            mac_address=[],
+            network_interface_id=[],
+            security_group_id=[],
+            security_group=[],
             public_ipv4_addresses=[],
             public_dns_hostnames=[],
             private_ipv4_addresses=[],
@@ -565,12 +570,12 @@ class AzureHost(object):
                     if pip_fqdn:
                         new_hostvars['public_dns_hostnames'].append(pip_fqdn)
 
-            new_hostvars['mac_address'] = nic._nic_model['properties'].get('macAddress')
-            new_hostvars['network_interface'] = nic._nic_model['name']
-            new_hostvars['network_interface_id'] = nic._nic_model['id']
-            new_hostvars['security_group_id'] = nic._nic_model['properties']['networkSecurityGroup']['id'] \
+            new_hostvars['mac_address'].append(nic._nic_model['properties'].get('macAddress'))
+            new_hostvars['network_interface'].append(nic._nic_model['name'])
+            new_hostvars['network_interface_id'].append(nic._nic_model['id'])
+            new_hostvars['security_group_id'].append(nic._nic_model['properties']['networkSecurityGroup']['id']) \
                 if nic._nic_model['properties'].get('networkSecurityGroup') else None
-            new_hostvars['security_group'] = parse_resource_id(new_hostvars['security_group_id'])['resource_name'] \
+            new_hostvars['security_group'].append(parse_resource_id(nic._nic_model['properties']['networkSecurityGroup']['id'])['resource_name']) \
                 if nic._nic_model['properties'].get('networkSecurityGroup') else None
 
         # set image and os_disk


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Append secondary network information to relevant hostvars.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes for issue #732 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Inventory plugin azure_rm.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #732 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
{
    "_meta": {
        "hostvars": {
            "REDACTED_157a": {
                "ansible_host": "REDACTED",
                "availability_zone": null,
                "computer_name": "REDACTED",
                "data_disks": [
                    {
                        "id": "/subscriptions/REDACTED/resourceGroups/RSG-REDACTED/providers/Microsoft.Compute/disks/REDACTED_lun_0_2_226d37e85d8c4329b1e9e67072e67bbe",
                        "lun": 0,
                        "name": "REDACTED_lun_0_2_226d37e85d8c4329b1e9e67072e67bbe"
                    },
                    {
                        "id": "/subscriptions/REDACTED/resourceGroups/RSG-REDACTED/providers/Microsoft.Compute/disks/REDACTED_lun_1_3_b79929d89ad14afa9f2b6a47baa9f77c",
                        "lun": 1,
                        "name": "REDACTED_lun_1_3_b79929d89ad14afa9f2b6a47baa9f77c"
                    }
                ],
                "default_inventory_hostname": "REDACTED_157a",
                "id": "/subscriptions/REDACTED/resourceGroups/rsg-REDACTED/providers/Microsoft.Compute/virtualMachines/REDACTED",
                "image": {
                    "id": "/subscriptions/590fa16d-e37a-43d4-900c-60256027e70e/resourceGroups/npoResourceGroup/providers/Microsoft.Compute/galleries/REDACTED/images/RHEL-8.2"
                },
                "location": "northeurope",
                "mac_address": [
                    "REDACTED",
                    "REDACTED"
                ],
                "name": "REDACTED",
                "network_interface": [
                    "REDACTED320",
                    "mgt-REDACTEDnic"
                ],
                "network_interface_id": [
                    "/subscriptions/REDACTED/resourceGroups/rsg-REDACTED/providers/Microsoft.Network/networkInterfaces/REDACTED320",
                    "/subscriptions/REDACTED/resourceGroups/rsg-REDACTED/providers/Microsoft.Network/networkInterfaces/mgt-REDACTEDnic"
                ],
                "os_disk": {
                    "id": "/subscriptions/REDACTED/resourceGroups/RSG-REDACTED/providers/Microsoft.Compute/disks/REDACTED_OsDisk_1_91ea17ff1fe24b78beab80f6e165cf88",
                    "name": "REDACTED_OsDisk_1_91ea17ff1fe24b78beab80f6e165cf88",
                    "operating_system_type": "linux"
                },
                "os_profile": {
                    "system": "linux"
                },
                "plan": null,
                "powerstate": "running",
                "private_ipv4_addresses": [
                    "REDACTED",
                    "REDACTED"
                ],
                "provisioning_state": "succeeded",
                "public_dns_hostnames": [],
                "public_ipv4_addresses": [],
                "resource_group": "rsg-REDACTED",
                "resource_type": "Microsoft.Compute/virtualMachines",
                "security_group": [
                    "sg-REDACTED",
                    "sg-REDACTEDMGT001"
                ],
                "security_group_id": [
                    "/subscriptions/REDACTED/resourceGroups/rsg-REDACTED/providers/Microsoft.Network/networkSecurityGroups/sg-REDACTED",
                    "/subscriptions/REDACTED/resourceGroups/rsg-REDACTED/providers/Microsoft.Network/networkSecurityGroups/sg-REDACTEDMGT001"
                ],
                "tags": {},
                "virtual_machine_size": "Standard_D4s_v3",
                "vmid": "60fd1b1a-3c49-4888-a587-ba650e10e4c0",
                "vmss": {}
            }
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "REDACTED_157a"
        ]
    }
}

```
