### PR TITLE
Added option for disabling MSI autodiscover feature in azure_keyvault_secret lookup plugin

### DIFF
--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -15,7 +15,6 @@ version_added: '1.12.0'
 requirements:
     - requests
     - azure
-    - msrest
 short_description: Read secret from Azure Key Vault.
 description:
   - This lookup returns the content of secret saved in Azure Key Vault.
@@ -181,7 +180,10 @@ class LookupModule(LookupBase):
 
         if use_msi:
             try:
-                token_res = requests.get('http://169.254.169.254/metadata/identity/oauth2/token', params=token_params, headers=token_headers, timeout=(3.05, 27))
+                token_res = requests.get('http://169.254.169.254/metadata/identity/oauth2/token',
+                                         params=token_params,
+                                         headers=token_headers,
+                                         timeout=(3.05, 27))
                 if token_res.ok:
                     token = token_res.json().get("access_token")
                     if token is not None:

--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -33,7 +33,7 @@ options:
     tenant_id:
         description: Tenant id of service principal.
     use_msi:
-        description: MSI token autodiscover, default is true
+        description: MSI token autodiscover, default is true.
 notes:
     - If version is not provided, this plugin will return the latest version of the secret.
     - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't required.


### PR DESCRIPTION
##### SUMMARY
Added an option to be able to disable MSI autodiscover feature.

The default for the module is to assume that the MSI metadata URL is available, which slows down the module considerably when not being able to access that IP.

This way the original intended functionality is preserved and we who want to use it without MSI available can do so without an almost 30s penalty.

Some things had to be moved around due to where the options kwarg is available.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure.azcollection.azure_keyvault_secret

##### ADDITIONAL INFORMATION
Below follows a paste from running with and without MSI autodiscover enabled
With MSI autodiscovery without MSI metadata host:
```
PLAY [localhost] ***************************************************************************************************************************************************************************

TASK [debug] *******************************************************************************************************************************************************************************
Friday 19 August 2022  09:35:14 +0200 (0:00:00.016)       0:00:00.016 *********
Your credentials class does not support session injection. Performance will not be at the maximum.
ok: [localhost] => {
    "msg": "the value of this secret is <redacted>"
}

PLAY RECAP *********************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Friday 19 August 2022  09:35:42 +0200 (0:00:28.608)       0:00:28.624 *********
===============================================================================
debug ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 28.61s
Playbook run took 0 days, 0 hours, 0 minutes, 28 seconds

```
Without MSI autodiscovery enabled:
```
PLAY [localhost] ***************************************************************************************************************************************************************************

TASK [debug] *******************************************************************************************************************************************************************************
Friday 19 August 2022  09:35:06 +0200 (0:00:00.019)       0:00:00.019 *********
Your credentials class does not support session injection. Performance will not be at the maximum.
ok: [localhost] => {
    "msg": "the value of this secret is <redacted>"
}

PLAY RECAP *********************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Friday 19 August 2022  09:35:07 +0200 (0:00:00.920)       0:00:00.939 *********
===============================================================================
debug ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.92s
Playbook run took 0 days, 0 hours, 0 minutes, 0 seconds
```

And some examples that were in the previous pull request

### Using MSI autodiscovery

```- hosts: local
  connection: local
  vars:
    azure_keyvault_url: https://something.vault.azure.net
    azure_client_id: xxxxxx-xxxx-xxxxx-xxxxx
    azure_secret: xxxxxx-xxx-xxxxx-xxxxxx
    azure_tenant_id: xxxxxxx-xxxx-xxxxx-xxxxx-
  tasks:
    - debug:
        msg: "{{ lookup('azure.azcollection.azure_keyvault_secret','secretname',vault_url=azure_keyvault_url, client_id=azure_client_id, secret=azure_secret, tenant_id=azure_tenant_id) }}
```
		
### Without MSI autodiscovery

```- hosts: local
  connection: local
  vars:
    azure_keyvault_url: https://something.vault.azure.net
    azure_client_id: xxxxxx-xxxx-xxxxx-xxxxx
    azure_secret: xxxxxx-xxx-xxxxx-xxxxxx
    azure_tenant_id: xxxxxxx-xxxx-xxxxx-xxxxx-
  tasks:
    - debug:
        msg: "{{ lookup('azure.azcollection.azure_keyvault_secret','secretname',vault_url=azure_keyvault_url, client_id=azure_client_id, secret=azure_secret, tenant_id=azure_tenant_id, use_msi=False) }}
```