### PR TITLE
Ensure display_status is initialised before it is used

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -433,6 +433,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
         resource_group = parse_resource_id(result['id']).get('resource_group')
         instance = None
         power_state = None
+        display_status = None
 
         try:
             instance = self.compute_client.virtual_machines.instance_view(resource_group, vm.name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1122 
Ensures `display_status` variable is initialised before it is used.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
