### PR TITLE
allow service principals and nested groups to be returned in membership attributes

### DIFF
--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -65,8 +65,7 @@ options:
         elements: str
     raw_membership:
         description:
-            - By default the group_members return property is flattened and partially filtered of non-User objects
-              before return. This argument disables those transformations.
+            - By default the group_members return property is flattened and partially filtered of non-User objects before return. This argument disables those transformations.
         default: false
         type: bool
 extends_documentation_fragment:
@@ -213,8 +212,7 @@ group_owners:
     type: list
 group_members:
     description:
-        - The members of the group. If raw_membership is true, this contains the transient members return property.
-          Otherwise, it contains the members return property.
+        - The members of the group. If raw_membership is false, this contains the transitive members property. Otherwise, it contains the members property.
     returned: always
     type: list
 '''

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -65,7 +65,8 @@ options:
         elements: str
     raw_membership:
         description:
-            - By default the group_members return property is flattened and partially filtered of non-User objects before return. This argument disables those transformations.
+            - By default the group_members return property is flattened and partially filtered of non-User objects before return. \
+             This argument disables those transformations.
         default: false
         type: bool
     description:

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -263,7 +263,6 @@ class AzureRMADGroup(AzureRMModuleBase):
         self.state = None
         self.results = dict(changed=False)
         self._client = None
-        self.include_service_principals = False
         self.raw_membership = False
 
         super(AzureRMADGroup, self).__init__(derived_arg_spec=self.module_arg_spec,

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -57,7 +57,8 @@ options:
         type: bool
     raw_membership:
         description:
-            - By default the group_members return property is flattened and partially filtered of non-User objects before return. This argument disables those transformations.
+            - By default the group_members return property is flattened and partially filtered of non-User objects before return.\
+              This argument disables those transformations.
         default: false
         type: bool
     all:
@@ -89,7 +90,6 @@ EXAMPLES = '''
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     return_owners: true
     return_group_members: true
-    
 - name: Return a specific group using object_id and return the owners and members of the group. Return service principals and nested groups.
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -57,8 +57,7 @@ options:
         type: bool
     raw_membership:
         description:
-            - By default the group_members return property is flattened and partially filtered of non-User objects
-              before return. This argument disables those transformations.
+            - By default the group_members return property is flattened and partially filtered of non-User objects before return. This argument disables those transformations.
         default: false
         type: bool
     all:
@@ -172,8 +171,7 @@ group_owners:
     type: list
 group_members:
     description:
-        - The members of the group. If raw_membership is set, this field may contain non-user objects 
-          (groups, service principals, etc)
+        - The members of the group. If raw_membership is set, this field may contain non-user objects (groups, service principals, etc)
     returned: always
     type: list
 '''

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -55,6 +55,19 @@ options:
             - Indicate whether the groups in which a groups is a member should be returned with the returned groups.
         default: False
         type: bool
+    raw_membership:
+        description:
+            - Indicate whether group membership should be returned from the transitive_members property, as opposed to 
+            the members property. Due to API limitations this property and include_service_principals cannot both
+            be true, as the transitive_members property only includes "User" objects
+        default: True
+        type: bool
+    raw_membership:
+        description:
+            - By default the group_members return property is flattened and partially filtered of non-User objects
+              before return. This argument disables those transformations.
+        default: false
+        type: bool
     all:
         description:
             - If True, will return all groups in tenant.
@@ -74,6 +87,11 @@ EXAMPLES = '''
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
+- name: Return a specific group using object_id and include service principals
+  azure_rm_adgroup_info:
+    object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    include_service_principals: true
+
 - name: Return a specific group using object_id and  return the owners of the group
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -84,6 +102,14 @@ EXAMPLES = '''
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     return_owners: true
     return_group_members: true
+    
+- name: Return a specific group using object_id and return the owners and members of the group. Specify the
+return should be unfiltered
+  azure_rm_adgroup_info:
+    object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    return_owners: true
+    return_group_members: true
+    raw_membership: true
 
 - name: Return a specific group using object_id and return the groups the group is a member of
   azure_rm_adgroup_info:
@@ -153,7 +179,8 @@ group_owners:
     type: list
 group_members:
     description:
-        - The members of the group.
+        - The members of the group. If raw_membership is set, this field may contain non-user objects 
+          (groups, service principals, etc)
     returned: always
     type: list
 '''
