### PR TITLE
Support unmount disk to VMs that not belong to the same resource group

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -481,14 +481,15 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         # unmount from the old virtual machine and mount to the new virtual machine
         if self.managed_by or self.managed_by == '':
             vm_name = parse_resource_id(disk_instance.get('managed_by', '')).get('name') if disk_instance else None
+            resource_group = parse_resource_id(disk_instance.get('managed_by', '')).get('resource_group') if disk_instance else None
             vm_name = vm_name or ''
             if self.managed_by != vm_name or self.is_attach_caching_option_different(vm_name, result):
                 changed = True
                 if not self.check_mode:
                     if vm_name:
-                        self.detach(self.resource_group, vm_name, result)
+                        self.detach(resource_group, vm_name, result)
                     if self.managed_by:
-                        self.attach(self.resource_group, self.managed_by, result)
+                        self.attach(resource_group, self.managed_by, result)
                     result = self.get_managed_disk()
 
         if self.state == 'absent' and disk_instance:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Support unmount disk to VMs that not belong to the same resource group, try to fixes #1199
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_manageddisk.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
