### PR TITLE
add tags option to azure_rm_resource_info module

### DIFF
--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -105,7 +105,7 @@ EXAMPLES = '''
     resource_group: "{{ resource_group }}"
     resource_type: resources
 
-- name: Get all snapshots of all resource groups of a subscription but filtering with two tags. 
+- name: Get all snapshots of all resource groups of a subscription but filtering with two tags.
     azure_rm_resource_info:
     provider: compute
     resource_type: snapshots

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -110,7 +110,7 @@ EXAMPLES = '''
     provider: compute
     resource_type: snapshots
     tags:
-        enviroment: dev
+      enviroment: dev
         department: hr
 '''
 

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -106,7 +106,7 @@ EXAMPLES = '''
     resource_type: resources
 
 - name: Get all snapshots of all resource groups of a subscription but filtering with two tags.
-    azure_rm_resource_info:
+  azure_rm_resource_info:
     provider: compute
     resource_type: snapshots
     tags:

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -82,6 +82,7 @@ options:
             - Each key-value pair in the dictionary specifies a tag name and its value to filter on differente resources. 
         type: dict
         required: false
+        default: {}
 
 extends_documentation_fragment:
     - azure.azcollection.azure

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -76,6 +76,12 @@ options:
                 description:
                     - Subresource name.
                 type: str
+    tags:
+        description:
+            - A dictionary of tags to filter on.
+            - Each key-value pair in the dictionary specifies a tag name and its value to filter on differente resources. 
+        type: dict
+        required: false
 
 extends_documentation_fragment:
     - azure.azcollection.azure
@@ -98,6 +104,14 @@ EXAMPLES = '''
   azure_rm_resource_info:
     resource_group: "{{ resource_group }}"
     resource_type: resources
+
+- name: Get all snapshots of all resource groups of a subscription but filtering with two tags. 
+    azure_rm_resource_info:
+    provider: compute
+    resource_type: snapshots
+    tags:
+        enviroment: dev
+        department: hr
 '''
 
 RETURN = '''
@@ -346,7 +360,8 @@ class AzureRMResourceInfo(AzureRMModuleBase):
             ),
             api_version=dict(
                 type='str'
-            )
+            ),
+            tags=dict(type='dict', default={})
         )
         # store the results of the module operation
         self.results = dict(
@@ -449,6 +464,12 @@ class AzureRMResourceInfo(AzureRMModuleBase):
                 self.fail('Failed to parse response: ' + str(e))
             if not skiptoken:
                 break
+        if kwargs['tags']:
+            filtered_response = []
+            for resource in self.results['response']:
+                if all(resource.get('tags', {}).get(tag_key) == tag_value for tag_key, tag_value in kwargs['tags'].items()):
+                    filtered_response.append(resource)
+            self.results['response'] = filtered_response
         return self.results
 
 

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -79,7 +79,7 @@ options:
     tags:
         description:
             - A dictionary of tags to filter on.
-            - Each key-value pair in the dictionary specifies a tag name and its value to filter on differente resources. 
+            - Each key-value pair in the dictionary specifies a tag name and its value to filter on differente resources.
         type: dict
         required: false
         default: {}

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -111,7 +111,7 @@ EXAMPLES = '''
     resource_type: snapshots
     tags:
       enviroment: dev
-        department: hr
+      department: hr
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
Add an option of tags to filter for one or more tags when getting differente resources. One or more tags can be added, and as default is use the "and" condition to search for multiple tags. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_resource_info  module

##### ADDITIONAL INFORMATION
Now the user can filter also by the tags of the resource

Before to get snapshots by tag  enviroment and value dev 
```
    - name: Get info of all snapshots 
      azure_rm_resource_info:
        provider: compute
        resource_type: snapshots 
      register: snapshots_output

    - name: Filter
      set_fact:
        filtered_snapshots: "{{ snapshots_output.response | selectattr('tags.enviroment', 'defined') | selectattr('tags.enviroment', 'equalto', 'dev') | list }}"
```

Now
```
    - name: Get info of all snapshots 
      azure_rm_resource_info:
        provider: compute
        resource_type: snapshots 
        tags: 
           enviroment: dev
      register: filtered_snapshots
```
