### PR TITLE
Add synchronizing of VNet peering when sync level is `LocalNotInSync`

### DIFF
--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -102,6 +102,7 @@ peering_sync_level:
     description:
         - The Sync Level of the Peering
     type: str
+    returned: always
     sample: "FullyInSync"
 '''
 
@@ -290,14 +291,14 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             response = self.create_or_update_vnet_peering()
             self.results['id'] = response['id']
             to_be_synced = self.check_sync(response)
-        
+
         if to_be_synced:
             self.results['changed'] = True
 
             if self.check_mode:
                 return self.results
             sync_response = self.sync_vnet_peering()
-            self.results['peering_sync_level']  = sync_response['peering_sync_level']
+            self.results['peering_sync_level'] = sync_response['peering_sync_level']
 
         return self.results
 
@@ -322,12 +323,12 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
         else:
             self.fail("remote_virtual_network could be a valid resource id, dict of name and resource_group, name of virtual network in same resource group.")
         return remote_vnet_id
-    
+
     def check_sync(self, exisiting_vnet_peering):
         if exisiting_vnet_peering['peering_sync_level'] == 'LocalNotInSync':
             return True
         return False
-        
+
     def check_update(self, exisiting_vnet_peering):
         if self.allow_forwarded_traffic != exisiting_vnet_peering['allow_forwarded_traffic']:
             return True

--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -291,7 +291,6 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             self.results['id'] = response['id']
             to_be_synced = self.check_sync(response)
         
-        #update_response = self.get_vnet_peering()
         if to_be_synced:
             self.results['changed'] = True
 

--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -374,7 +374,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             allow_gateway_transit=self.allow_gateway_transit,
             allow_forwarded_traffic=self.allow_forwarded_traffic,
             use_remote_gateways=self.use_remote_gateways
-            )
+        )
 
         try:
             response = self.network_client.virtual_network_peerings.begin_create_or_update(self.resource_group,
@@ -387,7 +387,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             return vnetpeering_to_dict(response)
         except Exception as exc:
             self.fail("Error creating Azure Virtual Network Peering: {0}.".format(exc.message))
-        
+
     def create_or_update_vnet_peering(self):
         '''
         Creates or Update Azure Virtual Network Peering.
@@ -409,7 +409,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             allow_gateway_transit=self.allow_gateway_transit,
             allow_forwarded_traffic=self.allow_forwarded_traffic,
             use_remote_gateways=self.use_remote_gateways
-            )
+        )
 
         try:
             response = self.network_client.virtual_network_peerings.begin_create_or_update(self.resource_group,

--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -451,7 +451,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
                                                                         self.virtual_network['name'],
                                                                         self.name)
             self.log("Response : {0}".format(response))
-            
+
             return vnetpeering_to_dict(response)
         except ResourceNotFoundError:
             self.log('Did not find the Virtual Network Peering.')

--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -450,8 +450,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
                                                                         self.virtual_network['name'],
                                                                         self.name)
             self.log("Response : {0}".format(response))
-            #print(response)
-            # self.result['extra'] = response
+            
             return vnetpeering_to_dict(response)
         except ResourceNotFoundError:
             self.log('Did not find the Virtual Network Peering.')

--- a/plugins/modules/azure_rm_virtualnetworkpeering.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering.py
@@ -98,6 +98,11 @@ id:
     type: str
     sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVirtualN
              etwork/virtualNetworkPeerings/myPeering"
