### PR TITLE
Add disk_encryption_set for data disks in azure_rm_virtualmachine

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -1116,6 +1116,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                 options=dict(
                     lun=dict(type='int', required=True),
                     disk_size_gb=dict(type='int'),
+                    disk_encryption_set=dict(type='str'),
                     managed_disk_type=dict(type='str', choices=['Standard_LRS', 'StandardSSD_LRS',
                                            'StandardSSD_ZRS', 'Premium_LRS', 'Premium_ZRS', 'UltraSSD_LRS']),
                     storage_account_name=dict(type='str'),

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -262,6 +262,10 @@ options:
                     - Size can be changed only when the virtual machine is deallocated.
                     - Not sure when I(managed_disk_id) defined.
                 type: int
+            disk_encryption_set:
+                description:
+                    - ID of disk encryption set for data disk.
+                type: str
             managed_disk_type:
                 description:
                     - Managed data disk type.
@@ -1865,6 +1869,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                             else:
                                 data_disk_vhd = None
                                 data_disk_managed_disk = self.compute_models.ManagedDiskParameters(storage_account_type=data_disk['managed_disk_type'])
+                                if data_disk.get('disk_encryption_set'):
+                                    data_disk_managed_disk.disk_encryption_set = self.compute_models.DiskEncryptionSetParameters(
+                                        id=data_disk['disk_encryption_set']
+                                    )
                                 disk_name = self.name + "-datadisk-" + str(count)
                                 count += 1
 
@@ -2116,6 +2124,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                             if data_disk.get('managed_disk'):
                                 managed_disk_type = data_disk['managed_disk'].get('storage_account_type')
                                 data_disk_managed_disk = self.compute_models.ManagedDiskParameters(storage_account_type=managed_disk_type)
+                                if data_disk.get('disk_encryption_set'):
+                                    data_disk_managed_disk.disk_encryption_set = self.compute_models.DiskEncryptionSetParameters(
+                                        id=data_disk['disk_encryption_set']
+                                    )
                                 data_disk_vhd = None
                             else:
                                 data_disk_vhd = data_disk['vhd']['uri']


### PR DESCRIPTION
##### SUMMARY
Add the parameter `data_disks.disk_encryption_set` to the `azure_rm_virtualmachine` module, making it possible to specify which DES to use when encrypting the data disk.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ADDITIONAL INFORMATION
This is required when creating a VM (with data disks) from an encrypted image which resides in another landing zone.