### PR TITLE
azure_rm_networkinterface.py supports adding multi ipconfigurations

### DIFF
--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -785,6 +785,10 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                 ip_configuration_result = self.construct_ip_configuration_set(results['ip_configurations'])
                 ip_configuration_request = self.construct_ip_configuration_set(self.ip_configurations)
                 ip_configuration_result_name = [item['name'] for item in ip_configuration_result]
+                if_configuration_request_name = [item['name'] for item in self.ip_configurations]
+                for item_result in ip_configuration_result:
+                    if item_result['name'] not in if_configuration_request_name:
+                        self.ip_configurations.append(item_result)
                 for item_request in ip_configuration_request:
                     if item_request['name'] not in ip_configuration_result_name:
                         changed = True

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -350,7 +350,7 @@
       - facts.networkinterfaces[0].ip_configurations[0].primary == True
       - facts.networkinterfaces[0].ip_configurations[1].primary == False
 
-- name: Remove one dns server and ip configuration
+- name: Remove one dns server and a new ip configuration
   azure_rm_networkinterface:
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
@@ -362,9 +362,9 @@
     dns_servers:
       - 8.9.10.11
     ip_configurations:
-      - name: ipconfig1
+      - name: ipconfig3
         public_ip_name: "tn{{ rpfx }}"
-        primary: true
+        primary: false
         load_balancer_backend_address_pools:
           - "{{ lb.state.backend_address_pools[0].id }}"
           - name: backendaddrpool1
@@ -378,7 +378,7 @@
       - output.state.dns_settings.dns_servers == ['8.9.10.11']
       - output.state.enable_ip_forwarding
       - output.state.network_security_group.name == "tn{{ rpfx }}sg"
-      - "output.state.ip_configurations | length == 1"
+      - "output.state.ip_configurations | length == 4"
       - output.state.ip_configurations[0].public_ip_address.name == "tn{{ rpfx }}"
       - output.state.enable_accelerated_networking
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
azure_rm_networkinterface.py supports adding multi ipconfigurations, try to fixes #1284 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_networkinterface.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