+peering_sync_level:
+    description:
+        - The Sync Level of the Peering
+    type: str
+    sample: "FullyInSync"
 '''
 
 try:
@@ -152,7 +157,8 @@ def vnetpeering_to_dict(vnetpeering):
         allow_gateway_transit=vnetpeering.allow_gateway_transit,
         allow_forwarded_traffic=vnetpeering.allow_forwarded_traffic,
         allow_virtual_network_access=vnetpeering.allow_virtual_network_access,
-        etag=vnetpeering.etag
+        etag=vnetpeering.etag,
+        peering_sync_level=vnetpeering.peering_sync_level
     )
     return results
 
@@ -220,6 +226,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             setattr(self, key, kwargs[key])
 
         to_be_updated = False
+        to_be_synced = False
 
         resource_group = self.get_resource_group(self.resource_group)
 
@@ -248,6 +255,7 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
 
                 # check if update
                 to_be_updated = self.check_update(response)
+                to_be_synced = self.check_sync(response)
 
             else:
                 # not exists, create new vnet peering
@@ -281,6 +289,16 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
 
             response = self.create_or_update_vnet_peering()
             self.results['id'] = response['id']
+            to_be_synced = self.check_sync(response)
+        
+        #update_response = self.get_vnet_peering()
+        if to_be_synced:
+            self.results['changed'] = True
+
+            if self.check_mode:
+                return self.results
+            sync_response = self.sync_vnet_peering()
+            self.results['peering_sync_level']  = sync_response['peering_sync_level']
 
         return self.results
 
@@ -305,7 +323,12 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
         else:
             self.fail("remote_virtual_network could be a valid resource id, dict of name and resource_group, name of virtual network in same resource group.")
         return remote_vnet_id
-
+    
+    def check_sync(self, exisiting_vnet_peering):
+        if exisiting_vnet_peering['peering_sync_level'] == 'LocalNotInSync':
+            return True
+        return False
+        
     def check_update(self, exisiting_vnet_peering):
         if self.allow_forwarded_traffic != exisiting_vnet_peering['allow_forwarded_traffic']:
             return True
@@ -330,6 +353,41 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             return results
         return False
 
+    def sync_vnet_peering(self):
+        '''
+        Creates or Update Azure Virtual Network Peering.
+
+        :return: deserialized Azure Virtual Network Peering instance state dictionary
+        '''
+        self.log("Creating or Updating the Azure Virtual Network Peering {0}".format(self.name))
+
+        vnet_id = format_resource_id(self.virtual_network['name'],
+                                     self.subscription_id,
+                                     'Microsoft.Network',
+                                     'virtualNetworks',
+                                     self.virtual_network['resource_group'])
+        peering = self.network_models.VirtualNetworkPeering(
+            id=vnet_id,
+            name=self.name,
+            remote_virtual_network=self.network_models.SubResource(id=self.remote_virtual_network),
+            allow_virtual_network_access=self.allow_virtual_network_access,
+            allow_gateway_transit=self.allow_gateway_transit,
+            allow_forwarded_traffic=self.allow_forwarded_traffic,
+            use_remote_gateways=self.use_remote_gateways
+            )
+
+        try:
+            response = self.network_client.virtual_network_peerings.begin_create_or_update(self.resource_group,
+                                                                                           self.virtual_network['name'],
+                                                                                           self.name,
+                                                                                           peering,
+                                                                                           sync_remote_address_space=True)
+            if isinstance(response, LROPoller):
+                response = self.get_poller_result(response)
+            return vnetpeering_to_dict(response)
+        except Exception as exc:
+            self.fail("Error creating Azure Virtual Network Peering: {0}.".format(exc.message))
+        
     def create_or_update_vnet_peering(self):
         '''
         Creates or Update Azure Virtual Network Peering.
@@ -350,7 +408,8 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
             allow_virtual_network_access=self.allow_virtual_network_access,
             allow_gateway_transit=self.allow_gateway_transit,
             allow_forwarded_traffic=self.allow_forwarded_traffic,
-            use_remote_gateways=self.use_remote_gateways)
+            use_remote_gateways=self.use_remote_gateways
+            )
 
         try:
             response = self.network_client.virtual_network_peerings.begin_create_or_update(self.resource_group,
@@ -392,6 +451,8 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
                                                                         self.virtual_network['name'],
                                                                         self.name)
             self.log("Response : {0}".format(response))
+            #print(response)
+            # self.result['extra'] = response
             return vnetpeering_to_dict(response)
         except ResourceNotFoundError:
             self.log('Did not find the Virtual Network Peering.')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a method to sync VNet Peering when the `peering_sync_level value` is `LocalNotInSync`.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1023

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualnetworkpeering

##### ADDITIONAL INFORMATION
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1.) Add a CIDR block of address space to an existing peered VNet.

2.) The peering is now "Out of sync".

3.) The peering where the sync_level is "LocalNotInSync" needs to be re-synched.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
{
    "changed": false,
    "failed": false
}

{
    "changed": true,
    "failed": false,
    "peering_sync_level": "FullyInSync"
}
```
