### PR TITLE
fix a typo error. related to #757

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1616,7 +1616,6 @@ class AzureRMAuth(object):
 
         cli_credentials = {
             'credentials': credentials,
-            'credential': credentials,
             'subscription_id': subscription_id,
             'cloud_environment': cloud_environment
         }

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1500,7 +1500,7 @@ class AzureRMAuth(object):
         if self.credentials.get('credentials') is not None:
             # AzureCLI credentials
             self.azure_credentials = self.credentials['credentials']
-            self.azure_credential_track2 = self.credentials['credential']
+            self.azure_credential_track2 = self.credentials['credentials']
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('secret') is not None and \
                 self.credentials.get('tenant') is not None:


### PR DESCRIPTION
##### SUMMARY
there is an issue with MSI Authentication.

Fixes #757 

```
Loading collection azure.azcollection from /home/jenkins/.ansible/collections/ansible_collections/azure/azcollection

# credential object dumped:
{'credentials': <msrestazure.azure_active_directory.MSIAuthentication object at 0x7f1f38d64c40>, 'subscription_id': 'XYZ-EDITED-XXYZ'}

[WARNING]:  * Failed to parse /work/env.azure_rm.yml with ansible_collections.azure.azcollection.plugins.inventory.azure_rm plugin: 'credential'
  File "/home/jenkins/.local/lib/python3.9/site-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/jenkins/.ansible/collections/ansible_collections/azure/azcollection/plugins/inventory/azure_rm.py", line 219, in parse
    self._credential_setup()
  File "/home/jenkins/.ansible/collections/ansible_collections/azure/azcollection/plugins/inventory/azure_rm.py", line 240, in _credential_setup
    self.azure_auth = AzureRMAuth(**auth_options)
  File "/home/jenkins/.ansible/collections/ansible_collections/azure/azcollection/plugins/module_utils/azure_rm_common.py", line 1513, in __init__

# root cause of the issue 
    self.azure_credential_track2 = self.credentials['credential']
[WARNING]: Unable to parse /work/env.azure_rm.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

azurerm inventory plugin

