### PR TITLE
Add features to azure_rm_galleryimage

### DIFF
--- a/plugins/modules/azure_rm_galleryimage.py
+++ b/plugins/modules/azure_rm_galleryimage.py
@@ -162,6 +162,22 @@ options:
                 description:
                     - The product ID.
                 type: str
+    features:
+        description:
+            - A list of gallery image features.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description:
+                    - The name of the gallery image feature..
+                type: str
+                required: True
+            value:
+                description:
+                    - The value of the gallery image feature.
+                type: str
+                required: True
     state:
         description:
             - Assert the state of the GalleryImage.
@@ -352,6 +368,21 @@ class AzureRMGalleryImages(AzureRMModuleBaseExt):
                     )
                 )
             ),
+            features=dict(
+                type='list',
+                disposition='/properties/*',
+                elements='dict',
+                options=dict(
+                    name=dict(
+                        type='str',
+                        required=True
+                    ),
+                    value=dict(
+                        type='str',
+                        required=True
+                    )
+                )
+            )
             state=dict(
                 type='str',
                 default='present',
@@ -373,7 +404,7 @@ class AzureRMGalleryImages(AzureRMModuleBaseExt):
 
         self.body = {}
         self.query_parameters = {}
-        self.query_parameters['api-version'] = '2019-07-01'
+        self.query_parameters['api-version'] = '2022-03-03'
         self.header_parameters = {}
         self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
 

--- a/plugins/modules/azure_rm_galleryimage.py
+++ b/plugins/modules/azure_rm_galleryimage.py
@@ -170,7 +170,7 @@ options:
         suboptions:
             name:
                 description:
-                    - The name of the gallery image feature..
+                    - The name of the gallery image feature.
                 type: str
                 required: True
             value:
@@ -382,7 +382,7 @@ class AzureRMGalleryImages(AzureRMModuleBaseExt):
                         required=True
                     )
                 )
-            )
+            ),
             state=dict(
                 type='str',
                 default='present',

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -151,7 +151,7 @@
     name: myGallery{{ rpfx }}
   register: output
 
-- name: Assedrt the gallery facts
+- name: Assert the gallery facts
   ansible.builtin.assert:
     that:
       - not output.changed
@@ -174,6 +174,10 @@
       offer: myOfferName
       sku: mySkuName
     description: Image Description
+    hypervgeneration: V2
+    features:
+      - name: SecurityType
+        value: TrustedLaunch
   register: output
 
 - name: Assert the gallery image created
@@ -194,6 +198,10 @@
       offer: myOfferName
       sku: mySkuName
     description: Image Description
+    hypervgeneration: V2
+    features:
+      - name: SecurityType
+        value: TrustedLaunch
   register: output
 
 - name: Assert the gallery image idempotent result
@@ -214,6 +222,10 @@
       offer: myOfferName
       sku: mySkuName
     description: Image Description XXXs
+    hypervgeneration: V2
+    features:
+      - name: SecurityType
+        value: TrustedLaunch
   register: output
 
 - name: Assert the gallery image updated


### PR DESCRIPTION
##### SUMMARY
Add the parameter `features` to the `azure_rm_galleryimage` module

Fixes #1282 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_galleryimage

##### ADDITIONAL INFORMATION
This is required to create VMs with Trusted Launch from these images.

The API version had to be bumped in order to support the properties.features setting.
