### PR TITLE
support for environment variable ANSIBLE_AZURE_VM_RESOURCE_GROUPS

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -270,7 +270,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _get_hosts(self):
         if os.environ.get('ANSIBLE_AZURE_VM_RESOURCE_GROUPS'):
-            for vm_rg in  os.environ['ANSIBLE_AZURE_VM_RESOURCE_GROUPS'].split(","):
+            for vm_rg in os.environ['ANSIBLE_AZURE_VM_RESOURCE_GROUPS'].split(","):
                 self._enqueue_vm_list(vm_rg)
         else:
             for vm_rg in self.get_option('include_vm_resource_groups'):

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -113,6 +113,7 @@ import hashlib
 import json
 import re
 import uuid
+import os
 
 try:
     from queue import Queue, Empty
@@ -268,8 +269,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._enqueue_get(url=url, api_version=self._compute_api_version, handler=self._on_vmss_page_response)
 
     def _get_hosts(self):
-        for vm_rg in self.get_option('include_vm_resource_groups'):
-            self._enqueue_vm_list(vm_rg)
+        if os.environ.get('ANSIBLE_AZURE_VM_RESOURCE_GROUPS'):
+            for vm_rg in  os.environ['ANSIBLE_AZURE_VM_RESOURCE_GROUPS'].split(","):
+                self._enqueue_vm_list(vm_rg)
+        else:
+            for vm_rg in self.get_option('include_vm_resource_groups'):
+                self._enqueue_vm_list(vm_rg)
 
         for vmss_rg in self.get_option('include_vmss_resource_groups'):
             self._enqueue_vmss_list(vmss_rg)


### PR DESCRIPTION
##### SUMMARY
Hi I have a fix for: https://github.com/ansible-collections/azure/issues/152

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure inventory

##### ADDITIONAL INFORMATION
Environment variable ANSIBLE_AZURE_VM_RESOURCE_GROUPS is used if exists. If not self option 'include_vm_resource_groups' is in use
 
```
ANSIBLE_AZURE_VM_RESOURCE_GROUPS=my-first-rg,my-sec-rg ansible-inventory -i azure_rm.yaml --graph
```

