### PR TITLE
[Feature] Enable certificate-based authentication with login with Service principal

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -103,6 +103,20 @@ options:
         description:
             - Parent argument.
         type: str
+    x509_certificate:
+        description:
+            - The X509 certificate used to create the service principal in PEM format.
+            - The certificate must be appended to the private key.
+            - Use when authenticating with a Service Principal.
+        type: str
+        version_added: '1.14.0'
+    thumbprint:
+        description:
+            - The thumbprint of the private key specified in I(x509_certificate).
+            - Use when authenticating with a Service Principal.
+            - Required if I(x509_certificate) is defined.
+        type: str
+        version_added: '1.14.0'
 requirements:
     - python >= 2.7
     - The host that executes this module must have the azure.azcollection collection installed via galaxy

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -103,7 +103,7 @@ options:
         description:
             - Parent argument.
         type: str
-    x509_certificate:
+    x509_certificate_path:
         description:
             - Path to the X509 certificate used to create the service principal in PEM format.
             - The certificate must be appended to the private key.
@@ -112,9 +112,9 @@ options:
         version_added: '1.14.0'
     thumbprint:
         description:
-            - The thumbprint of the private key specified in I(x509_certificate).
+            - The thumbprint of the private key specified in I(x509_certificate_path).
             - Use when authenticating with a Service Principal.
-            - Required if I(x509_certificate) is defined.
+            - Required if I(x509_certificate_path) is defined.
         type: str
         version_added: '1.14.0'
 requirements:

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -105,10 +105,10 @@ options:
         type: str
     x509_certificate:
         description:
-            - The X509 certificate used to create the service principal in PEM format.
+            - Path to the X509 certificate used to create the service principal in PEM format.
             - The certificate must be appended to the private key.
             - Use when authenticating with a Service Principal.
-        type: str
+        type: path
         version_added: '1.14.0'
     thumbprint:
         description:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -51,6 +51,8 @@ AZURE_COMMON_ARGS = dict(
     adfs_authority_url=dict(type='str', default=None),
     log_mode=dict(type='str', no_log=True),
     log_path=dict(type='str', no_log=True),
+    x509_certificate=dict(type='str', no_log=True),
+    thumbprint=dict(type='str', no_log=True),
 )
 
 AZURE_CREDENTIAL_ENV_MAPPING = dict(
@@ -63,7 +65,9 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
     password='AZURE_PASSWORD',
     cloud_environment='AZURE_CLOUD_ENVIRONMENT',
     cert_validation_mode='AZURE_CERT_VALIDATION_MODE',
-    adfs_authority_url='AZURE_ADFS_AUTHORITY_URL'
+    adfs_authority_url='AZURE_ADFS_AUTHORITY_URL',
+    x509_certificate='AZURE_X509_CERTIFICATE',
+    thumbprint='AZURE_THUMBPRINT'
 )
 
 
@@ -1440,7 +1444,8 @@ class AzureRMAuth(object):
 
     def __init__(self, auth_source=None, profile=None, subscription_id=None, client_id=None, secret=None,
                  tenant=None, ad_user=None, password=None, cloud_environment='AzureCloud', cert_validation_mode='validate',
-                 api_profile='latest', adfs_authority_url=None, fail_impl=None, is_ad_resource=False, **kwargs):
+                 api_profile='latest', adfs_authority_url=None, fail_impl=None, is_ad_resource=False,
+                 x509_certificate=None, thumbprint=None, **kwargs):
 
         if fail_impl:
             self._fail_impl = fail_impl
@@ -1461,7 +1466,9 @@ class AzureRMAuth(object):
             cloud_environment=cloud_environment,
             cert_validation_mode=cert_validation_mode,
             api_profile=api_profile,
-            adfs_authority_url=adfs_authority_url)
+            adfs_authority_url=adfs_authority_url,
+            x509_certificate=x509_certificate,
+            thumbprint=thumbprint)
 
         if not self.credentials:
             if HAS_AZURE_CLI_CORE:
@@ -1538,6 +1545,19 @@ class AzureRMAuth(object):
             self.azure_credential_track2 = client_secret.ClientSecretCredential(client_id=self.credentials['client_id'],
                                                                                 client_secret=self.credentials['secret'],
                                                                                 tenant_id=self.credentials['tenant'])
