### PR TITLE
Remove started default parameters

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -55,7 +55,6 @@ options:
             - Whether the VM is started or stopped.
             - Set to (true) with I(state=present) to start the VM.
             - Set to C(false) to stop the VM.
-        default: true
         type: bool
     allocated:
         description:
@@ -897,7 +896,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             subnet_name=dict(type='str', aliases=['subnet']),
             allocated=dict(type='bool', default=True),
             restarted=dict(type='bool', default=False),
-            started=dict(type='bool', default=True),
+            started=dict(type='bool'),
             generalized=dict(type='bool', default=False),
             data_disks=dict(type='list'),
             plan=dict(type='dict'),

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -1218,7 +1218,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                              .format(self.name, vm_dict['powerstate']))
                     changed = True
                     powerstate_change = 'deallocated'
-                elif not self.started and vm_dict['powerstate'] == 'running':
+                elif self.started is not None and not self.started and vm_dict['powerstate'] == 'running':
                     self.log("CHANGED: virtual machine {0} running and requested state 'stopped'".format(self.name))
                     changed = True
                     powerstate_change = 'poweroff'

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_deallocate.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_deallocate.yml
@@ -60,6 +60,7 @@
     resource_group: "{{ resource_group }}"
     name: "{{ vm_name }}"
     vm_size: Standard_B1ms
+    started: True
   register: start_result
 
 - name: Ensure VM was started


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove azure_rm_vritualmachine's started default value. It will update VM status when attach new tags to VM. try to fix #721 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
