### PR TITLE
Allow creating gallery image versions from storage accounts

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -326,9 +326,10 @@ EXAMPLES = '''
           storage_account_type: Standard_LRS
     storage_profile:
       os_disk:
-        resource_group: myResourceGroup
-        storage_account: myStorageAccount
-        uri: "https://myStorageAccount.blob.core.windows.net/myContainer/myImage.vhd"
+        source:
+          resource_group: myResourceGroup
+          storage_account: myStorageAccount
+          uri: "https://myStorageAccount.blob.core.windows.net/myContainer/myImage.vhd"
 '''
 
 RETURN = '''

--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -66,7 +66,8 @@ options:
                             - Reference to os disk snapshot.
                             - Could be resource ID.
                             - Could be a dictionary containing I(resource_group) and I(name).
-                            - Could be a dictionary containing I(resource_group), I(storage_account), and I(uri) if the snapshot is stored as a PageBlob in a storage account container.
+                            - Could be a dictionary containing I(resource_group), I(storage_account), and I(uri)
+                              if the snapshot is stored as a PageBlob in a storage account container.
                         type: raw
                     host_caching:
                         description:
@@ -587,7 +588,7 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                                 if kwargs[key]['os_disk']['source'].get('id') is not None:
                                     self.body['properties']['storageProfile']['osDiskImage']['source']['id'] = kwargs[key]['os_disk']['source'].get('id')
                                 elif kwargs[key]['os_disk']['source'].get('resource_group') is not None and \
-                                   kwargs[key]['os_disk']['source'].get('name') is not None:
+                                        kwargs[key]['os_disk']['source'].get('name') is not None:
                                     resource_group = kwargs[key]['os_disk']['source'].get('resource_group')
                                     self.body['properties']['storageProfile']['osDiskImage']['source']['id'] = ('/subscriptions/' +
                                                                                                                 self.subscription_id +
@@ -596,15 +597,16 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                                                                                                                 '/providers/Microsoft.Compute/snapshots/' +
                                                                                                                 kwargs[key]['os_disk']['source'].get('name'))
                                 elif kwargs[key]['os_disk']['source'].get('uri') is not None and \
-                                  kwargs[key]['os_disk']['source'].get('resource_group') is not None and \
-                                  kwargs[key]['os_disk']['source'].get('storage_account') is not None:
+                                        kwargs[key]['os_disk']['source'].get('resource_group') is not None and \
+                                        kwargs[key]['os_disk']['source'].get('storage_account') is not None:
                                     resource_group = kwargs[key]['os_disk']['source'].get('resource_group')
                                     storage_account = kwargs[key]['os_disk']['source'].get('storage_account')
                                     self.body['properties']['storageProfile']['osDiskImage']['source']['id'] = ('/subscriptions/' +
                                                                                                                 self.subscription_id +
                                                                                                                 '/resourceGroups/' +
                                                                                                                 resource_group +
-                                                                                                                '/providers/Microsoft.Storage/storageAccounts/' +
+                                                                                                                '/providers/Microsoft.Storage' +
+                                                                                                                '/storageAccounts/' +
                                                                                                                 storage_account)
                                     self.body['properties']['storageProfile']['osDiskImage']['source']['uri'] = kwargs[key]['os_disk']['source'].get('uri')
                                 else:

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -348,7 +348,7 @@
     resource_group: "{{ resource_group }}"
     gallery_name: myGallery{{ rpfx }}
     gallery_image_name: myImage
-    name: 10.1.3
+    name: 10.1.4
     location: eastus
     publishing_profile:
       end_of_life_date: "2050-10-01t00:00:00+00:00"
@@ -479,6 +479,20 @@
       - output.versions['location'] != None
       - output.versions['publishing_profile'] != None
       - output.versions['provisioning_state'] != None
+
+- name: Delete gallery image version from URI.
+  azure_rm_galleryimageversion:
+    resource_group: "{{ resource_group }}"
+    gallery_name: myGallery{{ rpfx }}
+    gallery_image_name: myImage
+    name: 10.1.4
+    state: absent
+  register: output
+
+- name: Assert the gallery image version from URI deleted
+  ansible.builtin.assert:
+    that:
+      - output.changed
 
 - name: Delete gallery image Version.
   azure_rm_galleryimageversion:

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -343,6 +343,46 @@
     that:
       - output.changed
 
+- name: Create or update a simple gallery Image Version.
+  azure_rm_galleryimageversion:
+    resource_group: "{{ resource_group }}"
+    gallery_name: myGallery{{ rpfx }}
+    gallery_image_name: myImage
+    name: 10.1.3
+    location: eastus
+    publishing_profile:
+      end_of_life_date: "2050-10-01t00:00:00+00:00"
+      exclude_from_latest: true
+      replica_count: 3
+      storage_account_type: Standard_LRS
+      target_regions:
+        - name: eastus
+          regional_replica_count: 1
+          encryption:
+            data_disk_images:
+              - disk_encryption_set_id: "{{ des_results.state.id }}"
+            os_disk_image:
+              disk_encryption_set_id: "{{ des_results.state.id }}"
+        - name: westus
+          regional_replica_count: 2
+          encryption:
+            data_disk_images:
+              - disk_encryption_set_id: "{{ des_results.state.id }}"
+            os_disk_image:
+              disk_encryption_set_id: "{{ des_results.state.id }}"
+          storage_account_type: Standard_ZRS
+    storage_profile:
+      source_image:
+        resource_group: "{{ resource_group }}"
+        storage_account: '{{ output.vms[0].storage_account_name }}'
+        uri: 'https://{{ output.vms[0].storage_account_name }}.blob.core.windows.net/{{ output.vms[0].storage_container_name }}/{{ output.vms[0].storage_blob_name }}'
+  register: output
+
+- name: Assert the gallery image version created
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
 - name: Create or update a simple gallery Image Version - idempotent
   azure_rm_galleryimageversion:
     resource_group: "{{ resource_group }}"

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -109,7 +109,7 @@
   azure_rm_virtualmachine_info:
     resource_group: "{{ resource_group }}"
     name: "vmforimage{{ rpfx }}"
-  register: output
+  register: vm_output
 
 - name: Create a snapshot by importing an unmanaged blob from the same subscription.
   azure_rm_snapshot:
@@ -118,7 +118,7 @@
     location: eastus
     creation_data:
       create_option: Import
-      source_uri: 'https://{{ output.vms[0].storage_account_name }}.blob.core.windows.net/{{ output.vms[0].storage_container_name }}/{{ output.vms[0].storage_blob_name }}'
+      source_uri: 'https://{{ vm_output.vms[0].storage_account_name }}.blob.core.windows.net/{{ vm_output.vms[0].storage_container_name }}/{{ vm_output.vms[0].storage_blob_name }}'
   register: output
 
 - name: Assert the snapshot created
@@ -372,10 +372,11 @@
               disk_encryption_set_id: "{{ des_results.state.id }}"
           storage_account_type: Standard_ZRS
     storage_profile:
-      source_image:
-        resource_group: "{{ resource_group }}"
-        storage_account: '{{ output.vms[0].storage_account_name }}'
-        uri: 'https://{{ output.vms[0].storage_account_name }}.blob.core.windows.net/{{ output.vms[0].storage_container_name }}/{{ output.vms[0].storage_blob_name }}'
+      os_disk:
+        source:
+          resource_group: "{{ resource_group }}"
+          storage_account: '{{ vm_output.vms[0].storage_account_name }}'
+          uri: 'https://{{ vm_output.vms[0].storage_account_name }}.blob.core.windows.net/{{ vm_output.vms[0].storage_container_name }}/{{ vm_output.vms[0].storage_blob_name }}'
   register: output
 
 - name: Assert the gallery image version created


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

It's possible to upload a VHD into a container in a storage account and then use that to import an image version. This adds a third way to specify an `os_disk` in the galleryimageversion plugin to support that approach.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
galleryimageversion
