### PR TITLE
Update documentation of `azure_rm_virtualnetwork` to reflect that the `dns_servers` limit on length is no longer 2.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: azure
 name: azcollection
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.14.0
+version: 1.15.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: azure
 name: azcollection
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.15.0
+version: 1.14.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/azure_rm_virtualnetwork.py
+++ b/plugins/modules/azure_rm_virtualnetwork.py
@@ -30,7 +30,7 @@ options:
             - address_prefixes
     dns_servers:
         description:
-            - Custom list of DNS servers. Maximum length of two.
+            - Custom list of DNS servers.
             - The first server in the list will be treated as the Primary server. This is an explicit list.
             - Existing DNS servers will be replaced with the specified list.
             - Use the I(purge_dns_servers) option to remove all custom DNS servers and revert to default Azure servers.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the documentation for the `azure_rm_virtualnetwork` module to reflect that the dns_servers variable doesn't have a limit on the length of the list.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1081 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The documentation says that the dns_servers list variable has a maximum length of 2. There is no limit to the number of DNS servers, so the documentation is incorrect.
```
