### PR TITLE
[Feature] improve service principal listing

### DIFF
--- a/plugins/modules/azure_rm_adserviceprincipal_info.py
+++ b/plugins/modules/azure_rm_adserviceprincipal_info.py
@@ -35,6 +35,7 @@ options:
     app_display_name:
         description:
             - service principal's display name.
+        type: str
 
 extends_documentation_fragment:
     - azure.azcollection.azure

--- a/plugins/modules/azure_rm_adserviceprincipal_info.py
+++ b/plugins/modules/azure_rm_adserviceprincipal_info.py
@@ -128,7 +128,7 @@ class AzureRMADServicePrincipalInfo(AzureRMModuleBase):
             elif self.app_id:
                 service_principals = list(client.service_principals.list(filter="servicePrincipalNames/any(c:c eq '{0}')".format(self.app_id)))
             elif self.app_display_name:
-                service_principals = list(client.service_principals.list(filter="appDisplayName eq '%s'" % self.app_display_name))
+                service_principals = list(client.service_principals.list(filter="DisplayName eq '%s'" % self.app_display_name))
             else:
                 service_principals = list(client.service_principals.list())
 

--- a/tests/integration/targets/azure_rm_adserviceprincipal/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adserviceprincipal/tasks/main.yml
@@ -60,6 +60,29 @@
         - ad_info.service_principals[0].app_display_name == ad_fact.app_display_name
         - ad_info.service_principals[0].app_role_assignment_required == True
 
+- name: Get ad service principal info by object_id
+  azure_rm_adserviceprincipal_info:
+    tenant: "{{ tenant_id }}"
+    app_display_name: "{{ ad_info.ad_fact.app_display_name }}"
+  register: ad_info
+
+- assert:
+    that:
+        - ad_info.service_principals[0].app_display_name == ad_fact.app_display_name
+        - ad_info.service_principals[0].app_role_assignment_required == True
+
+- name: Get ad service principal info by object_id
+  azure_rm_adserviceprincipal_info:
+    tenant: "{{ tenant_id }}"
+  register: ad_info
+
+- assert:
+    that:
+        - (ad_info | json_query(jmesquery))[0].app_display_name == ad_fact.app_display_name
+        - (ad_info | json_query(jmesquery))[0].app_role_assignment_required == True
+    vars:
+        jmesquery: "service_principals[?app_display_name == `{{ app_display_name }}`]"
+
 - name: delete ad service principal
   azure_rm_adserviceprincipal:
     app_id: "{{ app_id }}"

--- a/tests/integration/targets/azure_rm_adserviceprincipal/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adserviceprincipal/tasks/main.yml
@@ -63,7 +63,7 @@
 - name: Get ad service principal info by object_id
   azure_rm_adserviceprincipal_info:
     tenant: "{{ tenant_id }}"
-    app_display_name: "{{ ad_info.ad_fact.app_display_name }}"
+    app_display_name: "{{ ad_fact.app_display_name }}"
   register: ad_info
 
 - assert:


### PR DESCRIPTION
##### SUMMARY

Fixes #759 

This allows the user to list service principals by display name, or just
all principals for post-list processing.

examples

```
- name: Get ad service principal info by object_id
  azure_rm_adserviceprincipal_info:
    tenant: "{{ tenant_id }}"
  register: ad_info
```

```
- name: Get ad service principal info by object_id
  azure_rm_adserviceprincipal_info:
    tenant: "{{ tenant_id }}"
    app_display_name: "{{ ad_info.ad_fact.app_display_name }}"
  register: ad_info
```

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

azure_rm_adserviceprincipal_info
