### PR TITLE
Removing leftover storage account from test

### DIFF
--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -601,3 +601,4 @@
     - "{{ storage_account_name_default }}03"
     - "{{ storage_account_name_default }}04"
     - "{{ storage_account_name_default }}05"
+    - "{{ storage_account_name_default }}06"


### PR DESCRIPTION
##### SUMMARY
Last account is not cleaned up properly after test runs. This probably is masked if you re-create the resource group every time.

##### ISSUE TYPE
- Bugfix Pull Request

(really a tech debt fix)

##### COMPONENT NAME
tests/integration/targets/azure_rm_storageaccount

##### ADDITIONAL INFORMATION
1. Configure your environment for integration tests
2. Run SA integration test on an empty resource group
3. Resource group should be empty afterwards, but still shows one lingering SA
