### PR TITLE
Fix missing client_id in payload error when using only an Azure username and password

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1491,7 +1491,9 @@ class AzureRMAuth(object):
                                                                                     authority=self._adfs_authority_url)
 
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            client_id = self.credentials.get('client_id', '04b07795-8ddb-461a-bbee-02f9e1bf7b46')
+            client_id = self.credentialss.get('client_id')
+            if client_id is None:
+                client_id = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
             self.azure_credential_track2 = user_password.UsernamePasswordCredential(username=self.credentials['ad_user'],
                                                                                     password=self.credentials['password'],
                                                                                     tenant_id=self.credentials.get('tenant', 'organizations'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix code that does not set a default client_id correctly when only the ad_user and password are provided for authentication.

The code will now attempt to set the client_id to self.credentials.get('client_id'), if that value is `None` because it was not passed in, it will set client_id to a default value.

Fixes #1408 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Modules will now execute when a user only provides an Azure username and password.

```
