### PR TITLE
Ensure trailing slash on base_url

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -876,6 +876,12 @@ class AzureRMModuleBase(object):
             # most things are resource_manager, don't make everyone specify
             base_url = self.azure_auth._cloud_environment.endpoints.resource_manager
 
+        # https://github.com/Azure/msrestazure-for-python/pull/169
+        # China's base_url doesn't end in a trailing slash, though others do,
+        # and we need a trailing slash when generating credential_scopes below.
+        if not base_url.endswith("/"):
+            base_url += "/"
+
         mgmt_subscription_id = self.azure_auth.subscription_id
         if self.module.params.get('subscription_id'):
             mgmt_subscription_id = self.module.params.get('subscription_id')


### PR DESCRIPTION
##### SUMMARY
Ensure trailing slash on base_url

The `AZURE_CHINA_CLOUD.endpoints.resource_manager` and
`AZURE_GERMAN_CLOUD.endpoints.resource_manager` URLs don't end with a
trailing slash, but the `AZURE_PUBLIC_CLOUD` and `AZURE_US_GOV_CLOUD` URLs
do. This commit ensures consistency despite that.

https://github.com/Azure/msrestazure-for-python/blob/8849f398b6ebd4607de63c2f5d1318f44ec1d822/msrestazure/azure_cloud.py#L137

Without this, `base_url` is set to `'https://management.chinacloudapi.cn'`:

https://github.com/ansible-collections/azure/blob/256ed011ea3d2e15616529034f53078dcefd9d2d/plugins/module_utils/azure_rm_common.py#L877

And then `credential_scopes` is set to `[base_url + ".default"]`:

https://github.com/ansible-collections/azure/blob/256ed011ea3d2e15616529034f53078dcefd9d2d/plugins/module_utils/azure_rm_common.py#L892

Which results in an invalid `credential_scopes` of
`["https://management.chinacloudapi.cn.default"]` rather than
`["https://management.chinacloudapi.cn/.default"]`.

Fix also submitted upstream:
https://github.com/Azure/msrestazure-for-python/pull/169

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`azure_rm_common`