### PR TITLE
Add auth_mode to azure_rm_storageblob

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -675,7 +675,7 @@ class AzureRMModuleBase(object):
                 self.fail("Error {0} has a provisioning state of {1}. Expecting state to be {2}.".format(
                     azure_object.name, azure_object.provisioning_state, AZURE_SUCCESS_STATE))
 
-    def get_blob_service_client(self, resource_group_name, storage_account_name, auth_mode = 'key'):
+    def get_blob_service_client(self, resource_group_name, storage_account_name, auth_mode='key'):
         try:
             self.log("Getting storage account detail")
             account = self.storage_client.storage_accounts.get_properties(resource_group_name=resource_group_name, account_name=storage_account_name)

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -679,11 +679,11 @@ class AzureRMModuleBase(object):
         try:
             self.log("Getting storage account detail")
             account = self.storage_client.storage_accounts.get_properties(resource_group_name=resource_group_name, account_name=storage_account_name)
-            if auth_mode == 'key':
+            if auth_mode == 'login' and self.azure_auth.credentials.get('credential'):
+                credential = self.azure_auth.credentials['credential']
+            else:
                 account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name, account_name=storage_account_name)
                 credential = account_keys.keys[0].value
-            else:
-                credential = self.azure_auth.credentials['credential']
         except Exception as exc:
             self.fail("Error getting storage account detail for {0}: {1}".format(storage_account_name, str(exc)))
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -675,11 +675,15 @@ class AzureRMModuleBase(object):
                 self.fail("Error {0} has a provisioning state of {1}. Expecting state to be {2}.".format(
                     azure_object.name, azure_object.provisioning_state, AZURE_SUCCESS_STATE))
 
-    def get_blob_service_client(self, resource_group_name, storage_account_name):
+    def get_blob_service_client(self, resource_group_name, storage_account_name, auth_mode = 'key'):
         try:
             self.log("Getting storage account detail")
             account = self.storage_client.storage_accounts.get_properties(resource_group_name=resource_group_name, account_name=storage_account_name)
-            account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name, account_name=storage_account_name)
+            if auth_mode == 'key':
+                account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name, account_name=storage_account_name)
+                credential = account_keys.keys[0].value
+            else:
+                credential = self.azure_auth.credentials['credential']
         except Exception as exc:
             self.fail("Error getting storage account detail for {0}: {1}".format(storage_account_name, str(exc)))
 
@@ -687,7 +691,7 @@ class AzureRMModuleBase(object):
             self.log("Create blob service client")
             return BlobServiceClient(
                 account_url=account.primary_endpoints.blob,
-                credential=account_keys.keys[0].value,
+                credential=credential,
             )
         except Exception as exc:
             self.fail("Error creating blob service client for storage account {0} - {1}".format(storage_account_name, str(exc)))

--- a/plugins/modules/azure_rm_storageblob.py
+++ b/plugins/modules/azure_rm_storageblob.py
@@ -227,6 +227,7 @@ except ImportError:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.basic import env_fallback
 
+
 class AzureRMStorageBlob(AzureRMModuleBase):
 
     def __init__(self):

--- a/tests/integration/targets/azure_rm_storageblob/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageblob/tasks/main.yml
@@ -11,12 +11,14 @@
 
 - name: Create container
   azure_rm_storageblob:
+    auth_mode: login
     resource_group: "{{ resource_group }}"
     account_name: "{{ storage_account }}"
     container_name: my-blobs
 
 - name: Force upload blob
   azure_rm_storageblob:
+    auth_mode: login
     resource_group: "{{ resource_group }}"
     account_name: "{{ storage_account }}"
     container_name: my-blobs


### PR DESCRIPTION
Add the parameter `auth_mode` to the
`azure_rm_storageblob` module, making it possible to create blobs without using access keys.

##### SUMMARY
Add the parameter `auth_mode` to the `azure_rm_storageblob` module.

Fixes #1283, #1255 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
azure_rm_storageblob

##### ADDITIONAL INFORMATION
This allows customer which has disabled access keys to use the module.
