### PR TITLE
Update azure-cli-core to 2.34.0

### DIFF
--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -1,7 +1,7 @@
 packaging
 requests[security]
 xmltodict
-azure-cli-core==2.26.1
+azure-cli-core==2.34.0
 azure-common==1.1.11
 azure-identity==1.7.0
 azure-mgmt-apimanagement==0.2.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The rather strictly tied down `cryptography` dependency (`>=3.2,<3.4`) in `azure-cli-core` version 2.26.1 generates dependency issues in other projects using the `azure.azcollection`.
For example, see https://github.com/ansible/creator-ee/pull/23.

https://github.com/Azure/azure-cli/pull/19639 loosened the `cryptography` dependency and this PR now brings this change to this ansible collection.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
