### PR TITLE
Adding missing functionality to azure_rm_keyvaultkey

### DIFF
--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -27,6 +27,7 @@ options:
     key_type:
         description:
             - The type of key to create. For valid values, see JsonWebKeyType. Possible values include EC, EC-HSM, RSA, RSA-HSM, oct
+        default: 'RSA'
     key_size:
         description:
             - The key size in bits. For example 2048, 3072, or 4096 for RSA.

--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -26,16 +26,25 @@ options:
         required: true
     key_type:
         description:
-            - The type of key to create. For valid values, see JsonWebKeyType. Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'.
+            - The type of key to create. For valid values, see JsonWebKeyType. Possible values include EC, EC-HSM, RSA, RSA-HSM, oct
     key_size:
         description:
-            - The key size in bits. For example: 2048, 3072, or 4096 for RSA.
+            - The key size in bits. For example 2048, 3072, or 4096 for RSA.
     key_attributes:
         description:
-            - Possible values include: 'enabled', 'not_before', 'expires'.
+            - The attributes of a key managed by the key vault service.
+        suboptions:
+            enabled:
+                description: bool
+            not_before:
+                description:
+                    - not valid before date in UTC ISO format without the Z at the end
+            expires:
+                description:
+                    - not valid after date in UTC ISO format without the Z at the end
     curve:
         description:
-            - Elliptic curve name. For valid values, see JsonWebKeyCurveName. Possible values include - 'P-256', 'P-384', 'P-521', 'P-256K'.
+            - Elliptic curve name. For valid values, see JsonWebKeyCurveName. Possible values include P-256, P-384, P-521, P-256K.
     byok_file:
         description:
             - BYOK file.
@@ -111,6 +120,7 @@ key_addribute_spec = dict(
     expires=dict(type='str', no_log=True, required=False)
 )
 
+
 class AzureRMKeyVaultKey(AzureRMModuleBase):
     ''' Module that creates or deletes keys in Azure KeyVault '''
 
@@ -121,7 +131,7 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
             keyvault_uri=dict(type='str', no_log=True, required=True),
             key_type=dict(type='str', default='RSA'),
             key_size=dict(type='int'),
-            key_attributes=dict(type='dict', options=key_addribute_spec),
+            key_attributes=dict(type='dict', no_log=True, options=key_addribute_spec),
             curve=dict(type='str'),
             pem_file=dict(type='str'),
             pem_password=dict(type='str', no_log=True),
@@ -265,7 +275,7 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
             key_attributes = KeyAttributes(k_enabled, k_not_before, k_expires)
 
         key_bundle = self.client.create_key(vault_base_url=self.keyvault_uri, key_name=name, kty=key_type, key_size=key_size,
-                key_attributes=key_attributes, curve=curve, tags=tags)
+                                            key_attributes=key_attributes, curve=curve, tags=tags)
         key_id = KeyVaultId.parse_key_id(key_bundle.key.kid)
         return key_id.id
 

--- a/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
@@ -74,6 +74,90 @@
     key_name: testkey
   register: output
 
+- name: create a kevyault key of type EC
+  block:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        key_name: testkeyEC
+        key_type: EC
+        tags:
+          testing: test
+          delete: on-exit
+      register: output
+    - assert:
+        that: output.changed
+  rescue:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        state: absent
+        key_name: testkeyEC
+
+- name: delete a kevyault key of type EC
+  azure_rm_keyvaultkey:
+    keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+    state: absent
+    key_name: testkeyEC
+  register: output
+
+- name: create a kevyault key of size 4096
+  block:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        key_name: testkey4096
+        key_size: 4096
+        tags:
+          testing: test
+          delete: on-exit
+      register: output
+    - assert:
+        that: output.changed
+  rescue:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        state: absent
+        key_name: testkey4096
+
+- name: delete a kevyault key of size 4096
+  azure_rm_keyvaultkey:
+    keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+    state: absent
+    key_name: testkey4096
+  register: output
+
+- name: create a kevyault key with P-521 curve
+  block:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        key_name: testkeycurve
+        curve: P-521
+        tags:
+          testing: test
+          delete: on-exit
+      register: output
+    - assert:
+        that: output.changed
+  rescue:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        state: absent
+        key_name: testkeycurve
+
+- name: delete a kevyault key with P-521 curve
+  azure_rm_keyvaultkey:
+    keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+    state: absent
+    key_name: testkeycurve
+  register: output
+
+- assert:
+    that: output.changed
+
+- name: Delete instance of Key Vault
+  azure_rm_keyvault:
+    resource_group: "{{ resource_group }}"
+    vault_name: "vault{{ rpfx }}"
+    state: absent
+
 - assert:
     that: output.changed
 

--- a/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
@@ -149,14 +149,32 @@
     key_name: testkeycurve
   register: output
 
