### PR TITLE
Set ansible_host to the first public IP address, if no found, the first private IP will be set

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -316,7 +316,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.inventory.add_host(inventory_hostname)
             # FUTURE: configurable default IP list? can already do this via hostvar_expressions
             self.inventory.set_variable(inventory_hostname, "ansible_host",
-                                        next(chain([h.hostvars['public_ipv4_address']], h.hostvars['private_ipv4_addresses']), None))
+                                        next(chain(h.hostvars['public_ipv4_address'], h.hostvars['private_ipv4_addresses']), None))
             for k, v in iteritems(h.hostvars):
                 # FUTURE: configurable hostvar prefix? Makes docs harder...
                 self.inventory.set_variable(inventory_hostname, k, v)


### PR DESCRIPTION
…st private IP will be set

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set ansible_host to the first public IP address, if no found, the first private IP will be set, fixes #1384
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