+
+        elif self.credentials.get('client_id') is not None and \
+                self.credentials.get('tenant') is not None and \
+                self.credentials.get('thumbprint') is not None and \
+                self.credentials.get('x509_certificate') is not None:
+
+            self.azure_credentials = self.acquire_token_with_client_certificate(
+                self._adfs_authority_url,
+                self._cloud_environment.endpoints.active_directory_resource_id,
+                self.credentials['x509_certificate'],
+                self.credentials['thumbprint'],
+                self.credentials['client_id'],
+                self.credentials['tenant'])
 
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
             tenant = self.credentials.get('tenant')
@@ -1735,6 +1755,17 @@ class AzureRMAuth(object):
 
         context = AuthenticationContext(authority_uri)
         token_response = context.acquire_token_with_username_password(resource, username, password, client_id)
+
+        return AADTokenCredentials(token_response)
+
+    def acquire_token_with_client_certificate(self, authority, resource, x509_certificate, thumbprint, client_id, tenant):
+        authority_uri = authority
+
+        if tenant is not None:
+            authority_uri = authority + '/' + tenant
+
+        context = AuthenticationContext(authority_uri)
+        token_response = context.acquire_token_with_client_certificate(resource, client_id, x509_certificate, thumbprint)
 
         return AADTokenCredentials(token_response)
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -51,7 +51,7 @@ AZURE_COMMON_ARGS = dict(
     adfs_authority_url=dict(type='str', default=None),
     log_mode=dict(type='str', no_log=True),
     log_path=dict(type='str', no_log=True),
-    x509_certificate=dict(type='path', no_log=True),
+    x509_certificate_path=dict(type='path', no_log=True),
     thumbprint=dict(type='str', no_log=True),
 )
 
@@ -66,7 +66,7 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
     cloud_environment='AZURE_CLOUD_ENVIRONMENT',
     cert_validation_mode='AZURE_CERT_VALIDATION_MODE',
     adfs_authority_url='AZURE_ADFS_AUTHORITY_URL',
-    x509_certificate='AZURE_X509_CERTIFICATE',
+    x509_certificate_path='AZURE_X509_CERTIFICATE_PATH',
     thumbprint='AZURE_THUMBPRINT'
 )
 
@@ -1445,7 +1445,7 @@ class AzureRMAuth(object):
     def __init__(self, auth_source=None, profile=None, subscription_id=None, client_id=None, secret=None,
                  tenant=None, ad_user=None, password=None, cloud_environment='AzureCloud', cert_validation_mode='validate',
                  api_profile='latest', adfs_authority_url=None, fail_impl=None, is_ad_resource=False,
-                 x509_certificate=None, thumbprint=None, **kwargs):
+                 x509_certificate_path=None, thumbprint=None, **kwargs):
 
         if fail_impl:
             self._fail_impl = fail_impl
@@ -1467,7 +1467,7 @@ class AzureRMAuth(object):
             cert_validation_mode=cert_validation_mode,
             api_profile=api_profile,
             adfs_authority_url=adfs_authority_url,
-            x509_certificate=x509_certificate,
+            x509_certificate_path=x509_certificate_path,
             thumbprint=thumbprint)
 
         if not self.credentials:
@@ -1549,19 +1549,19 @@ class AzureRMAuth(object):
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
                 self.credentials.get('thumbprint') is not None and \
-                self.credentials.get('x509_certificate') is not None:
+                self.credentials.get('x509_certificate_path') is not None:
 
             self.azure_credentials = self.acquire_token_with_client_certificate(
                 self._adfs_authority_url,
                 self._cloud_environment.endpoints.active_directory_resource_id,
-                self.credentials['x509_certificate'],
+                self.credentials['x509_certificate_path'],
                 self.credentials['thumbprint'],
                 self.credentials['client_id'],
                 self.credentials['tenant'])
 
             self.azure_credential_track2 = certificate.CertificateCredential(tenant_id=self.credentials['tenant'],
                                                                              client_id=self.credentials['client_id'],
-                                                                             certificate_path=self.credentials['x509_certificate'])
+                                                                             certificate_path=self.credentials['x509_certificate_path'])
 
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
             tenant = self.credentials.get('tenant')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable authentication with x509 certificate for Service principals, instead of a password.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request