### PR TITLE
Add support for HTTP 2.0 in webapps (app service)

### DIFF
--- a/plugins/modules/azure_rm_webapp.py
+++ b/plugins/modules/azure_rm_webapp.py
@@ -139,6 +139,11 @@ options:
             - Keeps the app loaded even when there's no traffic.
         type: bool
 
+    http20_enabled:
+        description:
+            - Configures a web site to allow clients to connect over HTTP 2.0.
+        type: bool
+
     min_tls_version:
         description:
             - The minimum TLS encryption version required for the app.
@@ -494,6 +499,9 @@ class AzureRMWebApps(AzureRMModuleBase):
             always_on=dict(
                 type='bool',
             ),
+            http20_enabled=dict(
+                type='bool',
+            ),
             min_tls_version=dict(
                 type='str',
                 choices=['1.0', '1.1', '1.2'],
@@ -583,6 +591,7 @@ class AzureRMWebApps(AzureRMModuleBase):
                                                  "python_version",
                                                  "scm_type",
                                                  "always_on",
+                                                 "http20_enabled",
                                                  "min_tls_version",
                                                  "ftps_state"]
 
@@ -605,7 +614,7 @@ class AzureRMWebApps(AzureRMModuleBase):
             if hasattr(self, key):
                 setattr(self, key, kwargs[key])
             elif kwargs[key] is not None:
-                if key in ["scm_type", "always_on", "min_tls_version", "ftps_state"]:
+                if key in ["scm_type", "always_on", "http20_enabled", "min_tls_version", "ftps_state"]:
                     self.site_config[key] = kwargs[key]
 
         old_response = None
@@ -852,7 +861,7 @@ class AzureRMWebApps(AzureRMModuleBase):
     # compare xxx_version
     def is_site_config_changed(self, existing_config):
         for updatable_property in self.site_config_updatable_properties:
-            if self.site_config.get(updatable_property):
+            if updatable_property in self.site_config:
                 if not getattr(existing_config, updatable_property) or \
                         str(getattr(existing_config, updatable_property)).upper() != str(self.site_config.get(updatable_property)).upper():
                     return True

--- a/plugins/modules/azure_rm_webapp_info.py
+++ b/plugins/modules/azure_rm_webapp_info.py
@@ -138,6 +138,12 @@ webapps:
             returned: always
             type: bool
             sample: true
+        http20_enabled:
+            description:
+                - Configures a web site to allow clients to connect over HTTP 2.0.
+            returned: always
+            type: bool
+            sample: true
         min_tls_version:
             description:
                 - The minimum TLS encryption version required for the app.
@@ -486,6 +492,7 @@ class AzureRMWebAppInfo(AzureRMModuleBase):
                     curated_output['frameworks'].append({'name': tmp[0].lower(), 'version': tmp[1]})
 
             curated_output['always_on'] = configuration.get('always_on')
+            curated_output['http20_enabled'] = configuration.get('http20_enabled')
             curated_output['ftps_state'] = configuration.get('ftps_state')
             curated_output['min_tls_version'] = configuration.get('min_tls_version')
 

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -354,7 +354,7 @@
 
 - name: Create a web app with various site config params
   azure_rm_webapp:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ linux_app_plan_resource_group }}"
     name: "{{ linux_app_name }}-siteconfig"
     plan:
       resource_group: "{{ linux_app_plan_resource_group }}"
@@ -379,7 +379,7 @@
 
 - name: Create a web app with various site config params - idempotent
   azure_rm_webapp:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ linux_app_plan_resource_group }}"
     name: "{{ linux_app_name }}-siteconfig"
     plan:
       resource_group: "{{ linux_app_plan_resource_group }}"
@@ -404,7 +404,7 @@
 
 - name: Get facts for site config params
   azure_rm_webapp_info:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ linux_app_plan_resource_group }}"
     name: "{{ linux_app_name }}-siteconfig"
   register: facts
 - name: Assert site config params meet expectations
@@ -413,10 +413,11 @@
       - facts.webapps[0].always_on
       - facts.webapps[0].min_tls_version == '1.2'
       - facts.webapps[0].ftps_state == 'Disabled'
+      - not facts.webapps[0].http20_enabled
 
 - name: Update web app with various site config params - single change
   azure_rm_webapp:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ linux_app_plan_resource_group }}"
     name: "{{ linux_app_name }}-siteconfig"
     plan:
       resource_group: "{{ linux_app_plan_resource_group }}"
