### PR TITLE
Ensure enable_http2 works when targeting existing Application Gateways

### DIFF
--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -2274,7 +2274,7 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                   (old_response['operational_state'] == 'Running' and self.gateway_state == 'started')):
                 self.to_do = Actions.NoAction
             elif (self.parameters['location'] != old_response['location'] or
-                    self.parameters['enable_http2'] != old_response['enable_http2'] or
+                    self.parameters['enable_http2'] != old_response.get('enable_http2', False) or
                     self.parameters['sku']['name'] != old_response['sku']['name'] or
                     self.parameters['sku']['tier'] != old_response['sku']['tier'] or
                     self.parameters['sku'].get('capacity', None) != old_response['sku'].get('capacity', None) or


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We've found that, when deploying an application gateway using bicep templates, if the enable_http2 parameter is not specified it will make any kind of request to retrieve the status of that particular AppGW to not return the enable_http2 parameter status. We've verified that using the azcli and the API directly.
This makes any attempt to manage an existing AppGW deployed through the aforementioned means to fail since the `old_response` doesn't have the `enable_http2` key.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_appgateway