### PR TITLE
Add support for disable_instance_discovery

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -65,6 +65,19 @@ options:
         type: str
         choices: [ ignore, validate ]
         version_added: '0.0.1'
+    disable_instance_discovery:
+        description:
+            - Determines whether or not instance discovery is performed when attempting to authenticate.
+              Setting this to true will completely disable both instance discovery and authority validation.
+              This functionality is intended for use in scenarios where the metadata endpoint cannot be reached
+              such as in private clouds or Azure Stack. The process of instance discovery entails retrieving
+              authority metadata from https://login.microsoft.com/ to validate the authority. By setting this
+              to **True**, the validation of the authority is disabled. As a result, it is crucial to ensure
+              that the configured authority host is valid and trustworthy.
+            - Set via credential file profile or the C(AZURE_DISABLE_INSTANCE_DISCOVERY) environment variable.
+        type: bool
+        default: False
+        version_added: '2.3.0'
     auth_source:
         description:
             - Controls the source of the credentials to use for authentication.


### PR DESCRIPTION
##### SUMMARY
Added support in ansible common to support setting disable_instance_discovery when using azure clouds and you don't have access to login.microsoftonline.com.

This can be specified as a module argument, environment variable or in credential profile.  To enable set to True, default if False which doesn't change the current behaviour.

Fixes #1236

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common

##### ADDITIONAL INFORMATION
This issue affects users who are using the Azure US Government cloud

As of today the Azure Collection fails to connect in this environment:

Network access is allowed to Azure US Government cloud. (login.microsoftonline.us)
Network access is not allowed to Azure Public cloud. (login.microsoftonline.com)
Trying to use the Azure collection in this environment fails with attempts to connect to login.microsoftonline.com.
