### PR TITLE
Fixed the inconsistent return value of attach_caching caused by the azure-mgmt-compute upgrade

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -519,9 +519,10 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         if vm_name:
             vm = self._get_vm(vm_name)
             correspondence = next((d for d in vm.storage_profile.data_disks if d.name.lower() == disk.get('name').lower()), None)
-            if correspondence and correspondence.caching.name != self.attach_caching:
+            caching_options = self.compute_models.CachingTypes[self.attach_caching] if self.attach_caching and self.attach_caching != '' else None
+            if correspondence and correspondence.caching != caching_options:
                 resp = True
-                if correspondence.caching.name == 'none' and (self.attach_caching == '' or self.attach_caching is None):
+                if correspondence.caching == 'none' and (self.attach_caching == '' or self.attach_caching is None):
                     resp = False
         return resp
 


### PR DESCRIPTION
Fixed the inconsistent return value of attach_caching caused by the azure-mgmt-compute upgrade

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_managedisk.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
