### PR TITLE
Fixes required for use with multiple Cloud Environments 

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -896,7 +896,8 @@ class AzureRMModuleBase(object):
                 client_kwargs = dict(credentials=self.azure_auth.azure_credentials, base_url=base_url)
         else:
             if is_track2:
-                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, subscription_id=mgmt_subscription_id, base_url=base_url, credential_scopes=[base_url + ".default"])
+                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2,
+                                     subscription_id=mgmt_subscription_id, base_url=base_url, credential_scopes=[base_url + ".default"])
             else:
                 client_kwargs = dict(credentials=self.azure_auth.azure_credentials, subscription_id=mgmt_subscription_id, base_url=base_url)
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -891,12 +891,12 @@ class AzureRMModuleBase(object):
         # Some management clients do not take a subscription ID as parameters.
         if suppress_subscription_id:
             if is_track2:
-                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, base_url=base_url)
+                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, base_url=base_url, credential_scopes=[base_url + ".default"])
             else:
                 client_kwargs = dict(credentials=self.azure_auth.azure_credentials, base_url=base_url)
         else:
             if is_track2:
-                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, subscription_id=mgmt_subscription_id, base_url=base_url)
+                client_kwargs = dict(credential=self.azure_auth.azure_credential_track2, subscription_id=mgmt_subscription_id, base_url=base_url, credential_scopes=[base_url + ".default"])
             else:
                 client_kwargs = dict(credentials=self.azure_auth.azure_credentials, subscription_id=mgmt_subscription_id, base_url=base_url)
 

--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -181,7 +181,6 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
         if self.module.params['auth_source'] == 'msi':
             try:
                 self.log("Get KeyVaultClient from MSI")
-                resource = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
                 credentials = MSIAuthentication(resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception:

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -313,12 +313,13 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
         return self.results
 
     def get_keyvault_client(self):
+        kv_url = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
         # Don't use MSI credentials if the auth_source isn't set to MSI.  The below will Always result in credentials when running on an Azure VM.
         if self.module.params['auth_source'] == 'msi':
             try:
                 self.log("Get KeyVaultClient from MSI")
                 resource = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
-                credentials = MSIAuthentication(resource="https://{0}".format(resource))
+                credentials = MSIAuthentication(resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
@@ -326,7 +327,7 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(
-                    subscription_id=self.credentials['subscription_id'], resource="https://vault.azure.net")
+                    subscription_id=self.credentials['subscription_id'], resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception as exc:
                 self.log("Get KeyVaultClient from service principal")
@@ -346,7 +347,7 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
                 secret=self.credentials['secret'],
                 tenant=tenant,
                 cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                resource="https://{0}".format(kv_url))
 
             token = authcredential.token
             return token['token_type'], token['access_token']

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -318,7 +318,6 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
         if self.module.params['auth_source'] == 'msi':
             try:
                 self.log("Get KeyVaultClient from MSI")
-                resource = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
                 credentials = MSIAuthentication(resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception:

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -198,12 +198,12 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
         return self.results
 
     def get_keyvault_client(self):
+        kv_url = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
         # Don't use MSI credentials if the auth_source isn't set to MSI.  The below will Always result in credentials when running on an Azure VM.
         if self.module.params['auth_source'] == 'msi':
             try:
                 self.log("Get KeyVaultClient from MSI")
-                resource = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
-                credentials = MSIAuthentication(resource="https://{0}".format(resource))
+                credentials = MSIAuthentication(resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
@@ -211,7 +211,7 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(
-                    subscription_id=self.credentials['subscription_id'], resource="https://vault.azure.net")
+                    subscription_id=self.credentials['subscription_id'], resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception as exc:
                 self.log("Get KeyVaultClient from service principal")
@@ -231,7 +231,7 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 secret=self.credentials['secret'],
                 tenant=tenant,
                 cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                resource="https://{0}".format(kv_url))
 
             token = authcredential.token
             return token['token_type'], token['access_token']

--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -266,6 +266,7 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
         return self.results
 
     def get_keyvault_client(self):
+        kv_url = self.azure_auth._cloud_environment.suffixes.keyvault_dns.split('.', 1).pop()
         # Don't use MSI credentials if the auth_source isn't set to MSI.  The below will Always result in credentials when running on an Azure VM.
         if self.module.params['auth_source'] == 'msi':
             try:
@@ -279,7 +280,7 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(
-                    subscription_id=self.credentials['subscription_id'], resource="https://vault.azure.net")
+                    subscription_id=self.credentials['subscription_id'], resource="https://{0}".format(kv_url))
                 return KeyVaultClient(credentials)
             except Exception as exc:
                 self.log("Get KeyVaultClient from service principal")
@@ -302,7 +303,7 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
                 secret=self.credentials['secret'],
                 tenant=tenant,
                 cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
+                resource="https://{0}".format(kv_url))
 
             token = authcredential.token
             return token['token_type'], token['access_token']


### PR DESCRIPTION
##### SUMMARY
Fixes credential_scopes for track2 authentication when connecting to non "Azure Public" cloud environments
Fixes for AKV to correct resource url for non "Azure Public" cloud environments

fixes: #331 #836 #702 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

- azure_rm_common
- azure_rm_keyvaultkey
- azure_rm_keyvaultsecret
- azure_rm_keyvaultkey_info
- azure_rm_keyvaultsecret_info

##### ADDITIONAL INFORMATION
These changes allow you to use other cloud platforms in azure.

The track2 fixes are related to an azure-sdk issue i created: [here](https://github.com/Azure/azure-sdk-for-python/issues/24440) it uses poorly documented keyword credential_scopes to tell the SDK which environment the token request is for.

The AKV Changes are to remove the hard coded ` resource="https://vault.azure.net"` as each cloud environment has its own resource url for AKV. 

