### PR TITLE
#738 add mandatory field when updating IPAddress

### DIFF
--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -379,6 +379,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
                     pip = self.network_models.PublicIPAddress(
                         location=results['location'],
                         public_ip_allocation_method=results['public_ip_allocation_method'],
+                        sku=self.network_models.PublicIPAddressSku(name=self.sku) if self.sku else None,
                         tags=results['tags']
                     )
                     if self.domain_name:


### PR DESCRIPTION
- sku seems to be mandatory in Azure API

##### SUMMARY
Fixed #738

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_publicipaddress

##### ADDITIONAL INFORMATION
Sku is mandatory in azure API and this is why we need to have it while requesting changes otherwhise, the services complain you are trying to change the sku defaulting to Basic.
see #738 to have a better understanding of what's happening.