### PR TITLE
Fixed an error when client_id and secret are empty in kevault

### DIFF
--- a/plugins/modules/azure_rm_keyvaultkey.py
+++ b/plugins/modules/azure_rm_keyvaultkey.py
@@ -224,8 +224,8 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
                 self.log("Get KeyVaultClient from service principal")
         elif (self.module.params['auth_source'] == 'cli'
                 or (self.module.params['auth_source'] == 'auto'
-                    and self.credentials['client_id'] is None
-                    and self.credentials['secret'] is None)):
+                    and self.credentials.get('client_id') is None
+                    and self.credentials.get('secret') is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(

--- a/plugins/modules/azure_rm_keyvaultkey_info.py
+++ b/plugins/modules/azure_rm_keyvaultkey_info.py
@@ -323,8 +323,8 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
                 self.log("Get KeyVaultClient from service principal")
         elif (self.module.params['auth_source'] == 'cli'
                 or (self.module.params['auth_source'] == 'auto'
-                    and self.credentials['client_id'] is None
-                    and self.credentials['secret'] is None)):
+                    and self.credentials.get('client_id') is None
+                    and self.credentials.get('secret') is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(

--- a/plugins/modules/azure_rm_keyvaultsecret.py
+++ b/plugins/modules/azure_rm_keyvaultsecret.py
@@ -209,8 +209,8 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 self.log("Get KeyVaultClient from service principal")
         elif (self.module.params['auth_source'] == 'cli'
                 or (self.module.params['auth_source'] == 'auto'
-                    and self.credentials['client_id'] is None
-                    and self.credentials['secret'] is None)):
+                    and self.credentials.get('client_id') is None
+                    and self.credentials.get('secret') is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(

--- a/plugins/modules/azure_rm_keyvaultsecret_info.py
+++ b/plugins/modules/azure_rm_keyvaultsecret_info.py
@@ -277,8 +277,8 @@ class AzureRMKeyVaultSecretInfo(AzureRMModuleBase):
                 self.log("Get KeyVaultClient from service principal")
         elif (self.module.params['auth_source'] == 'cli'
                 or (self.module.params['auth_source'] == 'auto'
-                    and self.credentials['client_id'] is None
-                    and self.credentials['secret'] is None)):
+                    and self.credentials.get('client_id') is None
+                    and self.credentials.get('secret') is None)):
             try:
                 profile = get_cli_profile()
                 credentials, subscription_id, tenant = profile.get_login_credentials(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed an error when client_id and secret are empty in kevault, try to fix #1184
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_keyvaultkey.py
azure_rm_keyvaultkey_info.py
azure_rm_keyvaultsecret.py
azure_rm_keyvaultsecret_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
