### PR TITLE
Allow for template expressions in some parameters

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -250,6 +250,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             adfs_authority_url=self.get_option('adfs_authority_url')
         )
 
+        if self.templar.is_template(auth_options["tenant"]):
+            auth_options["tenant"] = self.templar.template(variable=auth_options["tenant"], disable_lookups=False)
+
+        if self.templar.is_template(auth_options["client_id"]):
+            auth_options["client_id"] = self.templar.template(variable=auth_options["client_id"], disable_lookups=False)
+
+        if self.templar.is_template(auth_options["secret"]):
+            auth_options["secret"] = self.templar.template(variable=auth_options["secret"], disable_lookups=False)
+
+        if self.templar.is_template(auth_options["subscription_id"]):
+            auth_options["subscription_id"] = self.templar.template(variable=auth_options["subscription_id"], disable_lookups=False)
+
         self.azure_auth = AzureRMAuth(**auth_options)
 
         self._clientconfig = AzureRMRestConfiguration(self.azure_auth.azure_credential_track2, self.azure_auth.subscription_id,


### PR DESCRIPTION
SUMMARY

We would love to be able to use templates to evaluate the values of client_id, secret, tenant and subscription_id when configuring authentication for the azure_rm inventory plugin.

PR to address issue #1438 
ISSUE TYPE

* Feature Pull Request

COMPONENT NAME

`azure_rm` inventory plugin

ADDITIONAL INFORMATION

Our use case is somewhat particular, and we can't leverage the cli or environment variables for various reasons and we want to avoid our secrets hard coded in file. The ideal way for us to get those values in without having them on a file on disk is to execute a lookup in a template. This behavior works as described in a few other inventory plugins we're using for enumerating VMs on other providers, but in this case the plugin only seems to accept static values in the following fields:

`client_id`
`secret`
`tenant`
`subscription_id`

the change would evaluate if the parameters passed are a template expression and would then resolve the expression before moving on to the `AzureRMAuth` method
