### PR TITLE
Fix a typo in runtime.yml for azure_rm_virtualmachinescalesetinstance_info

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -246,7 +246,7 @@ action_groups:
   - azure.azcollection.azure_rm_virtualmachinescalesetextension
   - azure.azcollection.azure_rm_virtualmachinescalesetextension_info
   - azure.azcollection.azure_rm_virtualmachinescalesetinstance
-  - azure.azcollection.azure_rm_virtualmachinescalesetinstance_inpy
+  - azure.azcollection.azure_rm_virtualmachinescalesetinstance_info
   - azure.azcollection.azure_rm_virtualmachinesize_info
   - azure.azcollection.azure_rm_virtualnetwork
   - azure.azcollection.azure_rm_virtualnetwork_info


### PR DESCRIPTION
##### SUMMARY

Updates a typo in the existing runtime.yml file preventing setting of default arguments to the `azure_rm_virtualmachinescalesetinstance_info` module.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

runtime.yml

##### ADDITIONAL INFORMATION

Solves issue where the `module_defaults` feature is not able to be used in conjunction with the `azure_rm_virtualmachinescalesetinstance_info` module.
