### PR TITLE
Fix append_tags for galleryimageversion

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -521,6 +521,10 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
             if self.state == 'absent':
                 self.to_do = Actions.Delete
             else:
+                update_tags, newtags = self.update_tags(old_response.get('tags', dict()))
+                if update_tags:
+                    self.tags = newtags
+                    self.body['tags'] = self.tags
                 modifiers = {}
                 self.create_compare_modifiers(self.module_arg_spec, '', modifiers)
                 self.results['modifiers'] = modifiers

--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -525,6 +525,7 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                 if update_tags:
                     self.tags = newtags
                     self.body['tags'] = self.tags
+                    self.to_do = Actions.Update
                 modifiers = {}
                 self.create_compare_modifiers(self.module_arg_spec, '', modifiers)
                 self.results['modifiers'] = modifiers


### PR DESCRIPTION
##### SUMMARY
Add functionality so append_tags is respected for galleryimageversion.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_galleryimageversion

##### ADDITIONAL INFORMATION
Before the change existing tags get overwritten for azure gallery image versions
