### PR TITLE
Update documentation in azure_rm_virtualnetwork_info and include a small change to match other patterns for getting network info.

### DIFF
--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -264,7 +264,8 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         results = []
 
         try:
-            item = self.network_client.virtual_networks.get(self.resource_group, self.name)
+            item = self.network_client.virtual_networks.get(resource_group_name=self.resource_group, 
+                                                            virtual_network_name=self.name)
         except ResourceNotFoundError:
             pass
 

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -23,7 +23,7 @@ description:
 options:
     name:
         description:
-            - Only show results for a specific security group.
+            - Only show results for a specific virtual network.
     resource_group:
         description:
             - Limit results by resource group. Required when filtering by name.

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -235,7 +235,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         super(AzureRMNetworkInterfaceInfo, self).__init__(self.module_arg_spec,
                                                           supports_check_mode=True,
                                                           supports_tags=False,
-                                                          facts_module=True
+                                                          facts_module=True,
                                                           required_together=self.required_together)
 
     def exec_module(self, **kwargs):

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -267,7 +267,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         results = []
 
         try:
-            item = self.network_client.virtual_networks.get(resource_group_name=self.resource_group, 
+            item = self.network_client.virtual_networks.get(resource_group_name=self.resource_group,
                                                             virtual_network_name=self.name)
         except ResourceNotFoundError:
             pass

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -225,6 +225,8 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             changed=False,
             virtualnetworks=[]
         )
+        
+        self.required_together = [('name', 'resource_group')]
 
         self.name = None
         self.resource_group = None
@@ -233,7 +235,8 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         super(AzureRMNetworkInterfaceInfo, self).__init__(self.module_arg_spec,
                                                           supports_check_mode=True,
                                                           supports_tags=False,
-                                                          facts_module=True)
+                                                          facts_module=True
+                                                          required_together=self.required_together)
 
     def exec_module(self, **kwargs):
         is_old_facts = self.module._name == 'azure_rm_virtualnetwork_facts'

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -225,8 +225,8 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             changed=False,
             virtualnetworks=[]
         )
-        
-        self.required_together = [('name', 'resource_group')]
+
+        self.required_if = [('name', '*', ['resource_group'])]
 
         self.name = None
         self.resource_group = None
@@ -236,7 +236,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
                                                           supports_check_mode=True,
                                                           supports_tags=False,
                                                           facts_module=True,
-                                                          required_together=self.required_together)
+                                                          required_if=self.required_if)
 
     def exec_module(self, **kwargs):
         is_old_facts = self.module._name == 'azure_rm_virtualnetwork_facts'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `get` method for `virtual_networks` implemented required parameters for `resource_group_name` and `virtual_network_name`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1086 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`azure_rm_virtualnetwork_info`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
Module Failure.

After:
Expected results.
```
