### PR TITLE
Support for azure-mgmt-recoveryservicesbackup v4.0+

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -271,7 +271,11 @@ try:
     from azure.mgmt.iothub import models as IoTHubModels
     from azure.mgmt.resource.locks import ManagementLockClient
     from azure.mgmt.recoveryservicesbackup import RecoveryServicesBackupClient
-    import azure.mgmt.recoveryservicesbackup.models as RecoveryServicesBackupModels
+    try:
+        #  Older versions of the library exposed the modules at the root of the package
+        import azure.mgmt.recoveryservicesbackup.models as RecoveryServicesBackupModels
+    except ImportError:
+        import azure.mgmt.recoveryservicesbackup.activestamp.models as RecoveryServicesBackupModels
     from azure.mgmt.search import SearchManagementClient
     from azure.mgmt.datalake.store import DataLakeStoreAccountManagementClient
     import azure.mgmt.datalake.store.models as DataLakeStoreAccountModel


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In newer versions of the library, the models module got split between two sub-packages, `passivestamp` and `activestamp`. All models used are part of the `activestamp` module, so conditionally import from there if the newer version is installed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_common

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I looked into this because I tried pip-installing the requirements-azure.txt file, which pins the azure-cli-core package to 2.34. I'm using Fedora and it ships with Python 3.12, which dropped distutils. I wanted to see if the new version of azure-cli-core stopped using distutils, so I updated everything and this was the only incompatibility I noticed.

The newer azure-cli-core doesn't help with the missing distutils, so for Python 3.12+ setuptools also needs to be installed (which now provides distutils).

