### PR TITLE
Conditionally call non MSI auth when interacting with keyvault

### DIFF
--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -185,6 +185,13 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
+        else:
+            try:
+                self.log("Get KeyVaultClient from MSI")
+                credentials = MSIAuthentication(resource='https://vault.azure.net')
+                return KeyVaultClient(credentials)
+            except Exception:
+                self.log("Get KeyVaultClient from service principal")
 
         # Create KeyVault Client using KeyVault auth class and auth_callback
         def auth_callback(server, resource, scope):

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -320,6 +320,13 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
+        else:
+            try:
+                self.log("Get KeyVaultClient from MSI")
+                credentials = MSIAuthentication(resource='https://vault.azure.net')
+                return KeyVaultClient(credentials)
+            except Exception:
+                self.log("Get KeyVaultClient from service principal")
 
         # Create KeyVault Client using KeyVault auth class and auth_callback
         def auth_callback(server, resource, scope):

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -207,6 +207,13 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
+        else:
+            try:
+                self.log("Get KeyVaultClient from MSI")
+                credentials = MSIAuthentication(resource='https://vault.azure.net')
+                return KeyVaultClient(credentials)
+            except Exception:
+                self.log("Get KeyVaultClient from service principal")
 
         # Create KeyVault Client using KeyVault auth class and auth_callback
         def auth_callback(server, resource, scope):

--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -273,6 +273,13 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
+        else:
+            try:
+                self.log("Get KeyVaultClient from MSI")
+                credentials = MSIAuthentication(resource='https://vault.azure.net')
+                return KeyVaultClient(credentials)
+            except Exception:
+                self.log("Get KeyVaultClient from service principal")
 
         # Create KeyVault Client using KeyVault auth class and auth_callback
         def auth_callback(server, resource, scope):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Conditionally call non MSI auth when interacting with keyvault. fixes #134 
The related PR #356 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_keyvaultkey.py
azure_rm_keyvaultkey_info.py
azure_rm_keyvaultsecret.py
azure_rm_keyvaultsecret_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
