### PR TITLE
azure_rm_backupazurevm: add option for recovery point expiry time

### DIFF
--- a/plugins/modules/azure_rm_backupazurevm.py
+++ b/plugins/modules/azure_rm_backupazurevm.py
@@ -40,6 +40,12 @@ options:
             - Backup Policy ID present under Recovery Service Vault mentioned in recovery_vault_name field.
         required: true
         type: str
+    recovery_point_expiry_time:
+        description:
+            - Recovery Point Expiry Time in UTC.
+            - This used if C(state) parameter is C(backup).
+        required: false
+        type: str
     state:
         description:
             - Assert the state of the protection item.
@@ -98,6 +104,7 @@ EXAMPLES = \
         resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/testVM'
         backup_policy_id: '/subscriptions/00000000-0000-0000-0000-000000000000/ \
         resourceGroups/myResourceGroup/providers/microsoft.recoveryservices/vaults/testVault/backupPolicies/ProdPolicy'
+        recovery_point_expiry_time: '2023-02-09T06:00:00Z'
         state: 'backup'
     '''
 
@@ -141,6 +148,9 @@ class BackupAzureVM(AzureRMModuleBaseExt):
                 type='str',
                 required=True
             ),
+            recovery_point_expiry_time=dict(
+                type='str'
+            ),
             state=dict(
                 type='str',
                 default='create',
@@ -152,6 +162,7 @@ class BackupAzureVM(AzureRMModuleBaseExt):
         self.recovery_vault_name = None
         self.resource_id = None
         self.backup_policy_id = None
+        self.recovery_point_expiry_time = None
         self.state = None
 
         self.results = dict(changed=False)
@@ -206,12 +217,15 @@ class BackupAzureVM(AzureRMModuleBaseExt):
                     }
             }
         elif self.state == 'backup':
-            return {
+            body = {
                 "properties": {
-                    "objectType": "IaasVMBackupRequest",
-                    "recoveryPointExpiryTimeInUTC": ""
+                    "objectType": "IaasVMBackupRequest"
                 }
             }
+            if self.recovery_point_expiry_time:
+                body["properties"]["recoveryPointExpiryTimeInUTC"] = self.recovery_point_expiry_time
+
+            return body
         elif self.state == 'stop':
             return {
                 "properties": {

--- a/plugins/modules/azure_rm_backupazurevm.py
+++ b/plugins/modules/azure_rm_backupazurevm.py
@@ -46,6 +46,7 @@ options:
             - This used if C(state) parameter is C(backup).
         required: false
         type: str
+        version_added: '1.15.0'
     state:
         description:
             - Assert the state of the protection item.

--- a/tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
@@ -25,6 +25,7 @@
     recovery_vault_name: "{{ recovery_vault_name }}"
     resource_id: "{{ resource_id }}"
     backup_policy_id: "{{ backup_policy_id }}"
+    recovery_point_expiry_time: "2025-02-03T05:00:00Z"
     state: "backup"
   register: output
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Previously, backups using `state: backup` in the `azure_rm_backupazurevm` module [could not specify](https://github.com/ansible-collections/azure/blob/v1.14.0/plugins/modules/azure_rm_backupazurevm.py#L212) an expiration date for the recovery point.

According to [Azure Document](https://learn.microsoft.com/en-us/azure/backup/backup-azure-arm-userestapi-backupazurevms#example-request-body-for-on-demand-backup), if expiry time is not specified it will be 30 days.

This PR will add option for recovery point expiry time.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `azure_rm_backupazurevm`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

If `recovery_point_expiry_time: "2022-12-25T06:00:00Z"` specified, you can check the expiry time on the job details  screen as bellow.

<img width="566" alt="image" src="https://user-images.githubusercontent.com/16851744/209436227-07fa5a40-cd62-47f0-bff4-88b7e3fd7e67.png">

