### PR TITLE
Adding tags to the azure_rm_appgateway module.

### DIFF
--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -1854,9 +1854,6 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                 type='str',
                 default='present',
                 choices=['present', 'absent']
-            ),
-            tags=dict(
-                type='dict'
             )
         )
 

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -2298,10 +2298,10 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
             else:
                 self.to_do = Actions.NoAction
 
-        update_tags, new_tags = self.update_tags(old_response['tags'])
-        if update_tags:
-            self.to_do = Actions.Update
-            self.parameters["tags"] = new_tags
+            update_tags, new_tags = self.update_tags(old_response['tags'])
+            if update_tags:
+                self.to_do = Actions.Update
+                self.parameters["tags"] = new_tags
 
         if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):
             self.log("Need to Create / Update the Application Gateway instance")

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -1854,6 +1854,9 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                 type='str',
                 default='present',
                 choices=['present', 'absent']
+            ),
+            tags=dict(
+                type='dict'
             )
         )
 
@@ -2239,6 +2242,8 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     self.parameters["web_application_firewall_configuration"] = kwargs[key]
                 elif key == "enable_http2":
                     self.parameters["enable_http2"] = kwargs[key]
+                elif key == "tags":
+                    self.parameters["tags"] = kwargs[key]
 
         response = None
 
@@ -2291,7 +2296,8 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     not compare_arrays(old_response, self.parameters, 'url_path_maps') or
                     not compare_arrays(old_response, self.parameters, 'trusted_root_certificates') or
                     not compare_dicts(old_response, self.parameters, 'autoscale_configuration') or
-                    not compare_dicts(old_response, self.parameters, 'web_application_firewall_configuration')):
+                    not compare_dicts(old_response, self.parameters, 'web_application_firewall_configuration') or
+                    not compare_dicts(old_response, self.parameters, 'tags')):
                 self.to_do = Actions.Update
             else:
                 self.to_do = Actions.NoAction

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -2293,7 +2293,7 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     not compare_arrays(old_response, self.parameters, 'url_path_maps') or
                     not compare_arrays(old_response, self.parameters, 'trusted_root_certificates') or
                     not compare_dicts(old_response, self.parameters, 'autoscale_configuration') or
-                    not compare_dicts(old_response, self.parameters, 'web_application_firewall_configuration'):
+                    not compare_dicts(old_response, self.parameters, 'web_application_firewall_configuration')):
                 self.to_do = Actions.Update
             else:
                 self.to_do = Actions.NoAction

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -2293,11 +2293,15 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     not compare_arrays(old_response, self.parameters, 'url_path_maps') or
                     not compare_arrays(old_response, self.parameters, 'trusted_root_certificates') or
                     not compare_dicts(old_response, self.parameters, 'autoscale_configuration') or
-                    not compare_dicts(old_response, self.parameters, 'web_application_firewall_configuration') or
-                    not compare_dicts(old_response, self.parameters, 'tags')):
+                    not compare_dicts(old_response, self.parameters, 'web_application_firewall_configuration'):
                 self.to_do = Actions.Update
             else:
                 self.to_do = Actions.NoAction
+
+        update_tags, new_tags = self.update_tags(old_response['tags'])
+        if update_tags:
+            self.to_do = Actions.Update
+            self.parameters["tags"] = new_tags
 
         if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):
             self.log("Need to Create / Update the Application Gateway instance")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The azure_rm_appgateway module looks like it was intended to use tags because of the `supports_tags=True` flag for AzureRMModuleBase, but it seems like they were just missed. I'm adding them in so when using this module the tags get set on the resource in Azure. I have confirmed create and update (deleting tags) works. There doesn't seem to be an existing issue for this yet.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_appgateway


