### PR TITLE
Parse paginated replies for listing all users/groups

### DIFF
--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -331,7 +331,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
             if response:
                 groups += response.value
 
-        return []
+        return groups
 
     async def get_group_owners(self, group_id):
         request_configuration = GroupsRequestBuilder.GroupsRequestBuilderGetRequestConfiguration(

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -327,7 +327,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         if response:
             groups += response.value
         while response is not None and response.odata_next_link is not None:
-            response = self._client.groups.with_url(response.odata_next_link).get(**kwargs)
+            response = await self._client.groups.with_url(response.odata_next_link).get(**kwargs)
             if response:
                 groups += response.value
 

--- a/plugins/modules/azure_rm_aduser_info.py
+++ b/plugins/modules/azure_rm_aduser_info.py
@@ -216,8 +216,8 @@ class AzureRMADUserInfo(AzureRMModuleBase):
                 users = asyncio.get_event_loop().run_until_complete(self.get_users_by_filter(self.odata_filter))
                 ad_users = list(users.value)
             elif self.all:
-                users = asyncio.get_event_loop().run_until_complete(self.get_users())
-                ad_users = list(users.value)
+                # this returns as a list, since we parse multiple pages
+                ad_users = asyncio.get_event_loop().run_until_complete(self.get_users())
 
             self.results['ad_users'] = [self.to_dict(user) for user in ad_users]
 
@@ -251,7 +251,17 @@ class AzureRMADUserInfo(AzureRMModuleBase):
                 select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType"]
             ),
         )
-        return await self._client.users.get(request_configuration=request_configuration)
+        users = []
+        # paginated response can be quite large
+        response = await self._client.users.get(request_configuration=request_configuration)
+        if response:
+            users += response.value
+        while response is not None and response.odata_next_link is not None:
+            response = self._client.users.with_url(response.odata_next_link).get(request_configuration=request_configuration)
+            if response:
+                users += response.value
+
+        return users
 
     async def get_users_by_filter(self, filter):
         return await self._client.users.get(

--- a/plugins/modules/azure_rm_aduser_info.py
+++ b/plugins/modules/azure_rm_aduser_info.py
@@ -257,7 +257,7 @@ class AzureRMADUserInfo(AzureRMModuleBase):
         if response:
             users += response.value
         while response is not None and response.odata_next_link is not None:
-            response = self._client.users.with_url(response.odata_next_link).get(request_configuration=request_configuration)
+            response = await self._client.users.with_url(response.odata_next_link).get(request_configuration=request_configuration)
             if response:
                 users += response.value
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/azure/issues/1447

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_aduser_info
azure_rm_adgroup_ino

##### ADDITIONAL INFORMATION
I'm not in a position to run any of the official tests, but I did load a dev build of this into a playbook I have for manipulating users/groups and I confirmed it properly returns my entire user and group list