@@ -441,7 +442,7 @@
 
 - name: Get facts for site config params
   azure_rm_webapp_info:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ linux_app_plan_resource_group }}"
     name: "{{ linux_app_name }}-siteconfig"
   register: facts
 - name: Assert site config params meet expectations
@@ -450,6 +451,111 @@
       - facts.webapps[0].always_on
       - facts.webapps[0].min_tls_version == '1.2'
       - facts.webapps[0].ftps_state == 'FtpsOnly'
+      - not facts.webapps[0].http20_enabled
+
+- name: Create a web app with HTTP 2.0
+  azure_rm_webapp:
+    resource_group: "{{ linux_app_plan_resource_group }}"
+    name: "{{ linux_app_name }}-http20"
+    plan:
+      resource_group: "{{ linux_app_plan_resource_group }}"
+      name: "{{ linux_app_name }}-http20-plan"
+      is_linux: true
+      sku: S1
+    frameworks:
+      - name: java
+        version: "8"
+        settings:
+          java_container: "tomcat"
+          java_container_version: "8.5"
+    client_affinity_enabled: false
+    https_only: true
+    always_on: true
+    min_tls_version: "1.2"
+    ftps_state: "Disabled"
+    http20_enabled: true
+  register: output
+- name: Assert the web app was created
+  ansible.builtin.assert:
+    that: output.changed
+
+- name: Create a web app with HTTP 2.0 - idempotent
+  azure_rm_webapp:
+    resource_group: "{{ linux_app_plan_resource_group }}"
+    name: "{{ linux_app_name }}-http20"
+    plan:
+      resource_group: "{{ linux_app_plan_resource_group }}"
+      name: "{{ linux_app_name }}-http20-plan"
+      is_linux: true
+      sku: S1
+    frameworks:
+      - name: java
+        version: "8"
+        settings:
+          java_container: "tomcat"
+          java_container_version: "8.5"
+    client_affinity_enabled: false
+    https_only: true
+    always_on: true
+    min_tls_version: "1.2"
+    ftps_state: "Disabled"
+    http20_enabled: true
+  register: output
+- name: Assert the web app not changed
+  ansible.builtin.assert:
+    that: not output.changed
+
+- name: Get facts for HTTP 2.0 appp
+  azure_rm_webapp_info:
+    resource_group: "{{ linux_app_plan_resource_group }}"
+    name: "{{ linux_app_name }}-http20"
+  register: facts
+- name: Assert site config params meet expectations
+  ansible.builtin.assert:
+    that:
+      - facts.webapps[0].always_on
+      - facts.webapps[0].min_tls_version == '1.2'
+      - facts.webapps[0].ftps_state == 'Disabled'
+      - facts.webapps[0].http20_enabled
+
+- name: Update web app to disable HTTP 2.0
+  azure_rm_webapp:
+    resource_group: "{{ linux_app_plan_resource_group }}"
+    name: "{{ linux_app_name }}-http20"
+    plan:
+      resource_group: "{{ linux_app_plan_resource_group }}"
+      name: "{{ linux_app_name }}-http20-plan"
+      is_linux: true
+      sku: S1
+    frameworks:
+      - name: java
+        version: "8"
+        settings:
+          java_container: "tomcat"
+          java_container_version: "8.5"
+    client_affinity_enabled: false
+    https_only: true
+    always_on: true
+    min_tls_version: "1.2"
+    ftps_state: "Disabled"
+    http20_enabled: false
+  register: output
+- name: Assert the web app was updated
+  ansible.builtin.assert:
+    that: output.changed
+
+- name: Get facts for HTTP 2.0 appp
+  azure_rm_webapp_info:
+    resource_group: "{{ linux_app_plan_resource_group }}"
+    name: "{{ linux_app_name }}-http20"
+  register: facts
+- name: Assert site config params meet expectations
+  ansible.builtin.assert:
+    that:
+      - facts.webapps[0].always_on
+      - facts.webapps[0].min_tls_version == '1.2'
+      - facts.webapps[0].ftps_state == 'Disabled'
+      - not facts.webapps[0].http20_enabled
 
 - name: Create a webapp slot (Check mode)
   azure_rm_webappslot:


### PR DESCRIPTION
##### SUMMARY

This PR adds support for being able to configure HTTP 2.0 on an web app (app service).

![image](https://github.com/ansible-collections/azure/assets/2243641/763776fb-15a0-49ae-b281-ca3da8b2b614)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_webapp.py

##### ADDITIONAL INFORMATION
Updated integration tests and they successfully execute.