### PR TITLE
Use creds in module args when auth_source is auto

### DIFF
--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -222,7 +222,10 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
-        elif self.module.params['auth_source'] in ['auto', 'cli']:
+        elif (self.module.params['auth_source'] == 'cli'
+                or (self.module.params['auth_source'] == 'auto'
+                    and self.credentials['client_id'] is None
+                    and self.credentials['secret'] is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -321,7 +321,10 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
-        elif self.module.params['auth_source'] in ['auto', 'cli']:
+        elif (self.module.params['auth_source'] == 'cli'
+                or (self.module.params['auth_source'] == 'auto'
+                    and self.credentials['client_id'] is None
+                    and self.credentials['secret'] is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -207,7 +207,10 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
-        elif self.module.params['auth_source'] in ['auto', 'cli']:
+        elif (self.module.params['auth_source'] == 'cli'
+                or (self.module.params['auth_source'] == 'auto'
+                    and self.credentials['client_id'] is None
+                    and self.credentials['secret'] is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(

--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -275,7 +275,10 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
                 return KeyVaultClient(credentials)
             except Exception:
                 self.log("Get KeyVaultClient from service principal")
-        elif self.module.params['auth_source'] in ['auto', 'cli']:
+        elif (self.module.params['auth_source'] == 'cli'
+                or (self.module.params['auth_source'] == 'auto'
+                    and self.credentials['client_id'] is None
+                    and self.credentials['secret'] is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(


### PR DESCRIPTION
##### SUMMARY
When service principals are specified in the module arguments (subscription_id, tenant, client_id, secret) and auth_type is auto, azure_rm_keyvaultkey, azure_rm_keyvaultkey_info, azure_rm_keyvaultsecret, azure_rm_keyvaultsecret_info first attempted to use credentials from env and the disk and only use the specified credentials if not found.

Fixes #1009

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_keyvaultkey
azure_rm_keyvaultkey_info
azure_rm_keyvaultsecret
azure_rm_keyvaultsecret_info

##### ADDITIONAL INFORMATION
To reproduce, specify a service principal in `cloud-config-azure.ini` and run:

    `ansible-test integration azure_rm_keyvaultsecret --allow-destructive`

The test will succeed.  Then, do an `az login` and re-run the above command.  The test will fail.  Delete your cached credentials:

    `rm ~/.azure/msal_token_cache.json`

Run the test again. The test will succeed.
