### PR TITLE
azure_rm_securitygroup: improve idempotency for protocol

### DIFF
--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -486,7 +486,7 @@ def compare_rules(old_rule, rule):
         changed = True
     if rule.get('description', None) != old_rule['description']:
         changed = True
-    if rule['protocol'] != old_rule['protocol']:
+    if rule['protocol'].lower() != old_rule['protocol'].lower():
         changed = True
     if str(rule['source_port_range']) != str(old_rule['source_port_range']):
         changed = True

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -249,6 +249,46 @@
       - output.changed
       - "{{ output.state.rules | length }} == 2"
 
+# Use azure_rm_resource module to create with uppercase protocol name
+- name: Create security group with uppercase protocol name
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: network
+    resource_type: networkSecurityGroups
+    resource_name: "{{ secgroupname }}"
+    api_version: 2022-07-01
+    body:
+      location: "{{ output.state.location }}"
+      properties:
+        securityRules:
+          - name: UPPER PROTOCOL NAME RULE
+            properties:
+              protocol: TCP  # UPPERCASE
+              access: Allow
+              sourceAddressPrefix: "*"
+              sourcePortRange: "*"
+              destinationAddressPrefix: "*"
+              destinationPortRange: 80
+              priority: 100
+              direction: Inbound
+
+- name: Create security group with capitalized protocol name(idempotent)
+  azure_rm_securitygroup:
+    resource_group: "{{ resource_group }}"
+    name: "{{ secgroupname }}"
+    rules:
+      - name: UPPER PROTOCOL NAME RULE
+        protocol: Tcp     # Capitalized
+        access: Allow
+        destination_port_range: 80
+        priority: 100
+        direction: Inbound
+  register: output
+- name: assert resource not updated
+  assert:
+    that:
+      - not output.changed
+
 - name: Create Application security group 1
   azure_rm_applicationsecuritygroup:
     resource_group: "{{ resource_group }}"

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -200,7 +200,7 @@
       - "{{ output.state.rules[0].source_address_prefixes | length }} == 3"
       - not output.state.rules[0].source_address_prefix
 
-- name: Create security group with source_address_prefixes(idempontent)
+- name: Create security group with source_address_prefixes(idempotent)
   azure_rm_securitygroup:
     resource_group: "{{ resource_group }}"
     name: "{{ secgroupname }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If you enter the protocol name from the Azure Portal, it will be uppercase (e.g. TCP).On the other hands, azure_rm_securitygroup module can specify protocol with capitalized (e.g. Tcp).

Due to this difference unintentional `changed` occurs.

This PR allows to diff protocol name by case-insensitive for improving idempotency.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `azure_rm_securitygroup` module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Added a test to verify that from a state with rules using `TCP`, running the same rules in the azure_rm_securitygroup module specifying `Tcp` does not result in changed. It works fine by my environment.