### PR TITLE
Update azure_rm_adapplication to return all AD Applications. Enhancement to search for application by app_display_name

### DIFF
--- a/plugins/modules/azure_rm_adapplication_info.py
+++ b/plugins/modules/azure_rm_adapplication_info.py
@@ -197,7 +197,7 @@ class AzureRMADApplicationInfo(AzureRMModuleBase):
             applications = await self._client.applications.get()
             for app in applications.value:
                 applications_list.append(app)
-            
+
             if applications.odata_next_link:
                 next_link = applications.odata_next_link
             else:

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -53,6 +53,11 @@
     app_id: "{{ create_output.app_id }}"
   register: output
 
+- name: Get ad app info by display name
+  azure_rm_adapplication_info:
+    object_id: "{{ create_output.app_display_name }}"
+  register: output
+
 - name: Assert the application facts
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add functionality to search for Application by app_display_name. Fix ad application search by tenant to return all applications.
- Update test for azure_rm_adapplication to search by display name.
- Some small documentation fixes.

Fixes #1419

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_adapplication_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Run a playbook with the following task in it:
```
- name: "Get all AD Applications from Tenant"
  azure.azcollection.azure_rm_adapplication_info:
    tenant: "{{ prod_tenant }}"
  register: ad_app_tenant_info

- name: "Print ad_app_tenant_info"
  ansible.builtin.debug:
    msg: "{{ ad_app_tenant_info.applications | length }}"
  when: 1 == 1
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE:
TASK [Get all AD Applications from Tenant] **********************************************************************************************************************
ok: [localhost]

TASK [Print ad_app_tenant_info] *********************************************************************************************************************************
ok: [localhost] => {
    "msg": "100"
}

AFTER:
TASK [Get all AD Applications from Tenant] **********************************************************************************************************************
ok: [localhost]

TASK [Print ad_app_tenant_info] *********************************************************************************************************************************
ok: [localhost] => {
    "msg": "2458"
}
```