-- assert:
-    that: output.changed
+- name: create a kevyault key with attributes
+  block:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        key_name: testkeyattribute
+        key_attributes:
+          enabled: true
+          not_before: '2032-12-01T00:00:00Z'
+        tags:
+          testing: test
+          delete: on-exit
+      register: output
+    - assert:
+        that: output.changed
+  rescue:
+    - azure_rm_keyvaultkey:
+        keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
+        state: absent
+        key_name: testkeyattributes
 
-- name: Delete instance of Key Vault
-  azure_rm_keyvault:
-    resource_group: "{{ resource_group }}"
-    vault_name: "vault{{ rpfx }}"
+- name: delete a kevyault key with attributes
+  azure_rm_keyvaultkey:
+    keyvault_uri: https://vault{{ rpfx }}.vault.azure.net
     state: absent
+    key_name: testkeyattribute
+  register: output
 
 - assert:
     that: output.changed


### PR DESCRIPTION
This PR adds the following functionality to azure_rm_keyvaultkey:

key_type
key_attributes
key_size
curve

This functionality is provided by the Azure API however was not previously included in the azure_rm_keyvaultkey module.

integration tests for these were added as well.
```
ansible-test integration azure_rm_keyvaultkey --allow-destructive -v
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/vagrant/ansible/venv/bin/python3
Using existing azure cloud config: tests/integration/cloud-config-azure.ini
Creating container database.
Run command: /home/vagrant/ansible/venv/bin/python3 /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running azure_rm_keyvaultkey integration test role
Initializing "/tmp/ansible-test-xa7t3fjt-injector" as the temporary injector directory.
Injecting "/tmp/python-1aeslyq1-ansible/python" as a execv wrapper for the "/home/vagrant/ansible/venv/bin/python3" interpreter.
Stream command: ansible-playbook azure_rm_keyvaultkey-fpfcljkp.yml -i inventory -v
Using /home/vagrant/azure/ansible_collections/azure/azcollection/tests/output/.tmp/integration/azure_rm_keyvaultkey-e084z1mc-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
[WARNING]: running playbook inside collection azure.azcollection

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [azure_rm_keyvaultkey : Prepare random number] ****************************
ok: [testhost] => {"ansible_facts": {"rpfx": "118a04b572", "tenant_id": "3b61e7aa-5e89-42a8-9f57-77ce3b182f44"}, "changed": false}

TASK [azure_rm_keyvaultkey : lookup service principal object id] ***************
ok: [testhost] => {"ansible_facts": {"object_id": "52be3afb-69b0-4040-85fb-342e09b344bd"}, "changed": false}

TASK [azure_rm_keyvaultkey : Create instance of Key Vault] *********************
[WARNING]: Azure API profile latest does not define an entry for
KeyVaultManagementClient
changed: [testhost] => {"changed": true, "id": "/subscriptions/4ec8b540-dbc4-45d7-a0c0-cf3693d5639a/resourceGroups/dfinn-ansible-testing/providers/Microsoft.KeyVault/vaults/vault118a04b572"}

TASK [azure_rm_keyvaultkey : azure_rm_keyvaultkey] *****************************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkey/028b9290eadb4c08a0ddb83c6781b861", "status": "Created"}}

TASK [azure_rm_keyvaultkey : assert] *******************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [azure_rm_keyvaultkey : delete a kevyault key] ****************************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkey/028b9290eadb4c08a0ddb83c6781b861", "status": "Deleted"}}

TASK [azure_rm_keyvaultkey : azure_rm_keyvaultkey] *****************************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkeyEC/cf7e3747374445b1b3f7b2abfd2b097d", "status": "Created"}}

TASK [azure_rm_keyvaultkey : assert] *******************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [azure_rm_keyvaultkey : delete a kevyault key of type EC] *****************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkeyEC/cf7e3747374445b1b3f7b2abfd2b097d", "status": "Deleted"}}

TASK [azure_rm_keyvaultkey : azure_rm_keyvaultkey] *****************************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkey4096/6eec511b951246068d2f1d6c6d28fbf7", "status": "Created"}}

TASK [azure_rm_keyvaultkey : assert] *******************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [azure_rm_keyvaultkey : delete a kevyault key of size 4096] ***************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkey4096/6eec511b951246068d2f1d6c6d28fbf7", "status": "Deleted"}}

TASK [azure_rm_keyvaultkey : azure_rm_keyvaultkey] *****************************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkeycurve/2275d963c2cd454193bc5e88c392f561", "status": "Created"}}

TASK [azure_rm_keyvaultkey : assert] *******************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [azure_rm_keyvaultkey : delete a kevyault key with P-521 curve] ***********
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkeycurve/2275d963c2cd454193bc5e88c392f561", "status": "Deleted"}}

TASK [azure_rm_keyvaultkey : azure_rm_keyvaultkey] *****************************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkeyattribute/a0027991846e43f682034d3d6474b5f4", "status": "Created"}}

TASK [azure_rm_keyvaultkey : assert] *******************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [azure_rm_keyvaultkey : delete a kevyault key with attributes] ************
changed: [testhost] => {"changed": true, "state": {"key_id": "********/keys/testkeyattribute/a0027991846e43f682034d3d6474b5f4", "status": "Deleted"}}

TASK [azure_rm_keyvaultkey : assert] *******************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [azure_rm_keyvaultkey : Delete instance of Key Vault] *********************
changed: [testhost] => {"changed": true}

PLAY RECAP *********************************************************************
testhost                   : ok=21   changed=12   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

sanity test output:
```
ansible-test sanity azure_rm_keyvaultkey --color --junit -v
Creating container database.
Read 269 sanity test ignore line(s) for Ansible 2.13 from: tests/sanity/ignore-2.13.txt
Loaded configuration: tests/config.yml
Running sanity test "action-plugin-docs"
Initializing "/tmp/ansible-test-7tbkql5m-injector" as the temporary injector directory.
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/action-plugin-docs.py
Running sanity test "ansible-doc"
Run command: ansible-doc -t module azure.azcollection.azure_rm_keyvaultkey
Run command: ansible-doc -t module --json azure.azcollection.azure_rm_keyvaultkey
Running sanity test "changelog"
No tests applicable.
Running sanity test "compile" on Python 2.7
No tests applicable.
Running sanity test "compile" on Python 3.5
No tests applicable.
WARNING: Skipping sanity test "compile" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.7 because it could not be found.
Running sanity test "compile" on Python 3.8
Run command with data: /home/vagrant/ansible/venv/bin/python3 /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/target/sanity/compile/compile.py
WARNING: Skipping sanity test "compile" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.10 because it could not be found.
Running sanity test "empty-init"
No tests applicable.
Running sanity test "future-import-boilerplate"
No tests applicable.
Running sanity test "ignores"
Running sanity test "import" on Python 2.7
No tests applicable.
Running sanity test "import" on Python 3.5
No tests applicable.
WARNING: Skipping sanity test "import" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.7 because it could not be found.
Running sanity test "import" on Python 3.8
Run command with data: importer.py
WARNING: Skipping sanity test "import" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.10 because it could not be found.
Running sanity test "line-endings"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/line-endings.py
Running sanity test "metaclass-boilerplate"
No tests applicable.
Running sanity test "no-assert"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-assert.py
Running sanity test "no-basestring"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-basestring.py
Running sanity test "no-dict-iteritems"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-dict-iteritems.py
Running sanity test "no-dict-iterkeys"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-dict-iterkeys.py
Running sanity test "no-dict-itervalues"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-dict-itervalues.py
Running sanity test "no-get-exception"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-get-exception.py
Running sanity test "no-illegal-filenames"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-illegal-filenames.py
Running sanity test "no-main-display"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-main-display.py
Running sanity test "no-smart-quotes"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-smart-quotes.py
Running sanity test "no-unicode-literals"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/no-unicode-literals.py
Running sanity test "pep8"
Run command: /home/vagrant/.ansible/test/venv/sanity.pep8/3.8/24fe57a3/bin/python -m pycodestyle --max-line-length 160 --config /dev/null --ignore E402,E741,W503,W504 plugins/modules/azure_rm_keyvaultkey.py
Running sanity test "pslint"
No tests applicable.
Running sanity test "pylint"
Run command: /home/vagrant/.ansible/test/venv/sanity.pylint/3.8/1d079f27/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/tools/collection_detail.py /home/vagrant/azure/ansible_collections/azure/azcollection
Checking 1 file(s) in context "modules" with config: /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
Run command: /home/vagrant/.ansible/test/venv/sanity.pylint/3.8/1d079f27/bin/python -m pylint --jobs 0 --reports n --max-line-length 160 --max-complexity 20 --rcfile /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/pylint/co ...
Running sanity test "replace-urlopen"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/replace-urlopen.py
Running sanity test "runtime-metadata"
No tests applicable.
Running sanity test "shebang"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/shebang.py
Running sanity test "shellcheck"
No tests applicable.
Running sanity test "symlinks"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/symlinks.py
Running sanity test "use-argspec-type-path"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/use-argspec-type-path.py
Running sanity test "use-compat-six"
Run command with data: /home/vagrant/.ansible/test/venv/sanity/3.8/4f53cda1/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/code-smell/use-compat-six.py
Running sanity test "validate-modules"
Run command: /home/vagrant/.ansible/test/venv/sanity.validate-modules/3.8/487215fd/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/tools/collection_detail.py /home/vagrant/azure/ansible_collections/azure/azcollection
Run command: /home/vagrant/.ansible/test/venv/sanity.validate-modules/3.8/487215fd/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate.py --format json --arg-spec --collection ansible_collec ...
Running sanity test "yamllint"
Run command with data: /home/vagrant/.ansible/test/venv/sanity.yamllint/3.8/3419780d/bin/python /home/vagrant/ansible/venv/lib/python3.8/site-packages/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
WARNING: Reviewing previous 8 warning(s):
WARNING: Skipping sanity test "compile" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.7 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.10 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.7 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.10 because it could not be found.
```