### PR TITLE
Add disable_outbound_snat configuration to azure_rm_loadbalancer module

### DIFF
--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -214,6 +214,12 @@ options:
             enable_floating_ip:
                 description:
                     - Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group.
+            disable_outbound_snat:
+                description:
+                    - Configure outbound source network address translation (SNAT)
+                    - The default value is False
+                    - True is equivalent to "Use outbound rules to provide backend pool members access to the internet" in portal
+                    - False is equivalent to "Use implicit outbound rule" in portal
     inbound_nat_rules:
         description:
             - Collection of inbound NAT Rules used by a load balancer.
@@ -570,6 +576,10 @@ load_balancing_rule_spec = dict(
     ),
     enable_floating_ip=dict(
         type='bool'
+    ),
+    disable_outbound_snat=dict(
+        type='bool',
+        default=False
     )
 )
 
@@ -777,7 +787,8 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
                     frontend_port=self.frontend_port,
                     backend_port=self.backend_port,
                     idle_timeout=self.idle_timeout,
-                    enable_floating_ip=False
+                    enable_floating_ip=False,
+                    disable_outbound_snat=False
                 )] if self.protocol else None
 
             # create new load balancer structure early, so it can be easily compared
@@ -870,7 +881,8 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
                 frontend_port=item.get('frontend_port'),
                 backend_port=item.get('backend_port'),
                 idle_timeout_in_minutes=item.get('idle_timeout'),
-                enable_floating_ip=item.get('enable_floating_ip')
+                enable_floating_ip=item.get('enable_floating_ip'),
+                disable_outbound_snat=item.get('disable_outbound_snat')
             ) for item in self.load_balancing_rules] if self.load_balancing_rules else None
 
             inbound_nat_rules_param = [self.network_models.InboundNatRule(

--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -74,7 +74,6 @@ options:
                     - This must be specified I(sku=Standard) and I(subnet) when setting zones.
                 type: list
                 elements: str
-
     backend_address_pools:
         description:
             - List of backend address pools.
@@ -216,10 +215,10 @@ options:
                     - Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group.
             disable_outbound_snat:
                 description:
-                    - Configure outbound source network address translation (SNAT)
-                    - The default value is False
-                    - True is equivalent to "Use outbound rules to provide backend pool members access to the internet" in portal
-                    - False is equivalent to "Use implicit outbound rule" in portal
+                    - Configure outbound source network address translation (SNAT).
+                    - The default behavior when omitted is equivalent to I(disable_outbound_snat=True).
+                    - True is equivalent to "(Recommended) Use outbound rules to provide backend pool members access to the internet" in portal.
+                    - False is equivalent to "Use default outbound access" in portal.
     inbound_nat_rules:
         description:
             - Collection of inbound NAT Rules used by a load balancer.
@@ -579,8 +578,8 @@ load_balancing_rule_spec = dict(
     ),
     disable_outbound_snat=dict(
         type='bool',
-        default=False
-    )
+        default=None
+    ),
 )
 
 
@@ -788,7 +787,6 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
                     backend_port=self.backend_port,
                     idle_timeout=self.idle_timeout,
                     enable_floating_ip=False,
-                    disable_outbound_snat=False
                 )] if self.protocol else None
 
             # create new load balancer structure early, so it can be easily compared
@@ -882,7 +880,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
                 backend_port=item.get('backend_port'),
                 idle_timeout_in_minutes=item.get('idle_timeout'),
                 enable_floating_ip=item.get('enable_floating_ip'),
-                disable_outbound_snat=item.get('disable_outbound_snat')
+                disable_outbound_snat=item.get('disable_outbound_snat'),
             ) for item in self.load_balancing_rules] if self.load_balancing_rules else None
 
             inbound_nat_rules_param = [self.network_models.InboundNatRule(

--- a/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
@@ -196,6 +196,7 @@
         frontend_port: 80
         backend_port: 80
         probe: prob0
+        disable_outbound_snat: True
   register: output
 
 - name: assert complex load balancer created
@@ -228,6 +229,7 @@
         frontend_port: 80
         backend_port: 80
         probe: prob0
+        disable_outbound_snat: True
     inbound_nat_rules:
       - name: inboundnatrule0
         backend_port: 8080
@@ -293,6 +295,7 @@
         frontend_port: 80
         backend_port: 80
         probe: prob0
+        disable_outbound_snat: False
   register: output
 
 - name: assert complex load balancer created


### PR DESCRIPTION
##### SUMMARY
Fixes #743

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`azure_rm_loadbalancer`

##### ADDITIONAL INFORMATION

```yaml
  - name: Add Load Balancer rules
    azure.azcollection.azure_rm_loadbalancer:
      profile: prod
      resource_group: dummy-resource-group
      name: dummy-load-balancer
      load_balancing_rules :
        - name: dummy-rule-1
          backend_port: 9999
          protocol: Tcp
          frontend_port: 9999
          frontend_ip_configuration: dummy-load-balancer-ip
          backend_address_pool : dummy-load-balancer-pool
          probe: dummy-health-probe
          disable_outbound_snat: true # << new feature
```
