### PR TITLE
azure_rm_virtualmachine: add option to choose whether or not to create a network security group

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -316,6 +316,7 @@ options:
             - Whether network security group created and attached to network interface or not.
         type: bool
         default: True
+        version_added: '1.15.0'
     remove_on_absent:
         description:
             - Associated resources to remove when removing a VM using I(state=absent).

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -2387,10 +2387,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         if self.created_nsg:
             self.results['actions'].append('Created default security group {0}'.format(self.name + '01'))
             group = self.create_default_securitygroup(self.resource_group, self.location, self.name + '01', self.os_type,
-                                                    self.open_ports)
+                                                      self.open_ports)
             parameters.network_security_group = self.network_models.NetworkSecurityGroup(id=group.id,
-                                                                                        location=group.location,
-                                                                                        resource_guid=group.resource_guid)
+                                                                                         location=group.location,
+                                                                                         resource_guid=group.resource_guid)
 
         parameters.ip_configurations[0].public_ip_address = pip
 

--- a/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
@@ -32,6 +32,10 @@ all:
         - name: "{{ 'int' ~ uid_short ~ '-2' }}"
           resource_group: "{{ resource_group_secondary }}"
 
+    azure_test_no_nsg:
+      network: 10.42.6.0/24
+      subnet: 10.42.6.0/28
+
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_no_nsg.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_no_nsg.yml
@@ -1,48 +1,5 @@
 - include_tasks: setup.yml
 
-# # Tests possible when CI user acccount setup with required authority
-# - name: Create virtual machine with image and plan which requires acceptance of terms
-#   azure_rm_virtualmachine:
-#     resource_group: "{{ resource_group }}"
-#     name: testvm009
-#     vm_size: Standard_A0
-#     storage_account: "{{ storage_account }}"
-#     storage_container: testvm001
-#     storage_blob: testvm003.vhd
-#     admin_username: adminuser
-#     admin_password: Password123!
-#     short_hostname: testvm
-#     os_type: Linux
-#     availability_set: "{{ availability_set }}"
-#     image: "{{ image_paid }}"
-#     plan_paid: "{{ plan_paid }}"
-#   register: create_image_plan_result
-
-# - assert:
-#     that:
-#       - create_image_plan_result is changed
-#       - create_image_plan_result.ansible_facts.azure_vm.properties.storageProfile.imageReference.publisher == image_paid.publisher
-
-# - name: Should be idempotent with image and plan which requires acceptance of terms
-#   azure_rm_virtualmachine:
-#     resource_group: "{{ resource_group }}"
-#     name: testvm009
-#     vm_size: Standard_A0
-#     storage_account: "{{ storage_account }}"
-#     storage_container: testvm001
-#     storage_blob: testvm003.vhd
-#     admin_username: adminuser
-#     admin_password: Password123!
-#     short_hostname: testvm
-#     os_type: Linux
-#     availability_set: "{{ availability_set }}"
-#     image: "{{ image_paid }}"
-#     plan_paid: "{{ plan_paid }}"
-#   register: create_image_plan_again_result
-
-# - assert:
-#     that: create_image_plan_again is not changed
-
 - name: Create minimal VM with defaults
   azure_rm_virtualmachine:
     resource_group: "{{ resource_group }}"
@@ -54,6 +11,7 @@
         key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
     vm_size: Standard_B1ms
     virtual_network: "{{ network_name }}"
+    created_nsg: false
     image:
       offer: UbuntuServer
       publisher: Canonical
@@ -67,11 +25,10 @@
     name: "{{ vm_name }}01"
   register: nsg_result
 
-- name: Assert that security group were exist before deleting
+- name: Assert that security group were not exist before deleting
   assert:
     that:
-      - nsg_result.securitygroups | length == 1
-      - nsg_result.securitygroups[0].network_interfaces | length == 1
+      - nsg_result.securitygroups | length == 0
 
 - name: Delete VM
   azure_rm_virtualmachine:
@@ -86,12 +43,6 @@
     name: "{{ vm_name }}01"
   register: nic_result
 
-- name: Query auto created security group
-  azure_rm_securitygroup_info:
-    resource_group: "{{ resource_group }}"
-    name: "{{ vm_name }}01"
-  register: nsg_result
-
 - name: Query auto created public IP
   azure_rm_publicipaddress_info:
     resource_group: "{{ resource_group }}"
@@ -103,7 +54,6 @@
     that:
       # what about the default storage group?
       - nic_result.networkinterfaces | length == 0
-      - nsg_result.securitygroups | length == 0
       - pip_result.publicipaddresses | length == 0
 
 - name: Destroy subnet


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, if `network_interface_names` is not specified, a network security group is created and attached to a default network interface .

This PR will add option that allow you to choose whether or not to create a network security group. The default value is `True`, so the network security group is created as before. If `False` is specified, the network security group will not be created.

This is intended for use cases where network security groups are connected to subnets.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `azure_rm_virtualmachine`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
n/a
```
