### PR TITLE
Read paginated response for gallery image versions

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion_info.py
+++ b/plugins/modules/azure_rm_galleryimageversion_info.py
@@ -239,13 +239,13 @@ class AzureRMGalleryImageVersionsInfo(AzureRMModuleBase):
                     self.query_parameters['skiptoken'] = skiptoken
 
                 response = self.mgmt_client.query(self.url,
-                                                'GET',
-                                                self.query_parameters,
-                                                self.header_parameters,
-                                                None,
-                                                [200, 404],
-                                                0,
-                                                0)
+                                                  'GET',
+                                                  self.query_parameters,
+                                                  self.header_parameters,
+                                                  None,
+                                                  [200, 404],
+                                                  0,
+                                                  0)
                 try:
                     response = json.loads(response.text)
                     if isinstance(response, dict):

--- a/plugins/modules/azure_rm_galleryimageversion_info.py
+++ b/plugins/modules/azure_rm_galleryimageversion_info.py
@@ -211,7 +211,9 @@ class AzureRMGalleryImageVersionsInfo(AzureRMModuleBase):
 
     def listbygalleryimage(self):
         response = None
-        results = {}
+        results = dict(
+            response=[]
+        )
         # prepare url
         self.url = ('/subscriptions' +
                     '/{{ subscription_id }}' +
@@ -230,20 +232,37 @@ class AzureRMGalleryImageVersionsInfo(AzureRMModuleBase):
         self.url = self.url.replace('{{ image_name }}', self.gallery_image_name)
 
         try:
-            response = self.mgmt_client.query(self.url,
-                                              'GET',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              None,
-                                              self.status_code,
-                                              600,
-                                              30)
-            results = json.loads(response.text)
+            skiptoken = None
+
+            while True:
+                if skiptoken:
+                    self.query_parameters['skiptoken'] = skiptoken
+
+                response = self.mgmt_client.query(self.url,
+                                                'GET',
+                                                self.query_parameters,
+                                                self.header_parameters,
+                                                None,
+                                                [200, 404],
+                                                0,
+                                                0)
+                try:
+                    response = json.loads(response.text)
+                    if isinstance(response, dict):
+                        if response.get('value'):
+                            results['response'] = results['response'] + response['value']
+                            skiptoken = response.get('nextLink')
+                        else:
+                            results['response'] = results['response'] + [response]
+                except Exception as e:
+                    self.fail('Failed to parse response: ' + str(e))
+                if not skiptoken:
+                    break
             # self.log('Response : {0}'.format(response))
         except CloudError as e:
             self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
 
-        return [self.format_item(x) for x in results['value']] if results['value'] else []
+        return [self.format_item(x) for x in results['response']] if results['response'] else []
 
     def format_item(self, item):
         d = {


### PR DESCRIPTION
##### SUMMARY

The query returns a pagineated response with a "nextLink" key in the response object. If the response has such a key, we launch another request to collect the next batch, etc.

I based my code on [this code (azure_rm_resource_info.py)](https://github.com/ansible-collections/azure/blob/dev/plugins/modules/azure_rm_resource_info.py)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
n/a

##### ADDITIONAL INFORMATION
Ansible playbook to reproduce the bug:

Requires you to have more than 50 versions in one azure gallery image

```paste below
---
- name: List images in gallery
  hosts: localhost
  connection: local
  vars:
    gallery_resource_group: IMAGE-GALLERY
    gallery_name: ImageGallery
    gallery_image_name: gallery

  tasks:
    - name: List gallery image versions in our gallery images.
      azure_rm_galleryimageversion_info:
        resource_group: "{{ gallery_resource_group }}"
        gallery_name: "{{ gallery_name }}"
        gallery_image_name: "{{ gallery_image_name }}"
      register: tmp
      
    - debug:
        msg: "{{tmp.versions|length}}"
```

Before the bugfix this will ouput 50, after it will output the correct amount.