### PR TITLE
Refs #1033 fix security profile for azure_rm_virtualmachine_info

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -275,39 +275,39 @@ vms:
             description:
                 - Specifies the Security related profile settings for the virtual machine.
             type: complex
-            returned: always
+            returned: when-used
             contains:
                 encryption_at_host:
                     description:
                         - This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine.
                         - This will enable the encryption for all the disks including Resource/Temp disk at host itself.
                     type: bool
-                    returned: always
+                    returned: when-enabled
                     sample: True
                 security_type:
                     description:
                         - Specifies the SecurityType of the virtual machine.
                         - It is set as TrustedLaunch to enable UefiSettings.
                     type: str
-                    returned: always
+                    returned: when-enabled
                     sample: TrustedLaunch
                 uefi_settings:
                     description:
                         - Specifies the security settings like secure boot and vTPM used while creating the virtual machine.
                     type: complex
-                    returned: always
+                    returned: when-enabled
                     contains:
                         secure_boot_enabled:
                             description:
                                 - Specifies whether secure boot should be enabled on the virtual machine.
                             type: bool
-                            returned: always
+                            returned: when-enabled
                             sample: True
                         v_tpm_enabled:
                             description:
                                 - Specifies whether vTPM should be enabled on the virtual machine.
                             type: bool
-                            returned: always
+                            returned: when-enabled
                             sample: True
 '''
 
@@ -459,11 +459,16 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
 
         if vm.security_profile is not None:
             new_result['security_profile'] = dict()
-            new_result['security_profile']['encryption_at_host'] = vm.security_profile.encryption_at_host
-            new_result['security_profile']['security_type'] = vm.security_profile.security_type
-            new_result['security_profile']['uefi_settings'] = dict()
-            new_result['security_profile']['uefi_settings']['secure_boot_enabled'] = vm.security_profile.uefi_settings.secure_boot_enabled
-            new_result['security_profile']['uefi_settings']['v_tpm_enabled'] = vm.security_profile.uefi_settings.v_tpm_enabled
+            if vm.security_profile.encryption_at_host is not None:
+                new_result['security_profile']['encryption_at_host'] = vm.security_profile.encryption_at_host
+            if vm.security_profile.security_type is not None:
+                new_result['security_profile']['security_type'] = vm.security_profile.security_type
+            if vm.security_profile.uefi_settings is not None:
+                new_result['security_profile']['uefi_settings'] = dict()
+                if vm.security_profile.uefi_settings.secure_boot_enabled is not None:
+                   new_result['security_profile']['uefi_settings']['secure_boot_enabled'] = vm.security_profile.uefi_settings.secure_boot_enabled
+                if vm.security_profile.uefi_settings.v_tpm_enabled is not None:
+                   new_result['security_profile']['uefi_settings']['v_tpm_enabled'] = vm.security_profile.uefi_settings.v_tpm_enabled
 
         new_result['power_state'] = power_state
         new_result['display_status'] = display_status

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -466,7 +466,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
             if vm.security_profile.uefi_settings is not None:
                 new_result['security_profile']['uefi_settings'] = dict()
                 if vm.security_profile.uefi_settings.secure_boot_enabled is not None:
-                   new_result['security_profile']['uefi_settings']['secure_boot_enabled'] = vm.security_profile.uefi_settings.secure_boot_enabled
+                    new_result['security_profile']['uefi_settings']['secure_boot_enabled'] = vm.security_profile.uefi_settings.secure_boot_enabled
                 if vm.security_profile.uefi_settings.v_tpm_enabled is not None:
                    new_result['security_profile']['uefi_settings']['v_tpm_enabled'] = vm.security_profile.uefi_settings.v_tpm_enabled
 

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -468,7 +468,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
                 if vm.security_profile.uefi_settings.secure_boot_enabled is not None:
                     new_result['security_profile']['uefi_settings']['secure_boot_enabled'] = vm.security_profile.uefi_settings.secure_boot_enabled
                 if vm.security_profile.uefi_settings.v_tpm_enabled is not None:
-                   new_result['security_profile']['uefi_settings']['v_tpm_enabled'] = vm.security_profile.uefi_settings.v_tpm_enabled
+                    new_result['security_profile']['uefi_settings']['v_tpm_enabled'] = vm.security_profile.uefi_settings.v_tpm_enabled
 
         new_result['power_state'] = power_state
         new_result['display_status'] = display_status


### PR DESCRIPTION
##### SUMMARY
The output of the restapi for the VM does not always contain SecurityProfile, it furthermore only contains some information, I ran into an issue when enabling encryption_at_host, the API will then return:
```
    "securityProfile": {
      "encryptionAtHost": true
    },
```
and not the other keys that you expect in your code, so I made them all set-only-when-returned. I did not test if there are specific combinations that will always be set together, I do not use trusted launch/tpm in my env yet. I also changed the return value table to reflect that securityProfile is not always returned as well as the other values.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
azure_rm_virtualmachine_info.py
