### PR TITLE
Support the include_host_filters

### DIFF
--- a/plugins/doc_fragments/azure_rm.py
+++ b/plugins/doc_fragments/azure_rm.py
@@ -47,6 +47,11 @@ options:
             expression in the list is evaluated for each host; when the expression is true, the host is excluded
             from the inventory.
         default: []
+    include_host_filters:
+        description: Include hosts from the inventory with a list of Jinja2 conditional expressions. Each
+            expression in the list is evaluated for each host; when the expression is true, the host is included
+            in the inventory, all hosts are includes in the inventory by default.
+        default: [true]
     batch_fetch:
         description: To improve performance, results are fetched using an unsupported batch API. Disabling
             C(batch_fetch) uses a much slower serial fetch, resulting in many more round-trips. Generally only

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -114,7 +114,7 @@ include_host_filters:
     - location in ['eastus'] and powerstate == 'running'
     - location in ['eastus2'] and tags['tagkey'] is defined and tags['tagkey'] == 'tagkey'
 
-    
+ 
 '''
 
 # FUTURE: do we need a set of sane default filters, separate from the user-defineable ones?

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -108,7 +108,7 @@ exclude_host_filters:
 
 # includes a host to the inventory when any of these expressions is true, can refer to any vars defined on the host
 include_host_filters:
-    # includes hosts that in the eastus region and power on 
+    # includes hosts that in the eastus region and power on
     - location in ['eastus'] and powerstate == 'running'
     # includes hosts in the eastus region and power on OR includes hosts in the eastus2 region and tagkey is tagkey
     - location in ['eastus'] and powerstate == 'running'

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -223,7 +223,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         self._filters = self.get_option('exclude_host_filters') + self.get_option('default_host_filters')
 
-        self._include_filters = self.get_option('include_host_filters') 
+        self._include_filters = self.get_option('include_host_filters')
 
         try:
             self._credential_setup()
@@ -341,12 +341,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         return False
 
-    def _filter_include_host(self,inventory_hostname, hostvars):
-        return self._filter_host(self._include_filters,inventory_hostname,hostvars)
-    
-    def _filter_exclude_host(self,inventory_hostname, hostvars):
-        return self._filter_host(self._filters ,inventory_hostname,hostvars)
-    
+    def _filter_include_host(self, inventory_hostname, hostvars):
+        return self._filter_host(self._include_filters, inventory_hostname, hostvars)
+
+    def _filter_exclude_host(self, inventory_hostname, hostvars):
+        return self._filter_host(self._filters, inventory_hostname, hostvars)
 
     def _get_hostname(self, host, hostnames=None, strict=False):
         hostname = None

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -114,7 +114,6 @@ include_host_filters:
     - location in ['eastus'] and powerstate == 'running'
     - location in ['eastus2'] and tags['tagkey'] is defined and tags['tagkey'] == 'tagkey'
 
- 
 '''
 
 # FUTURE: do we need a set of sane default filters, separate from the user-defineable ones?

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -105,6 +105,16 @@ exclude_host_filters:
     - tags['tagkey2'] is defined and tags['tagkey2'] == 'tagkey2'
     # excludes hosts that are powered off
     - powerstate != 'running'
+
+# includes a host to the inventory when any of these expressions is true, can refer to any vars defined on the host
+include_host_filters:
+    # includes hosts that in the eastus region and power on 
+    - location in ['eastus'] and powerstate == 'running'
+    # includes hosts in the eastus region and power on OR includes hosts in the eastus2 region and tagkey is tagkey
+    - location in ['eastus'] and powerstate == 'running'
+    - location in ['eastus2'] and tags['tagkey'] is defined and tags['tagkey'] == 'tagkey'
+
+    
 '''
 
 # FUTURE: do we need a set of sane default filters, separate from the user-defineable ones?
@@ -215,6 +225,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         self._filters = self.get_option('exclude_host_filters') + self.get_option('default_host_filters')
 
+        self._include_filters = self.get_option('include_host_filters') 
+
         try:
             self._credential_setup()
             self._get_hosts()
@@ -297,7 +309,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         for h in self._hosts:
             # FUTURE: track hostnames to warn if a hostname is repeated (can happen for legacy and for composed inventory_hostname)
             inventory_hostname = self._get_hostname(h, hostnames=constructable_hostnames, strict=constructable_config_strict)
-            if self._filter_host(inventory_hostname, h.hostvars):
+            if self._filter_exclude_host(inventory_hostname, h.hostvars):
+                continue
+            if not self._filter_include_host(inventory_hostname, h.hostvars):
                 continue
             self.inventory.add_host(inventory_hostname)
             # FUTURE: configurable default IP list? can already do this via hostvar_expressions
@@ -313,10 +327,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self._add_host_to_keyed_groups(constructable_config_keyed_groups, h.hostvars, inventory_hostname, strict=constructable_config_strict)
 
     # FUTURE: fix underlying inventory stuff to allow us to quickly access known groupvars from reconciled host
-    def _filter_host(self, inventory_hostname, hostvars):
+    def _filter_host(self, filter, inventory_hostname, hostvars):
         self.templar.available_variables = hostvars
 
-        for condition in self._filters:
+        for condition in filter:
             # FUTURE: should warn/fail if conditional doesn't return True or False
             conditional = "{{% if {0} %}} True {{% else %}} False {{% endif %}}".format(condition)
             try:
@@ -328,6 +342,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 continue
 
         return False
+
+    def _filter_include_host(self,inventory_hostname, hostvars):
+        return self._filter_host(self._include_filters,inventory_hostname,hostvars)
+    
+    def _filter_exclude_host(self,inventory_hostname, hostvars):
+        return self._filter_host(self._filters ,inventory_hostname,hostvars)
+    
 
     def _get_hostname(self, host, hostnames=None, strict=False):
         hostname = None

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -113,7 +113,6 @@ include_host_filters:
     # includes hosts in the eastus region and power on OR includes hosts in the eastus2 region and tagkey is tagkey
     - location in ['eastus'] and powerstate == 'running'
     - location in ['eastus2'] and tags['tagkey'] is defined and tags['tagkey'] == 'tagkey'
-
 '''
 
 # FUTURE: do we need a set of sane default filters, separate from the user-defineable ones?


### PR DESCRIPTION
The azure_rm inventory currently only supports the blacklist filter through exclude_host_filter; the include_host_filters is added to support the whitelist filter. By default, include_host_filters is set to [true] to avoid impacting any of the existing azure_rm inventory configurations.