### PR TITLE
Replace config with _config in azure_rm_common.py to support azure-mgmt-network latest version

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -926,9 +926,11 @@ class AzureRMModuleBase(object):
 
         if not is_track2:
             client.config = self.add_user_agent(client.config)
-
-        if self.azure_auth._cert_validation_mode == 'ignore':
-            client.config.session_configuration_callback = self._validation_ignore_callback
+            if self.azure_auth._cert_validation_mode == 'ignore':
+                client.config.session_configuration_callback = self._validation_ignore_callback
+        else:
+            if self.azure_auth._cert_validation_mode == 'ignore':
+                client._config.session_configuration_callback = self._validation_ignore_callback
 
         return client
 

--- a/tests/integration/targets/azure_rm_privateendpoint/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpoint/tasks/main.yml
@@ -64,8 +64,9 @@
           - postgresqlServer
     subnet:
       id: "{{ subnet_output.state.id }}"
-    tags: 
+    tags:
       key1: value1
+    cert_validation_mode: ignore
   register: output
 
 - name: Assert status succeeded and results match expectations


### PR DESCRIPTION
##### SUMMARY

In azure-mgmt-network version 16.0.0 (or later), `config` seems to have been replaced with `_config`. `config` is only used in some logic, but it raises an AttributeError, especially when `cert_validation_mode: ignore` is specified.
This PR replaces `config` with `_config` to address this matter.

- Fixes #903 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- plugins/module_utils/azure_rm_common.py

##### ADDITIONAL INFORMATION
None