### PR TITLE
Changed aad_profile.admin_group_object_ids to take a list of string

### DIFF
--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -235,7 +235,8 @@ options:
             admin_group_object_ids:
                 description:
                     - AAD group object IDs that will have admin role of the cluster.
-                type: str
+                type: list
+                elements: str
     addon:
         description:
             - Profile of managed cluster add-on.
@@ -632,7 +633,7 @@ aad_profile_spec = dict(
     server_app_secret=dict(type='str', no_log=True),
     tenant_id=dict(type='str'),
     managed=dict(type='bool', default='false'),
-    admin_group_object_ids=dict(type='str')
+    admin_group_object_ids=dict(type='list', elements='str')
 )
 
 


### PR DESCRIPTION
##### SUMMARY
Azure expect a list of strings as a value for admin_group_object_ids, while current implementations sends a string.
This causes the following error: `msrest.exceptions.SerializationError: Refuse str type as a valid iter type.`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_aks

##### ADDITIONAL INFORMATION
