### PR TITLE
Fix typo. Change `credentialss` to `credentials`

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1491,7 +1491,9 @@ class AzureRMAuth(object):
                                                                                     authority=self._adfs_authority_url)
 
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            client_id = self.credentials.get('client_id', '04b07795-8ddb-461a-bbee-02f9e1bf7b46')
+            client_id = self.credentialss.get('client_id')
+            if client_id is None:
+                client_id = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
             self.azure_credential_track2 = user_password.UsernamePasswordCredential(username=self.credentials['ad_user'],
                                                                                     password=self.credentials['password'],
                                                                                     tenant_id=self.credentials.get('tenant', 'organizations'),

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1522,7 +1522,7 @@ class AzureRMAuth(object):
                                                                                     authority=self._adfs_authority_url)
 
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            client_id = self.credentialss.get('client_id')
+            client_id = self.credentials.get('client_id')
             if client_id is None:
                 client_id = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
             self.azure_credential_track2 = user_password.UsernamePasswordCredential(username=self.credentials['ad_user'],

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -53,6 +53,11 @@
     app_id: "{{ create_output.app_id }}"
   register: output
 
+- name: Get ad app info by display name
+  azure_rm_adapplication_info:
+    object_id: "{{ create_output.app_display_name }}"
+  register: output
+
 - name: Assert the application facts
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
- Fixes #1408
- Add app_display_name option and fix bug that doesn't fetch all applications from tenant.
- Update adapplication module test to test for adapplication_info module search by display_name
- Fix typo line 1525

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
