### PR TITLE
Update adgroup test cases to use object_id

### DIFF
--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -93,16 +93,16 @@ EXAMPLES = '''
     mail_nickname: "Group-Mail-Nickname"
     state: 'present'
     present_members:
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ ad_object_1_object_id }}"
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ ad_object_2_object_id }}"
+      - "{{ ad_object_1_object_id }}"
+      - "{{ ad_object_2_object_id }}"
 
 - name: Ensure Users are Members of a Group using object_id
   azure_rm_adgroup:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     state: 'present'
     present_members:
-      - "https://graph.windows.net/{{ ad_object_1_tenant_id }}/directoryObjects/{{ ad_object_1_object_id }}"
-      - "https://graph.windows.net/{{ ad_object_2_tenant_id }}/directoryObjects/{{ ad_object_2_object_id }}"
+      - "{{ ad_object_1_object_id }}"
+      - "{{ ad_object_2_object_id }}"
 
 - name: Ensure Users are not Members of a Group using display_name and mail_nickname
   azure_rm_adgroup:
@@ -125,16 +125,16 @@ EXAMPLES = '''
     mail_nickname: "Group-Mail-Nickname"
     state: 'present'
     present_owners:
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ ad_object_1_object_id }}"
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ ad_object_2_object_id }}"
+      - "{{ ad_object_1_object_id }}"
+      - "{{ ad_object_2_object_id }}"
 
 - name: Ensure Users are Owners of a Group using object_id
   azure_rm_adgroup:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     state: 'present'
     present_owners:
-      - "https://graph.windows.net/{{ ad_object_1_tenant_id }}/directoryObjects/{{ ad_object_1_object_id }}"
-      - "https://graph.windows.net/{{ ad_object_2_tenant_id }}/directoryObjects/{{ ad_object_2_object_id }}"
+      - "{{ ad_object_1_object_id }}"
+      - "{{ ad_object_2_object_id }}"
 
 - name: Ensure Users are not Owners of a Group using display_name and mail_nickname
   azure_rm_adgroup:

--- a/tests/integration/targets/azure_rm_adgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adgroup/tasks/main.yml
@@ -66,8 +66,8 @@
     mail_nickname: "{{ resource_prefix }}-Group-Root"
     state: 'present'
     present_members:
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ create_pass_first.object_id }}"
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ create_pass_second.object_id }}"
+      - "{{ create_pass_first.object_id }}"
+      - "{{ create_pass_second.object_id }}"
   register: add_pass
 
 - name: Validate members are in the group
@@ -81,7 +81,7 @@
     object_id: "{{ group_create_changed_shouldpass.object_id }}"
     state: 'present'
     present_members:
-      - "https://graph.windows.net/{{ tenant_id }}/directoryObjects/{{ create_pass_first.object_id }}"
+      - "{{ create_pass_first.object_id }}"
   register: add_already_present_member_to_group_shouldpass
 
 - name: Validate nothing changed from already present member


### PR DESCRIPTION
##### SUMMARY
The format of members must have changed at some point and only object_id's are valid to add.  This pr updates the test cases to use object_id and they now pass.

Fixes: #1387 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_adgroup

##### ADDITIONAL INFORMATION
You can see from the following method that only object_id can be passed:
    async def add_group_member(self, group_id, obj_id):
        request_body = ReferenceCreate(
            odata_id="https://graph.microsoft.com/v1.0/directoryObjects/{0}".format(obj_id),
        )
        await self._client.groups.by_group_id(group_id).members.ref.post(body=request_body)

I believe this changed in commit 21f6e15217ee042f166a129c4ac3745d3a949a38 when the code migrated from ADGraph to MSGraph.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [Ensure member is in group using display_name and mail_nickname] *************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was:         error: MainError(additional_data={}, code='Request_BadRequest', details=None, inner_error=InnerError(additional_data={'date': DateTime(2024, 1, 22, 18, 35, 52, tzinfo=Timezone('UTC'))}, client_request_id='dd2fbb69-b31b-4174-8dce-def8b308a093', date=None, odata_type=None, request_id='7063e0ee-119b-44fb-8891-ed752f1006da'), message='Unexpected segment DynamicPathSegment. Expected property/$value.', target=None)
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 302, in exec_module\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 324, in update_members\n  File \"/usr/lib64/python3.8/asyncio/base_events.py\", line 616, in run_until_complete\n    return future.result()\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 472, in add_group_member\n  File \"/usr/local/lib/python3.8/site-packages/msgraph/generated/groups/item/members/ref/ref_request_builder.py\", line 73, in post\n    return await self.request_adapter.send_no_response_content_async(request_info, error_mapping)\n  File \"/usr/local/lib/python3.8/site-packages/kiota_http/httpx_request_adapter.py\", line 377, in send_no_response_content_async\n    await self.throw_failed_responses(response, error_map, parent_span, parent_span)\n  File \"/usr/local/lib/python3.8/site-packages/kiota_http/httpx_request_adapter.py\", line 501, in throw_failed_responses\n    raise exc\nmsgraph.generated.models.o_data_errors.o_data_error.ODataError: \n        APIError\n        Code: 400\n        message: None\n        error: MainError(additional_data={}, code='Request_BadRequest', details=None, inner_error=InnerError(additional_data={'date': DateTime(2024, 1, 22, 18, 35, 52, tzinfo=Timezone('UTC'))}, client_request_id='dd2fbb69-b31b-4174-8dce-def8b308a093', date=None, odata_type=None, request_id='7063e0ee-119b-44fb-8891-ed752f1006da'), message='Unexpected segment DynamicPathSegment. Expected property/$value.', target=None)\n        \n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1705948549.463567-185232-28868562038901/AnsiballZ_azure_rm_adgroup.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1705948549.463567-185232-28868562038901/AnsiballZ_azure_rm_adgroup.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1705948549.463567-185232-28868562038901/AnsiballZ_azure_rm_adgroup.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.azure.azcollection.plugins.modules.azure_rm_adgroup', init_globals=dict(_module_fqn='ansible_collections.azure.azcollection.plugins.modules.azure_rm_adgroup', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 501, in <module>\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 497, in main\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 249, in __init__\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/module_utils/azure_rm_common.py\", line 446, in __init__\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/modules/azure_rm_adgroup.py\", line 307, in exec_module\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible_collections/azure/azcollection/plugins/module_utils/azure_rm_common.py\", line 479, in fail\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible/module_utils/basic.py\", line 1533, in fail_json\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible/module_utils/basic.py\", line 1506, in _return_formatted\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible/module_utils/common/parameters.py\", line 887, in remove_values\n  File \"/tmp/ansible_azure.azcollection.azure_rm_adgroup_payload_dw_05hpm/ansible_azure.azcollection.azure_rm_adgroup_payload.zip/ansible/module_utils/common/parameters.py\", line 461, in _remove_values_conditions\nTypeError: Value of unknown type: <class 'msgraph.generated.models.o_data_errors.o_data_error.ODataError'>, \n        APIError\n        Code: 400\n        message: None\n        error: MainError(additional_data={}, code='Request_BadRequest', details=None, inner_error=InnerError(additional_data={'date': DateTime(2024, 1, 22, 18, 35, 52, tzinfo=Timezone('UTC'))}, client_request_id='dd2fbb69-b31b-4174-8dce-def8b308a093', date=None, odata_type=None, request_id='7063e0ee-119b-44fb-8891-ed752f1006da'), message='Unexpected segment DynamicPathSegment. Expected property/$value.', target=None)\n        \n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

After:
TASK [Ensure member is in group using display_name and mail_nickname] *************************************************
changed: [localhost]
```
