### PR TITLE
The Azure Data Lake Store has retired to disable azure_rm_datalakestore testing

### DIFF
--- a/plugins/modules/azure_rm_datalakestore.py
+++ b/plugins/modules/azure_rm_datalakestore.py
@@ -504,6 +504,7 @@ class AzureRMDatalakeStore(AzureRMModuleBase):
                                                    supports_tags=True)
 
     def exec_module(self, **kwargs):
+        self.module.deprecate("The 'azure_rm_datalakestore.py' module will deprecated. Azure Data Lake Storage Gen1 retired on February 29,2024", version=(2.3, ))
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_datalakestore.py
+++ b/plugins/modules/azure_rm_datalakestore.py
@@ -504,7 +504,7 @@ class AzureRMDatalakeStore(AzureRMModuleBase):
                                                    supports_tags=True)
 
     def exec_module(self, **kwargs):
-        self.module.deprecate("The 'azure_rm_datalakestore.py' module will deprecated. Azure Data Lake Storage Gen1 retired on February 29,2024", version=(2.3, ))
+        self.module.deprecate("The azure_rm_datalakestore.py will deprecated. Azure Data Lake Storage Gen1 retired on February 29,2024", version=(2.3, ))
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_datalakestore_info.py
+++ b/plugins/modules/azure_rm_datalakestore_info.py
@@ -312,7 +312,7 @@ class AzureRMDatalakeStoreInfo(AzureRMModuleBase):
                                                        supports_tags=False)
 
     def exec_module(self, **kwargs):
-        self.module.deprecate("The 'azure_rm_datalakestore_info.py' module will deprecated. Azure Data Lake Storage Gen1 retired on February 29,2024", version=(2.3, ))
+        self.module.deprecate("The azure_rm_datalakestore_info.py will deprecated. Azure Data Lake Storage Gen1 retired on February 29,2024", version=(2.3, ))
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_datalakestore_info.py
+++ b/plugins/modules/azure_rm_datalakestore_info.py
@@ -312,6 +312,7 @@ class AzureRMDatalakeStoreInfo(AzureRMModuleBase):
                                                        supports_tags=False)
 
     def exec_module(self, **kwargs):
+        self.module.deprecate("The 'azure_rm_datalakestore_info.py' module will deprecated. Azure Data Lake Storage Gen1 retired on February 29,2024", version=(2.3, ))
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/tests/integration/targets/azure_rm_datalakestore/aliases
+++ b/tests/integration/targets/azure_rm_datalakestore/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group10
 destructive
+disabled


### PR DESCRIPTION
The Azure Data Lake Storage Gen1 retired on February 29,2024. Disable azure_rm_datalakestore testing,

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_datalakestore.py
azure_rm_datalakestore_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
