### PR TITLE
Add azure_rm_accesstoken_info module

### DIFF
--- a/plugins/modules/azure_rm_accesstoken_info.py
+++ b/plugins/modules/azure_rm_accesstoken_info.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2023 Patrick Uiterwijk <@puiterwijk>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_accesstoken_info
+
+version_added: "1.19.0"
+
+short_description: Get Azure API access token
+
+description:
+    - Get an access token for Azure APIs.
+
+options:
+    scopes:
+        description:
+            - The scopes to request.
+        type: list
+        elements: str
+        required: True
+    claims:
+        description:
+            - Additional claims required in the token.
+        type: list
+        elements: str
+    token_tenant_id:
+        description:
+            - Tenant to include in the token request.
+        type: str
+    enable_cae:
+        description:
+            - Whether to enable Continuous Access Evaluation (CAE) for the requested token.
+        default: false
+        type: bool
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Patrick Uiterwijk (@puiterwijk)
+'''
+
+EXAMPLES = '''
+- name: Get access token for Microsoft Graph
+  azure.azcollection.azure_rm_accesstoken_info:
+    scopes:
+      - https://graph.microsoft.com/.default
+'''
+
+RETURN = '''
+access_token:
+    description:
+        - API access token.
+    returned: success
+    type: str
+    sample: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ.L8i6g3PfcHlioHCCPURC9pmXT7gdJpx3kOoyAfNUwCc
+expires_on:
+    description:
+        - Timestamp the token expires on.
+    returned: success
+    type: int
+    sample: 1699337824
+'''
+
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+class AzureRMAccessToken(AzureRMModuleBase):
+
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            scopes=dict(type='list', elements='str', required=True),
+            claims=dict(type='list', elements='str'),
+            token_tenant_id=dict(type='str'),
+            enable_cae=dict(type='bool', default=False),
+        )
+
+        self.scopes = None
+        self.claims = None
+        self.token_tenant_id = None
+        self.enable_cae = False
+
+        self.results = dict(changed=False)
+
+        super(AzureRMAccessToken, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                 supports_check_mode=True,
+                                                 supports_tags=False,
+                                                 is_ad_resource=False)
+
+    def exec_module(self, **kwargs):
+        for key in list(self.module_arg_spec.keys()):
+            setattr(self, key, kwargs[key])
+
+        claims = None
+        if self.claims is not None:
+            claims = ' '.join(self.claims)
+
+        cred = self.azure_auth.azure_credential_track2
+        token = cred.get_token(
+            *self.scopes,
+            claims=claims,
+            tenant_id=self.token_tenant_id,
+            enable_cae=self.enable_cae,
+        )
+
+        self.results['access_token'] = token.token
+        self.results['expires_on'] = token.expires_on
+        return self.results
+
+
+def main():
+    AzureRMAccessToken()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/azure_rm_accesstoken_info/aliases
+++ b/tests/integration/targets/azure_rm_accesstoken_info/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+shippable/azure/group15
+destructive

--- a/tests/integration/targets/azure_rm_accesstoken_info/meta/main.yml
+++ b/tests/integration/targets/azure_rm_accesstoken_info/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_accesstoken_info/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_accesstoken_info/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Get access token for graphql
+  azure.azcollection.azure_rm_accesstoken_info:
+    scopes:
+      - https://graph.microsoft.com/.default
+  register: result
+
+- name: Assert the facts
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result is not failed
+      - "'access_token' in result"
+      - "'expires_on' in result"


### PR DESCRIPTION
This adds a module to retrieve an access token for Azure.

##### SUMMARY
This adds a new module to retrieve an Azure access token.
These tokens might be useful for other tasks, for example as a bearer token when pulling DevOps repositories.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
azure_rm_access_token