### PR TITLE
Fix VM info module for failed VM provisions

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -409,6 +409,10 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
                 display_status = instance['statuses'][index]['displayStatus']
                 power_state = 'generalized'
                 break
+            elif code[0] == 'ProvisioningState' and code[1] == 'failed':
+                display_status = instance['statuses'][index]['displayStatus']
+                power_state = ''
+                break
 
         new_result = {}
         new_result['power_state'] = power_state


### PR DESCRIPTION
##### SUMMARY
Fixes usage of undeclared variables for virtual machines that failed to provision correctly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`azure_rm_virtualmachine_info.py`

##### ADDITIONAL INFORMATION
`serialize_vm()` in `azure_rm_virtualmachine_info.py` fails with the message:
```
  msg: Error getting virtual machine None - local variable 'display_status' referenced before assignment
```

The value of `instance` for the failed-to-provision VM is:
```
{
  'hyperVGeneration': 'V1',
  'disks': [{ <snip> }],
  'statuses': [{
    'code': 'ProvisioningState/failed/NetworkingInternalOperationError',
    'level': 'Error',
    'displayStatus': 'Provisioning failed',
    'message': 'An unexpected error occured while processing the network profile of the VM. Please retry later.',
    'time': '2021-12-21T10:06:31.289877Z',
  }]
}
```