### PR TITLE
Remove references to Redis 4 and support upgrading to Redis 6

### DIFF
--- a/plugins/modules/azure_rm_rediscache.py
+++ b/plugins/modules/azure_rm_rediscache.py
@@ -111,9 +111,8 @@ options:
             - The major version of Redis.
         type: str
         choices:
-            - "4"
             - "6"
-        default: "4"
+        default: "6"
         version_added: "1.10.0"
     shard_count:
         description:
@@ -400,8 +399,8 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             ),
             redis_version=dict(
                 type="str",
-                default="4",
-                choices=["4", "6"]
+                default="6",
+                choices=["6"]
             ),
             shard_count=dict(
                 type='int'
@@ -609,7 +608,8 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             self.log("public_network_access diff: origin {0} / update {1}".format(existing['public_network_access'], self.public_network_access))
             return True
         if self.redis_version is not None and existing['redis_version'][0] != self.redis_version[0]:
-            self.fail("Updating redis_version is not supported")
+            self.log("redis_version diff: origin {0} / update {1}".format(existing['redis_version'], self.redis_version))
+            return True
         for config in self.redis_configuration_properties:
             if getattr(self, config) is not None and existing.get(config, None) != getattr(self, config, None):
                 self.log("redis_configuration {0} diff: origin {1} / update {2}".format(config, existing.get(config, None), getattr(self, config, None)))

--- a/plugins/modules/azure_rm_rediscache.py
+++ b/plugins/modules/azure_rm_rediscache.py
@@ -111,6 +111,7 @@ options:
             - The major version of Redis.
         type: str
         choices:
+            - "4"
             - "6"
         default: "6"
         version_added: "1.10.0"
@@ -400,7 +401,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
             redis_version=dict(
                 type="str",
                 default="6",
-                choices=["6"]
+                choices=["4", "6"]
             ),
             shard_count=dict(
                 type='int'

--- a/plugins/modules/azure_rm_rediscache_info.py
+++ b/plugins/modules/azure_rm_rediscache_info.py
@@ -168,7 +168,7 @@ rediscaches:
                 - The version of Redis.
             returned: always
             type: str
-            sample: 4.0.14
+            sample: 6.0.14
             version_added: "1.10.0"
         shard_count:
             description:

--- a/tests/integration/targets/azure_rm_rediscache/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_rediscache/tasks/main.yml
@@ -183,7 +183,7 @@
     sku:
       name: basic
       size: C1
-    redis_version: "4"
+    redis_version: "6"
     minimum_tls_version: "1.2"
     public_network_access: "Disabled"
     wait_for_provisioning: false
@@ -207,7 +207,7 @@
       - facts.rediscaches[0].provisioning_state != None
       - facts.rediscaches[0].sku.name == 'basic'
       - facts.rediscaches[0].sku.size == 'C1'
-      - facts.rediscaches[0].redis_version is version('4', '>=') and facts.rediscaches[0].redis_version is version('5', '<')
+      - facts.rediscaches[0].redis_version is version('6', '>=') and facts.rediscaches[0].redis_version is version('7', '<')
       - facts.rediscaches[0].minimum_tls_version == '1.2'
       - facts.rediscaches[0].public_network_access == 'Disabled'
 
@@ -235,7 +235,7 @@
       sku:
         name: basic
         size: C1
-      redis_version: "4"
+      redis_version: "6"
       minimum_tls_version: "1.2"
       public_network_access: "Disabled"
       wait_for_provisioning: true
@@ -252,7 +252,7 @@
       sku:
         name: basic
         size: C1
-      redis_version: "4"
+      redis_version: "6"
       minimum_tls_version: "1.1"
       public_network_access: "Disabled"
       wait_for_provisioning: true
@@ -269,7 +269,7 @@
       sku:
         name: basic
         size: C1
-      redis_version: "4"
+      redis_version: "6"
       minimum_tls_version: "1.1"
       public_network_access: "Enabled"
       wait_for_provisioning: true


### PR DESCRIPTION
##### SUMMARY

Redis 4 is no longer being supported and existing instances need to be updated: https://azure.microsoft.com/en-us/updates/upgrade-your-azure-cache-for-redis-instances-to-use-redis-version-6-by-30-june-2023/

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_rediscache

##### ADDITIONAL INFORMATION

See announcement here: https://azure.microsoft.com/en-us/updates/upgrade-your-azure-cache-for-redis-instances-to-use-redis-version-6-by-30-june-2023/

Upgrading an existing instance (from 4->6) is supported (I have tested) so the module is being updated appropriately.
