### PR TITLE
Fix azure_rm_webapp fails when state is 'absent' 

### DIFF
--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -763,7 +763,7 @@ class AzureRMWebApps(AzureRMModuleBase):
                 self.log('Web App instance deleted')
 
             else:
-                self.fail("Web app {0} not exists.".format(self.name))
+                self.log("Web app {0} not exists.".format(self.name))
 
         if to_be_updated:
             self.log('Need to Create/Update web app')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix azure_rm_webapp fails when state is 'absent' and app service does not exist, try to fix #1078 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_webapp.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
