### PR TITLE
Vpngw generation add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.13.1 (2022-07-14)
+
+### FEATURE ENHANCEMENT
+  - azure_rm_virtualnetworkgateway: Added support for `vpn_gateway_generation` 
+
 ## v1.13.0 (2022-05-27)
 
 ### NEW MODULES
@@ -60,7 +65,7 @@
   - azcollection: Install collection to local directory during development ([#763](https://github.com/ansible-collections/azure/pull/763))
 
 ### BREAKING CHANGES:
-  - azure_rm_virtualmachinescaleset: Change default value of `single_placement_group` from `True` to `Flase` ([#851](https://github.com/ansible-collections/azure/pull/851))
+  - azure_rm_virtualmachinescaleset: Change default value of `single_placement_group` from `True` to `False` ([#851](https://github.com/ansible-collections/azure/pull/851))
 
 ## v1.12.0 (2022-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Change Log
 
-## v1.13.1 (2022-07-14)
-
-### FEATURE ENHANCEMENT
-  - azure_rm_virtualnetworkgateway: Added support for `vpn_gateway_generation` 
-
 ## v1.13.0 (2022-05-27)
 
 ### NEW MODULES

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: azure
 name: azcollection
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.13.0
+version: 1.13.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: azure
 name: azcollection
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.13.1
+version: 1.13.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -98,7 +98,7 @@ AZURE_API_PROFILES = {
             virtual_machine_run_commands='2018-10-01'
         ),
         'ManagementGroupsClient': '2020-05-01',
-        'NetworkManagementClient': '2019-06-01',
+        'NetworkManagementClient': '2019-11-01',
         'ResourceManagementClient': '2017-05-10',
         'SearchManagementClient': '2020-08-01',
         'StorageManagementClient': '2021-06-01',

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -102,7 +102,7 @@ options:
             - HighPerformance
     vpn_gateway_generation:
         description:
-            - The generation for this VirtualNetworkGateway. Must be C(None) if C(gateway_type) is not VPN. 
+            - The generation for this VirtualNetworkGateway. Must be C(None) if C(gateway_type) is not VPN.
         default: Generation1
         choices:
             - None

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -100,6 +100,14 @@ options:
             - Standard
             - Basic
             - HighPerformance
+    vpn_gateway_generation:
+        description:
+            - The generation for this VirtualNetworkGateway. Must be C(None) if C(gateway_type) is not VPN. 
+        default: Generation1
+        choices:
+            - None
+            - Generation1
+            - Generation2
     bgp_settings:
         description:
             - Virtual network gateway's BGP speaker settings.
@@ -122,6 +130,20 @@ EXAMPLES = '''
       azure_rm_virtualnetworkgateway:
         resource_group: myResourceGroup
         name: myVirtualNetworkGateway
+        ip_configurations:
+          - name: testipconfig
+            private_ip_allocation_method: Dynamic
+            public_ip_address_name: testipaddr
+        virtual_network: myVirtualNetwork
+        tags:
+          common: "xyz"
+
+    - name: Create virtual network gateway Generation2
+      azure_rm_virtualnetworkgateway:
+        resource_group: myResourceGroup
+        name: myVirtualNetworkGateway
+        sku: vpn_gw2
+        vpn_gateway_generation: Generation2
         ip_configurations:
           - name: testipconfig
             private_ip_allocation_method: Dynamic
@@ -203,6 +225,7 @@ def vgw_to_dict(vgw):
         location=vgw.location,
         gateway_type=vgw.gateway_type,
         vpn_type=vgw.vpn_type,
+        vpn_gateway_generation=vgw.vpn_gateway_generation,
         enable_bgp=vgw.enable_bgp,
         tags=vgw.tags,
         provisioning_state=vgw.provisioning_state,
@@ -232,6 +255,7 @@ class AzureRMVirtualNetworkGateway(AzureRMModuleBase):
             ip_configurations=dict(type='list', default=None, elements='dict', options=ip_configuration_spec),
             gateway_type=dict(type='str', default='vpn', choices=['vpn', 'express_route']),
             vpn_type=dict(type='str', default='route_based', choices=['route_based', 'policy_based']),
+            vpn_gateway_generation=dict(type='str', default='Generation1', choices=['None', 'Generation1', 'Generation2']),
             enable_bgp=dict(type='bool', default=False),
             sku=dict(default='VpnGw1', choices=['VpnGw1', 'VpnGw2', 'VpnGw3', 'Standard', 'Basic', 'HighPerformance']),
             bgp_settings=dict(type='dict', options=bgp_spec),
@@ -247,6 +271,7 @@ class AzureRMVirtualNetworkGateway(AzureRMModuleBase):
         self.vpn_type = None
         self.enable_bgp = None
         self.sku = None
+        self.vpn_gateway_generation = None
         self.bgp_settings = None
 
         self.results = dict(
@@ -342,6 +367,7 @@ class AzureRMVirtualNetworkGateway(AzureRMModuleBase):
                     ip_configurations=vgw_ip_configurations,
                     gateway_type=_snake_to_camel(self.gateway_type, True),
                     vpn_type=_snake_to_camel(self.vpn_type, True),
+                    vpn_gateway_generation=_snake_to_camel(self.vpn_gateway_generation, True),
                     enable_bgp=self.enable_bgp,
                     sku=vgw_sku,
                     bgp_settings=vgw_bgp_settings

--- a/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
@@ -4,6 +4,7 @@
   set_fact:
     vnetname: "vnet{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
     vngname: "vng{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    pubipname: "testPublicIP{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
 - name: Create virtual network gateway without bgp settings (check mode)
   check_mode: yes
@@ -13,7 +14,7 @@
     ip_configurations:
       - name: testipconfig
         private_ip_allocation_method: Dynamic
-        public_ip_address_name: testPublicIP
+        public_ip_address_name: "{{ pubipname }}"
     virtual_network: "{{ vnetname }}"
     tags:
       common: "xyz"
@@ -21,6 +22,25 @@
 
 - assert:
     that: output.changed
+
+- name: Create virtual network gateway Generation2 (check mode)
+  check_mode: yes
+  azure_rm_virtualnetworkgateway:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vngname }}"
+    sku: VpnGw2
+    vpn_gateway_generation: Generation2
+    ip_configurations:
+      - name: testipconfig
+        private_ip_allocation_method: Dynamic
+        public_ip_address_name: "{{ pubipname }}"
+    virtual_network: "{{ vnetname }}"
+    tags:
+      common: "xyz"
+
+- assert:
+    that: output.changed
+
 
 - name: long-running virtualnetworkgateway tests [run with `--tags long_run,untagged` to enable]
   tags: [long_run, never]
@@ -42,7 +62,7 @@
     azure_rm_publicipaddress:
         resource_group: "{{ resource_group }}"
         allocation_method: Dynamic
-        name: testPublicIP
+        name: "{{ pubipname }}"
 
   - name: Create virtual network gateway without bgp settings
     azure_rm_virtualnetworkgateway:
@@ -67,7 +87,7 @@
       ip_configurations:
         - name: testipconfig
           private_ip_allocation_method: Dynamic
-          public_ip_address_name: testPublicIP
+          public_ip_address_name: "{{ pubipname }}"
       virtual_network: "{{ vnetname }}"
       tags:
         common: "xyz"
@@ -83,10 +103,76 @@
       ip_configurations:
         - name: testipconfig
           private_ip_allocation_method: Dynamic
-          public_ip_address_name: testPublicIP
+          public_ip_address_name: "{{ pubipname }}"
       virtual_network: "{{ vnetname }}"
       tags:
         common: "mno"
+    register: output
+  - assert:
+      that: output.changed
+
+  - name: Delete virtual network gateway
+    azure_rm_virtualnetworkgateway:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vngname }}"
+      state: absent
+    register: output
+  - assert:
+      that: output.changed
+
+- name: long-running generation virtualnetworkgateway tests [run with `--tags long_run_gen,untagged` to enable]
+  tags: [long_run_gen, never]
+  block:
+  - name: Create virtual network
+    azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vnetname }}"
+        address_prefixes: "10.0.0.0/16"
+
+  - name: Add subnet
+    azure_rm_subnet:
+        resource_group: "{{ resource_group }}"
+        name: GatewaySubnet
+        address_prefix: "10.0.2.0/24"
+        virtual_network: "{{ vnetname }}"
+
+  - name: Create public IP address
+    azure_rm_publicipaddress:
+        resource_group: "{{ resource_group }}"
+        allocation_method: Dynamic
+        name: "{{ pubipname }}"
+
+  - name: Create virtual network gateway w/ sku and Generation2
+    azure_rm_virtualnetworkgateway:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vngname }}"
+      sku: VpnGw2
+      vpn_gateway_generation: Generation2
+      ip_configurations:
+        - name: testipconfig
+          private_ip_allocation_method: Dynamic
+          public_ip_address_name: "{{ pubipname }}"
+      virtual_network: "{{ vnetname }}"
+      tags:
+        common: "xyz"
+
+  - assert:
+      that: output.changed
+
+  - name: Update virtual network gateway
+    azure_rm_virtualnetworkgateway:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vngname }}"
+      sku: VpnGw2
+      vpn_gateway_generation: Generation2
+      ip_configurations:
+        - name: testipconfig
+          private_ip_allocation_method: Dynamic
+          public_ip_address_name: "{{ pubipname }}"
+      virtual_network: "{{ vnetname }}"
+      tags:
+        common: "mno"
+
     register: output
   - assert:
       that: output.changed
@@ -108,3 +194,25 @@
   register: output
 - assert:
     that: not output.changed
+
+# Clean up networking components after test
+- name: Delete subnet
+  azure_rm_subnet:
+    resource_group: "{{ resource_group }}"
+    name: GatewaySubnet
+    virtual_network: "{{ vnetname }}"
+    state: absent
+  
+
+- name: Delete public IP address
+  azure_rm_publicipaddress:
+    resource_group: "{{ resource_group }}"
+    allocation_method: Dynamic
+    name: "{{ pubipname }}"
+    state: absent
+
+- name: Delete virtual network
+  azure_rm_virtualnetwork:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vnetname }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I needed the ability to set the Generation of the VirtualNetworkGateway and wanted to contribute this to the community.
Adding the ability to set Virtual Network Gateway Generation in azure_rm_virtualnetworkgateway module. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/module_utils/azure_rm_common.py
plugins/modules/azure_rm_virtualnetworkgateway.py
tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Adding support for setting VPNGW generation
- Updated azure_rm_common.py NetworkManagementClient version to 2019-11-01
- Updated azure_rm_virtualnetworkgateway.py for additional input and choices of VPNGW Generation options as outlined in SDK
- Updated integration test to generate public ip name in same method as vngname for multiple runs
- Updated integration tests adding block for gen setting and clean up of VNET/SUBNET/PUBIP after test and delete of VPNGW

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Create virtual network gateway without bgp settings
  azure_rm_virtualnetworkgateway:
    resource_group: "{{ resource_group }}"
    name: "{{ vngname }}"
    ip_configurations:
      - name: testipconfig
        private_ip_allocation_method: Dynamic
        public_ip_address_name: "{{ pubipname }}"
    virtual_network: "{{ vnetname }}"
    tags:
      common: "xyz"
```
```yaml
- name: Create virtual network gateway Generation2 (check mode)
  check_mode: yes
  azure_rm_virtualnetworkgateway:
    resource_group: "{{ resource_group }}"
    name: "{{ vngname }}"
    sku: VpnGw2
    vpn_gateway_generation: Generation2
    ip_configurations:
      - name: testipconfig
        private_ip_allocation_method: Dynamic
        public_ip_address_name: "{{ pubipname }}" #testPublicIP
    virtual_network: "{{ vnetname }}"
    tags:
      common: "xyz"
```
