### PR TITLE
Correct documentation of return attribute for azure_rm_webapp

### DIFF
--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -320,7 +320,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-azure_webapp:
+id:
     description:
         - ID of current web app.
     returned: always


### PR DESCRIPTION
##### SUMMARY
The documentation for [azure_rm_webapp](https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_webapp_module.html#return-values) states the return attribute is `azure_webapp`, when it is actually `id`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
azure_rm_webapp

