### PR TITLE
Ansible "is match" does not need a ^

### DIFF
--- a/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
@@ -118,7 +118,7 @@
       - output.state.private_dns_zone_configs[0].record_sets | length == 1
       - output.state.private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
       - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
-      - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('^10.1.*')
+      - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('10.1.*')
       - output.state.private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
       - output.state.private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
       - output.state.private_dns_zone_configs[0].record_sets[0].record_type == 'A'
@@ -158,7 +158,7 @@
       - output.groups[0].private_dns_zone_configs[0].record_sets | length == 1
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
-      - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('^10.1.*')
+      - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('10.1.*')
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_type == 'A'
@@ -183,7 +183,7 @@
       - output.groups[0].private_dns_zone_configs[0].record_sets | length == 1
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
-      - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('^10.1.*')
+      - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('10.1.*')
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
       - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_type == 'A'
@@ -211,7 +211,7 @@
       - output.state.private_dns_zone_configs[0].record_sets | length == 1
       - output.state.private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
       - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
-      - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('^10.1.*')
+      - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses[0] is match('10.1.*')
       - output.state.private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
       - output.state.private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
       - output.state.private_dns_zone_configs[0].record_sets[0].record_type == 'A'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible "is match" does not need a ^， delete '^', fixes  #1262
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible_collections_azure/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
