### PR TITLE
Add vm_agent_version to output of azure_rm_virtualmachine_info

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -247,9 +247,7 @@ vms:
                 - Version of the Azure VM Agent (waagent) running inside the VM.
             returned: always
             type: str
-            sample:
-                - 'Unknown'
-                - '2.9.1.1'
+            sample: '2.9.1.1'
         vm_size:
             description:
                 - Virtual machine size.

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -242,6 +242,14 @@ vms:
             returned: always
             type: dict
             sample: { "key1":"value1" }
+        vm_agent_version:
+            description:
+                - Version of the Azure VM Agent (waagent) running inside the VM.
+            returned: always
+            type: str
+            sample:
+                - 'Unknown'
+                - '2.9.1.1'
         vm_size:
             description:
                 - Virtual machine size.
@@ -456,6 +464,11 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
                 break
 
         new_result = {}
+
+        if instance.get('vm_agent') is not None:
+            new_result['vm_agent_version'] = instance['vm_agent'].get('vm_agent_version')
+        else:
+            new_result['vm_agent_version'] = 'Unknown'
 
         if vm.security_profile is not None:
             new_result['security_profile'] = dict()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Also return vm_agent_version in azure_rm_virtualmachine_info

This is only returned by API for turned on VMs, so if it's undefined also return "Unknown". "Unknown" + powered on VM means something is wrong with the agent inside the VM.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine_info
