### PR TITLE
azure_rm_dnsrecordset: fix updating SOA record

### DIFF
--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -187,6 +187,21 @@ EXAMPLES = '''
     records:
     - entry: 'v=spf1 a -all'
 
+- name: Update SOA record
+  azure_rm_dnsrecordset:
+    resource_group: "{{ resource_group }}"
+    relative_name: "@"
+    zone_name: "{{ domain_name }}.com"
+    record_type: SOA
+    records:
+      - host: ns1-99.example.com.
+        email: azuredns-hostmaster99.example.com
+        serial_number: 99
+        refresh_time: 3699
+        retry_time: 399
+        expire_time: 2419299
+        minimum_ttl: 399
+
 '''
 
 RETURN = '''

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -189,9 +189,9 @@ EXAMPLES = '''
 
 - name: Update SOA record
   azure_rm_dnsrecordset:
-    resource_group: "{{ resource_group }}"
+    resource_group: myResourceGroup
     relative_name: "@"
-    zone_name: "{{ domain_name }}.com"
+    zone_name: testing.com
     record_type: SOA
     records:
       - host: ns1-99.example.com.

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -314,11 +314,6 @@ RECORD_ARGSPECS = dict(
         retry_time=dict(type='int'),
         expire_time=dict(type='int'),
         minimum_ttl=dict(type='int')
-        # serial_number=dict(type='long'),
-        # refresh_time=dict(type='long'),
-        # retry_time=dict(type='long'),
-        # expire_time=dict(type='long'),
-        # minimum_ttl=dict(type='long')
     ),
     CAA=dict(
         value=dict(type='str', aliases=['entry']),

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -309,11 +309,16 @@ RECORD_ARGSPECS = dict(
     SOA=dict(
         host=dict(type='str', aliases=['entry']),
         email=dict(type='str'),
-        serial_number=dict(type='long'),
-        refresh_time=dict(type='long'),
-        retry_time=dict(type='long'),
-        expire_time=dict(type='long'),
-        minimum_ttl=dict(type='long')
+        serial_number=dict(type='int'),
+        refresh_time=dict(type='int'),
+        retry_time=dict(type='int'),
+        expire_time=dict(type='int'),
+        minimum_ttl=dict(type='int')
+        # serial_number=dict(type='long'),
+        # refresh_time=dict(type='long'),
+        # retry_time=dict(type='long'),
+        # expire_time=dict(type='long'),
+        # minimum_ttl=dict(type='long')
     ),
     CAA=dict(
         value=dict(type='str', aliases=['entry']),

--- a/tests/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
@@ -178,6 +178,28 @@
     that:
       - results.changed
 
+- name: Update SOA record
+  azure_rm_dnsrecordset:
+    resource_group: "{{ resource_group }}"
+    relative_name: "@"
+    zone_name: "{{ domain_name }}.com"
+    record_type: SOA
+    state: present
+    records:
+      - host: ns1-99.example.com.
+        email: azuredns-hostmaster99.example.com
+        serial_number: 99
+        refresh_time: 3699
+        retry_time: 399
+        expire_time: 2419299
+        minimum_ttl: 399
+  register: results
+
+- name: Assert that SOA record set was created
+  assert:
+    that:
+      - results.changed
+
 - name: Delete DNS zone
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fix #1047

fix type convert error in updating SOA record.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- azure_rm_dnsrecordset

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

integration test works fine in my local as bellow.

```paste below
TASK [azure_rm_dnsrecordset : Update SOA record] *******************************
changed: [testhost] => {"changed": true, "state": {"etag": "xxxxx", "fqdn": "480b92c2cae5ec3d25349.com.", "id": "/subscriptions/xxxxx/resourceGroups/myrg/providers/Microsoft.Network/dnszones/480b92c2cae5ec3d25349.com/SOA/@", "name": "@", "provisioning_state": "Succeeded", "soa_record": {"email": "azuredns-hostmaster99.example.com", "expire_time": 2419299, "host": "ns1-99.example.com.", "minimum_ttl": 399, "refresh_time": 3699, "retry_time": 399, "serial_number": 99}, "target_resource": {}, "ttl": 3600, "type": "SOA"}}
```
