### PR TITLE
Update dependency to resolve upstream issue

### DIFF
--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -12,7 +12,7 @@ azure-mgmt-compute==26.1.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-core==1.3.0
 azure-mgmt-containerregistry==9.1.0
-azure-containerregistry==1.0.0
+azure-containerregistry==1.1.0
 azure-mgmt-containerservice==20.0.0
 azure-mgmt-datalake-store==1.0.0
 azure-mgmt-datafactory==2.0.0


### PR DESCRIPTION
##### SUMMARY

This PR updates the `azure-containerregistry` Python dependency in order to pull in the upstream fix in https://github.com/Azure/azure-sdk-for-python/issues/28234.

Trying to use `azure_rm_containerregistrytag` when deleting an empty repository (one with no tags) resulted in an SDK issue, which is resolved in [version 1.1.0](https://pypi.org/project/azure-containerregistry/1.1.0/).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure.azcollection.azure_rm_containerregistrytag

##### ADDITIONAL INFORMATION

See https://github.com/Azure/azure-sdk-for-python/issues/28234 for full detail.
