### PR TITLE
removed subscription_id from azure_keyvault_secret lookup when using az cli auth

### DIFF
--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -45,6 +45,10 @@ notes:
 """
 
 EXAMPLE = """
+- name: Look up secret when azure cli login
+  debug:
+    msg: msg: "{{ lookup('azure.azcollection.azure_keyvault_secret', 'testsecret', vault_url=key_vault_uri)}}"
+
 - name: Look up secret when ansible host is MSI enabled Azure VM
   debug:
     msg: "the value of this secret is {{

--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -39,7 +39,8 @@ notes:
     - For enabling MSI on Azure VM, please refer to this doc https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/
     - After enabling MSI on Azure VM, remember to grant access of the Key Vault to the VM by adding a new Acess Policy in Azure Portal.
     - If MSI is not enabled on ansible host, it's required to provide a valid service principal which has access to the key vault.
-    - To authenticate via service principal, pass client_id, secret and tenant_id or set environment variables AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID.
+    - To authenticate via service principal, pass client_id, secret and tenant_id or set environment variables
+      AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID.
     - Authentication via C(az login) is also supported.
     - To use a plugin from a collection, please reference the full namespace, collection name, and lookup plugin name that you want to use.
 """
@@ -120,7 +121,6 @@ try:
     import logging
     from azure.common.exceptions import ClientRequestError
     from msrest.exceptions import ClientRequestError
-    from azure.keyvault.models import KeyVaultErrorException
     from azure.identity import DefaultAzureCredential, ClientSecretCredential
     from azure.keyvault.secrets import SecretClient
 

--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -116,9 +116,9 @@ from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 try:
+    import logging
     import requests
     from azure.keyvault.secrets import SecretClient
-    import logging
     from azure.common.exceptions import ClientRequestError
     from msrest.exceptions import ClientRequestError
     from azure.identity import DefaultAzureCredential, ClientSecretCredential

--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Hai Cao, <t-haicao@microsoft.com>
+# Copyright (c) 2022 Hai Cao, <t-haicao@microsoft.com>, Marcin Slowikowski (@msl0)
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,6 +10,7 @@ DOCUMENTATION = """
 name: azure_keyvault_secret
 author:
     - Hai Cao (@tk5eq) <t-haicao@microsoft.com>
+    - Marcin Slowikowski (@msl0)
 version_added: '1.12.0'
 requirements:
     - requests
@@ -32,21 +33,18 @@ options:
         description: Secret of the service principal.
     tenant_id:
         description: Tenant id of service principal.
-    subscription_id:
-        description: Your Azure subscription Id.
 notes:
     - If version is not provided, this plugin will return the latest version of the secret.
     - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't required.
     - For enabling MSI on Azure VM, please refer to this doc https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/
     - After enabling MSI on Azure VM, remember to grant access of the Key Vault to the VM by adding a new Acess Policy in Azure Portal.
     - If MSI is not enabled on ansible host, it's required to provide a valid service principal which has access to the key vault.
+    - To authenticate via service principal, pass client_id, secret and tenant_id or set environment variables AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID.
+    - Authentication via C(az login) is also supported.
     - To use a plugin from a collection, please reference the full namespace, collection name, and lookup plugin name that you want to use.
 """
 
 EXAMPLE = """
-- name: Look up secret when azure cli login
-  debug:
-    msg: msg: "{{ lookup('azure.azcollection.azure_keyvault_secret', 'testsecret', vault_url=key_vault_uri, subscription_id=subscription_id)}}"
 - name: Look up secret when ansible host is MSI enabled Azure VM
   debug:
     msg: "the value of this secret is {{
@@ -109,23 +107,25 @@ RETURN = """
     description: secret content string
 """
 
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 try:
     import requests
     import logging
-    import os
-    from azure.common.credentials import ServicePrincipalCredentials, get_cli_profile
-    from azure.keyvault import KeyVaultClient
-    from msrest.exceptions import AuthenticationError, ClientRequestError
-    from azure.keyvault.models.key_vault_error import KeyVaultErrorException
+    from azure.common.exceptions import ClientRequestError
+    from msrest.exceptions import ClientRequestError
+    from azure.keyvault.models import KeyVaultErrorException
+    from azure.identity import DefaultAzureCredential, ClientSecretCredential
+    from azure.keyvault.secrets import SecretClient
 except ImportError:
     pass
 
 display = Display()
 
 TOKEN_ACQUIRED = False
+
+logger = logging.getLogger("azure.identity").setLevel(logging.ERROR)
 
 token_params = {
     'api-version': '2018-02-01',
@@ -157,30 +157,24 @@ def lookup_secret_non_msi(terms, vault_url, kwargs):
     logging.getLogger('msrestazure.azure_active_directory').addHandler(logging.NullHandler())
     logging.getLogger('msrest.service_client').addHandler(logging.NullHandler())
 
-    client_id = kwargs['client_id'] if kwargs.get('client_id') else os.environ.get('AZURE_CLIENT_ID')
-    secret = kwargs['secret'] if kwargs.get('secret') else os.environ.get('AZURE_SECRET')
-    tenant_id = kwargs['tenant_id'] if kwargs.get('tenant_id') else os.environ.get('AZURE_TENANT')
-    subscription_id = kwargs['subscription_id'] if kwargs.get('subscription_id') else os.environ.get('AZURE_SUBSCRIPTION_ID')
+    client_id = kwargs['client_id'] if kwargs.get('client_id') else None
+    secret = kwargs['secret'] if kwargs.get('secret') else None
+    tenant_id = kwargs['tenant_id'] if kwargs.get('tenant_id') else None
 
-    try:
-        if client_id is not None and secret is not None and tenant_id is not None:
-            credentials = ServicePrincipalCredentials(
-                client_id=client_id,
-                secret=secret,
-                tenant=tenant_id
-            )
-        elif subscription_id is not None:
-            profile = get_cli_profile()
-            credentials, subscription_id, tenant = profile.get_login_credentials(
-                subscription_id=subscription_id, resource="https://vault.azure.net")
-        client = KeyVaultClient(credentials)
-    except AuthenticationError:
-        raise AnsibleError('Invalid credentials provided.')
+    if all(v is not None for v in [client_id, secret, tenant_id]):
+        credential = ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=secret,
+        )
+    else:
+        credential = DefaultAzureCredential()
+    client = SecretClient(vault_url, credential)
 
     ret = []
     for term in terms:
         try:
-            secret_val = client.get_secret(vault_url, term, '').value
+            secret_val = client.get_secret(term).value
             ret.append(secret_val)
         except ClientRequestError:
             raise AnsibleError('Error occurred in request')


### PR DESCRIPTION
Added support for Azure CLI authentication without subscription ID in azure_keyvault_secret lookup plugin, fixes #1174  