@@ -167,6 +194,7 @@ try:
         TransitiveMembersRequestBuilder
     from msgraph.generated.groups.item.get_member_groups.get_member_groups_post_request_body import \
         GetMemberGroupsPostRequestBody
+    from msgraph.generated.groups.item.members.members_request_builder import MembersRequestBuilder
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -184,6 +212,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
             return_owners=dict(type='bool', default=False),
             return_group_members=dict(type='bool', default=False),
             return_member_groups=dict(type='bool', default=False),
+            include_service_principals=dict(type='bool', default=False),
             all=dict(type='bool', default=False),
         )
 
@@ -195,6 +224,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         self.return_owners = False
         self.return_group_members = False
         self.return_member_groups = False
+        self.raw_membership = False
         self.all = False
 
         self.results = dict(changed=False)
@@ -345,17 +375,34 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         return await self._client.groups.by_group_id(group_id).owners.get(request_configuration=request_configuration)
 
     async def get_group_members(self, group_id, filters=None):
+        if self.raw_membership:
+            return await self.get_raw_group_members(group_id, filters)
+        else:
+            return await self.get_transitive_group_members(group_id, filters)
+
+    async def get_transitive_group_members(self, group_id, filters=None):
         request_configuration = TransitiveMembersRequestBuilder.TransitiveMembersRequestBuilderGetRequestConfiguration(
             query_parameters=TransitiveMembersRequestBuilder.TransitiveMembersRequestBuilderGetQueryParameters(
                 count=True,
-                select=['id', 'displayName', 'userPrincipalName', 'mailNickname', 'mail', 'accountEnabled', 'userType',
-                        'appId', 'appRoleAssignmentRequired']
-
             ),
         )
         if filters:
             request_configuration.query_parameters.filter = filters
         return await self._client.groups.by_group_id(group_id).transitive_members.get(
+            request_configuration=request_configuration)
+
+    async def get_raw_group_members(self, group_id, filters=None):
+        request_configuration = MembersRequestBuilder.MembersRequestBuilderGetRequestConfiguration(
+            query_parameters=MembersRequestBuilder.MembersRequestBuilderGetQueryParameters(
+                count=True,
+                # this ensures service principals are returned
+                # see https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
+                expand=["members"]
+            ),
+        )
+        if filters:
+            request_configuration.query_parameters.filter = filters
+        return await self._client.groups.by_group_id(group_id).members.get(
             request_configuration=request_configuration)
 
     async def get_member_groups(self, obj_id):

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -79,11 +79,6 @@ EXAMPLES = '''
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-- name: Return a specific group using object_id and include service principals
-  azure_rm_adgroup_info:
-    object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    include_service_principals: true
-
 - name: Return a specific group using object_id and  return the owners of the group
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -95,8 +90,7 @@ EXAMPLES = '''
     return_owners: true
     return_group_members: true
     
-- name: Return a specific group using object_id and return the owners and members of the group. Specify the
-return should be unfiltered
+- name: Return a specific group using object_id and return the owners and members of the group. Return service_principals and nested groups.
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     return_owners: true

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -90,7 +90,7 @@ EXAMPLES = '''
     return_owners: true
     return_group_members: true
     
-- name: Return a specific group using object_id and return the owners and members of the group. Return service_principals and nested groups.
+- name: Return a specific group using object_id and return the owners and members of the group. Return service principals and nested groups.
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     return_owners: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes https://github.com/ansible-collections/azure/issues/1506

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

azure_rm_adgroup
azure_rm_adgroup_info

##### ADDITIONAL INFORMATION
I also fixed a few typos in docs and function names. Verified with some manual testing and a clean pass of ansible sanity tests
