### PR TITLE
Fix version_added in azure_rm_virtualmachine

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -318,7 +318,7 @@ options:
             - Whether network security group created and attached to network interface or not.
         type: bool
         default: True
-        version_added: '1.15.0'
+        version_added: '1.16.0'
     remove_on_absent:
         description:
             - Associated resources to remove when removing a VM using I(state=absent).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The #1056 has released as version 1.16.0.  Not mentioned in [CHANGELOG.md](https://github.com/ansible-collections/azure/blob/dev/CHANGELOG.md#v1160-2023-5-31).

So I fixed `version_added` of `create_nsg` option  `1.15.0` to `1.16.0`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `azure_rm_virtualmachine` module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

The diff between 1.15.0 and 1.16.0 are https://github.com/ansible-collections/azure/compare/v1.15.0...v1.16.0