### PR TITLE
Add Microsoft.ContainerService/managedClusters to subnet delegations

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -124,6 +124,7 @@ options:
                 required: True
                 type: str
                 choices:
+                    - Microsoft.ContainerService/managedClusters
                     - Microsoft.Web/serverFarms
                     - Microsoft.ContainerInstance/containerGroups
                     - Microsoft.Netapp/volumes
@@ -352,7 +353,8 @@ delegations_spec = dict(
                  'Microsoft.DBforPostgreSQL/serversv2', 'Microsoft.AzureCosmosDB/clusters', 'Microsoft.MachineLearningServices/workspaces',
                  'Microsoft.DBforPostgreSQL/singleServers', 'Microsoft.DBforPostgreSQL/flexibleServers', 'Microsoft.DBforMySQL/serversv2',
                  'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.ApiManagement/service', 'Microsoft.Synapse/workspaces',
-                 'Microsoft.PowerPlatform/vnetaccesslinks', 'Microsoft.Network/managedResolvers', 'Microsoft.Kusto/clusters']
+                 'Microsoft.PowerPlatform/vnetaccesslinks', 'Microsoft.Network/managedResolvers', 'Microsoft.Kusto/clusters',
+                 'Microsoft.ContainerService/managedClusters']
     ),
     actions=dict(
         type='list',


### PR DESCRIPTION
##### SUMMARY
I am in the need of adding Microsoft.ContainerService/managedClusters  delegation for AKS. Tough I think it might be also ok to remove all the array from the definition and let the Server API check the correct type. Please let me know if I can remove all type checking of the client lib. 

- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_subnet.py

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create a subnet
  azure.azcollection.azure_rm_subnet:
    resource_group: global
    virtual_network_name: global
    name: "{{ cluster.name }}APISubnet"
    address_prefix_cidr: "{{ cluster.api_subnet }}"
    delegations:
    - serviceName: Microsoft.ContainerService/managedClusters
      name: ContainerService
```
