### PR TITLE
Fix unsuppoeted header in `azure_rm_adgroup`

### DIFF
--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -479,7 +479,6 @@ class AzureRMADGroup(AzureRMModuleBase):
             query_parameters=GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters(
                 count=True,
             ),
-            headers={'ConsistencyLevel': "eventual", }
         )
         return await self._client.groups.by_group_id(group_id).owners.get(request_configuration=request_configuration)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The issue #1338  also occurs when using the `present_owners` parameter of the `azure_rm_adgroup` module.
This pull request fixes the bug in the same way as #1355.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_adgroup