### PR TITLE
remove functionality which should have been removed for Ansible 2.9

### DIFF
--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -328,99 +328,6 @@ options:
                     - Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination.
                     - This element is only used when I(protocol=Tcp).
                 type: bool
-    public_ip_address_name:
-        description:
-            - (deprecated) Name of an existing public IP address object to associate with the security group.
-            - This option has been deprecated, and will be removed in 2.9. Use I(frontend_ip_configurations) instead.
-        type: str
-        aliases:
-            - public_ip_address
-            - public_ip_name
-            - public_ip
-    probe_port:
-        description:
-            - (deprecated) The port that the health probe will use.
-            - This option has been deprecated, and will be removed in 2.9. Use I(probes) instead.
-        type: int
-    probe_protocol:
-        description:
-            - (deprecated) The protocol to use for the health probe.
-            - This option has been deprecated, and will be removed in 2.9. Use I(probes) instead.
-        type: str
-        choices:
-            - Tcp
-            - Http
-            - Https
-    probe_interval:
-        description:
-            - (deprecated) Time (in seconds) between endpoint health probes.
-            - This option has been deprecated, and will be removed in 2.9. Use I(probes) instead.
-        type: int
-        default: 15
-    probe_fail_count:
-        description:
-            - (deprecated) The amount of probe failures for the load balancer to make a health determination.
-            - This option has been deprecated, and will be removed in 2.9. Use I(probes) instead.
-        default: 3
-        type: int
-    probe_request_path:
-        description:
-            - (deprecated) The URL that an HTTP probe or HTTPS probe will use (only relevant if I(probe_protocol=Http) or I(probe_protocol=Https)).
-            - This option has been deprecated, and will be removed in 2.9. Use I(probes) instead.
-        type: str
-    protocol:
-        description:
-            - (deprecated) The protocol (TCP or UDP) that the load balancer will use.
-            - This option has been deprecated, and will be removed in 2.9. Use I(load_balancing_rules) instead.
-        type: str
-        choices:
-            - Tcp
-            - Udp
-    load_distribution:
-        description:
-            - (deprecated) The type of load distribution that the load balancer will employ.
-            - This option has been deprecated, and will be removed in 2.9. Use I(load_balancing_rules) instead.
-        type: str
-        choices:
-            - Default
-            - SourceIP
-            - SourceIPProtocol
-    frontend_port:
-        description:
-            - (deprecated) Frontend port that will be exposed for the load balancer.
-            - This option has been deprecated, and will be removed in 2.9. Use I(load_balancing_rules) instead.
-        type: int
-    backend_port:
-        description:
-            - (deprecated) Backend port that will be exposed for the load balancer.
-            - This option has been deprecated, and will be removed in 2.9. Use I(load_balancing_rules) instead.
-        type: int
-    idle_timeout:
-        description:
-            - (deprecated) Timeout for TCP idle connection in minutes.
-            - This option has been deprecated, and will be removed in 2.9. Use I(load_balancing_rules) instead.
-        type: int
-        default: 4
-    natpool_frontend_port_start:
-        description:
-            - (deprecated) Start of the port range for a NAT pool.
-            - This option has been deprecated, and will be removed in 2.9. Use I(inbound_nat_pools) instead.
-        type: int
-    natpool_frontend_port_end:
-        description:
-            - (deprecated) End of the port range for a NAT pool.
-            - This option has been deprecated, and will be removed in 2.9. Use I(inbound_nat_pools) instead.
-        type: int
-    natpool_backend_port:
-        description:
-            - (deprecated) Backend port used by the NAT pool.
-            - This option has been deprecated, and will be removed in 2.9. Use I(inbound_nat_pools) instead.
-        type: int
-    natpool_protocol:
-        description:
-            - (deprecated) The protocol for the NAT pool.
-            - This option has been deprecated, and will be removed in 2.9. Use I(inbound_nat_pools) instead.
-        type: str
 extends_documentation_fragment:
     - azure.azcollection.azure
     - azure.azcollection.azure_tags
@@ -710,58 +617,6 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
                 type='list',
                 elements='dict',
                 options=load_balancing_rule_spec
-            ),
-            public_ip_address_name=dict(
-                type='str',
-                aliases=['public_ip_address', 'public_ip_name', 'public_ip']
-            ),
-            probe_port=dict(
-                type='int'
-            ),
-            probe_protocol=dict(
-                type='str',
-                choices=['Tcp', 'Http', 'Https']
-            ),
-            probe_interval=dict(
-                type='int',
-                default=15
-            ),
-            probe_fail_count=dict(
-                type='int',
-                default=3
-            ),
-            probe_request_path=dict(
-                type='str'
-            ),
-            protocol=dict(
-                type='str',
-                choices=['Tcp', 'Udp']
-            ),
-            load_distribution=dict(
-                type='str',
-                choices=['Default', 'SourceIP', 'SourceIPProtocol']
-            ),
-            frontend_port=dict(
-                type='int'
-            ),
-            backend_port=dict(
-                type='int'
-            ),
-            idle_timeout=dict(
-                type='int',
-                default=4
-            ),
-            natpool_frontend_port_start=dict(
-                type='int'
-            ),
-            natpool_frontend_port_end=dict(
-                type='int'
-            ),
-            natpool_backend_port=dict(
-                type='int'
-            ),
-            natpool_protocol=dict(
-                type='str'
             )
         )
 
@@ -775,22 +630,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
         self.inbound_nat_rules = None
         self.inbound_nat_pools = None
         self.load_balancing_rules = None
-        self.public_ip_address_name = None
         self.state = None
-        self.probe_port = None
-        self.probe_protocol = None
-        self.probe_interval = None
-        self.probe_fail_count = None
-        self.probe_request_path = None
-        self.protocol = None
-        self.load_distribution = None
-        self.frontend_port = None
-        self.backend_port = None
-        self.idle_timeout = None
-        self.natpool_frontend_port_start = None
-        self.natpool_frontend_port_end = None
-        self.natpool_backend_port = None
-        self.natpool_protocol = None
         self.tags = None
 
         self.results = dict(changed=False, state=dict())
@@ -814,54 +654,6 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
         load_balancer = self.get_load_balancer()
 
         if self.state == 'present':
-            # compatible parameters
-            is_compatible_param = not self.frontend_ip_configurations and not self.backend_address_pools and not self.probes and not self.inbound_nat_pools
-            is_compatible_param = is_compatible_param and not load_balancer  # the instance should not be exist
-            is_compatible_param = is_compatible_param or self.public_ip_address_name or self.probe_protocol or self.natpool_protocol or self.protocol
-            if is_compatible_param:
-                self.deprecate('Discrete load balancer config settings are deprecated and will be removed.'
-                               ' Use frontend_ip_configurations, backend_address_pools, probes, inbound_nat_pools lists instead.', version=(2, 9))
-                frontend_ip_name = 'frontendip0'
-                backend_address_pool_name = 'backendaddrp0'
-                prob_name = 'prob0'
-                inbound_nat_pool_name = 'inboundnatp0'
-                lb_rule_name = 'lbr'
-                self.frontend_ip_configurations = [dict(
-                    name=frontend_ip_name,
-                    public_ip_address=self.public_ip_address_name
-                )]
-                self.backend_address_pools = [dict(
-                    name=backend_address_pool_name
-                )]
-                self.probes = [dict(
-                    name=prob_name,
-                    port=self.probe_port,
-                    protocol=self.probe_protocol,
-                    interval=self.probe_interval,
-                    fail_count=self.probe_fail_count,
-                    request_path=self.probe_request_path
-                )] if self.probe_protocol else None
-                self.inbound_nat_pools = [dict(
-                    name=inbound_nat_pool_name,
-                    frontend_ip_configuration_name=frontend_ip_name,
-                    protocol=self.natpool_protocol,
-                    frontend_port_range_start=self.natpool_frontend_port_start,
-                    frontend_port_range_end=self.natpool_frontend_port_end,
-                    backend_port=self.natpool_backend_port
-                )] if self.natpool_protocol else None
-                self.load_balancing_rules = [dict(
-                    name=lb_rule_name,
-                    frontend_ip_configuration=frontend_ip_name,
-                    backend_address_pool=backend_address_pool_name,
-                    probe=prob_name,
-                    protocol=self.protocol,
-                    load_distribution=self.load_distribution,
-                    frontend_port=self.frontend_port,
-                    backend_port=self.backend_port,
-                    idle_timeout=self.idle_timeout,
-                    enable_floating_ip=False,
-                )] if self.protocol else None
-
             # create new load balancer structure early, so it can be easily compared
             if not load_balancer:
                 frontend_ip_configurations_param = [self.network_models.FrontendIPConfiguration(

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -79,47 +79,6 @@ options:
             - Windows
             - Linux
         default: Linux
-    private_ip_address:
-        description:
-            - (Deprecate) Valid IPv4 address that falls within the specified subnet.
-            - This option will be deprecated in 2.9, use I(ip_configurations) instead.
-        type: str
-    private_ip_allocation_method:
-        description:
-            - (Deprecate) Whether or not the assigned IP address is permanent.
-            - When creating a network interface, if you specify I(private_ip_address=Static), you must provide a value for I(private_ip_address).
-            - You can update the allocation method to C(Static) after a dynamic private IP address has been assigned.
-            - This option will be deprecated in 2.9, use I(ip_configurations) instead.
-        default: Dynamic
-        type: str
-        choices:
-            - Dynamic
-            - Static
-    public_ip:
-        description:
-            - (Deprecate) When creating a network interface, if no public IP address name is provided a default public IP address will be created.
-            - Set to C(false) if you do not want a public IP address automatically created.
-            - This option will be deprecated in 2.9, use I(ip_configurations) instead.
-        type: bool
-        default: 'yes'
-    public_ip_address_name:
-        description:
-            - (Deprecate) Name of an existing public IP address object to associate with the security group.
-            - This option will be deprecated in 2.9, use I(ip_configurations) instead.
-        type: str
-        aliases:
-            - public_ip_address
-            - public_ip_name
-    public_ip_allocation_method:
-        description:
-            - (Deprecate) If a I(public_ip_address_name) is not provided, a default public IP address will be created.
-            - The allocation method determines whether or not the public IP address assigned to the network interface is permanent.
-            - This option will be deprecated in 2.9, use I(ip_configurations) instead.
-        type: str
-        choices:
-            - Dynamic
-            - Static
-        default: Dynamic
     ip_configurations:
         description:
             - List of IP configurations. Each configuration object should include
@@ -323,7 +282,6 @@ EXAMPLES = '''
     virtual_network: vnet001
     subnet_name: subnet001
     create_with_security_group: false
-    public_ip: false
     ip_configurations:
       - name: default
         primary: true
@@ -614,13 +572,8 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             create_with_security_group=dict(type='bool', default=True),
             security_group=dict(type='raw', aliases=['security_group_name']),
             state=dict(default='present', choices=['present', 'absent']),
-            private_ip_address=dict(type='str'),
-            private_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
-            public_ip_address_name=dict(type='str', aliases=['public_ip_address', 'public_ip_name']),
-            public_ip=dict(type='bool', default=True),
             subnet_name=dict(type='str', aliases=['subnet']),
             virtual_network=dict(type='raw', aliases=['virtual_network_name']),
-            public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
             ip_configurations=dict(type='list', default=[], elements='dict', options=ip_configuration_spec),
             os_type=dict(type='str', choices=['Windows', 'Linux'], default='Linux'),
             open_ports=dict(type='list', elements='str'),
@@ -638,13 +591,8 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         self.create_with_security_group = None
         self.enable_accelerated_networking = None
         self.security_group = None
-        self.private_ip_address = None
-        self.private_ip_allocation_method = None
-        self.public_ip_address_name = None
-        self.public_ip = None
         self.subnet_name = None
         self.virtual_network = None
-        self.public_ip_allocation_method = None
         self.state = None
         self.tags = None
         self.os_type = None
@@ -703,17 +651,13 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     if len(asgs) > 0:
                         config['application_security_groups'] = asgs
 
+        # If ip_confiurations is not specified then provide the default
+        # private interface
         if self.state == 'present' and not self.ip_configurations:
-            # construct the ip_configurations array for compatible
-            self.deprecate('Setting ip_configuration flatten is deprecated and will be removed.'
-                           ' Using ip_configurations list to define the ip configuration', version=(2, 9))
             self.ip_configurations = [
                 dict(
-                    private_ip_address=self.private_ip_address,
-                    private_ip_allocation_method=self.private_ip_allocation_method,
-                    public_ip_address_name=self.public_ip_address_name if self.public_ip else None,
-                    public_ip_allocation_method=self.public_ip_allocation_method,
                     name='default',
+                    private_ip_allocation_method='Dynamic',
                     primary=True
                 )
             ]
@@ -875,7 +819,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
     def get_or_create_public_ip_address(self, ip_config):
         name = ip_config.get('public_ip_address_name')
 
-        if not (self.public_ip and name):
+        if not name:
             return None
 
         pip = self.get_public_ip_address(name)

--- a/tests/integration/targets/azure_rm_image/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_image/tasks/main.yml
@@ -33,9 +33,12 @@
   azure_rm_networkinterface:
     resource_group: "{{ resource_group }}"
     name: "{{ vm_name }}"
+    ip_configurations:
+      - name: default
+        public_ip_address_name: "{{ public_ip_name }}"
+        primary: true
     virtual_network: "{{ vm_name }}"
     subnet: "{{ vm_name }}"
-    public_ip_name: "{{ public_ip_name }}"
     security_group: "{{ security_group_name }}"
 
 - name: Create virtual machine

--- a/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
@@ -32,7 +32,9 @@
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
     name: "{{ lbname_a }}"
-    public_ip: "{{ pipaname }}"
+    frontend_ip_configurations:
+      - name: frontendip0
+        public_ip_address: "{{ pipaname }}"
   check_mode: true
   register: output
 
@@ -44,7 +46,9 @@
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
     name: "{{ lbname_a }}"
-    public_ip: "{{ pipaname }}"
+    frontend_ip_configurations:
+      - name: frontendip0
+        public_ip_address: "{{ pipaname }}"
   register: output
 
 - name: Assert load balancer created
@@ -55,7 +59,9 @@
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
     name: "{{ lbname_a }}"
-    public_ip: "{{ pipaname }}"
+    frontend_ip_configurations:
+      - name: frontendip0
+        public_ip_address: "{{ pipaname }}"
   register: output
 
 - name: Assert no change
@@ -90,20 +96,34 @@
     resource_group: '{{ resource_group }}'
     name: "{{ lbname_b }}"
     sku: Standard
-    public_ip_address: "{{ pipbname }}"
-    probe_protocol: Tcp
-    probe_port: 80
-    probe_interval: 10
-    probe_fail_count: 3
-    protocol: Tcp
-    load_distribution: Default
-    frontend_port: 80
-    backend_port: 8080
-    idle_timeout: 4
-    natpool_frontend_port_start: 30
-    natpool_frontend_port_end: 40
-    natpool_backend_port: 80
-    natpool_protocol: Tcp
+    frontend_ip_configurations:
+      - name: frontendip0
+        public_ip_address: "{{ pipbname }}"
+    backend_address_pools:
+      - name: backendaddrp0
+    probes:
+      - name: prob0
+        port: 80
+        protocol: Tcp
+        interval: 10
+        fail_count: 3
+    inbound_nat_pools:
+      - name: inboundnatp0
+        frontend_ip_configuration_name: frontendip0
+        protocol: Tcp
+        frontend_port_range_start: 30
+        frontend_port_range_end: 40
+        backend_port: 80
+    load_balancing_rules:
+      - name: lbr
+        frontend_ip_configuration: frontendip0
+        backend_address_pool: backendaddrp0
+        probe: prob0
+        frontend_port: 80
+        backend_port: 8080
+        idle_timeout: 4
+        load_distribution: Default
+        protocol: Tcp
   register: output
 
 - name: Assert complex load balancer created
@@ -117,20 +137,34 @@
     resource_group: '{{ resource_group }}'
     name: "{{ lbname_b }}"
     sku: Standard
-    public_ip_address: "{{ pipbname }}"
-    probe_protocol: Tcp
-    probe_port: 80
-    probe_interval: 10
-    probe_fail_count: 3
-    protocol: Tcp
-    load_distribution: Default
-    frontend_port: 80
-    backend_port: 8080
-    idle_timeout: 4
-    natpool_frontend_port_start: 30
-    natpool_frontend_port_end: 40
-    natpool_backend_port: 80
-    natpool_protocol: Tcp
+    frontend_ip_configurations:
+      - name: frontendip0
+        public_ip_address: "{{ pipbname }}"
+    backend_address_pools:
+      - name: backendaddrp0
+    probes:
+      - name: prob0
+        port: 80
+        protocol: Tcp
+        interval: 10
+        fail_count: 3
+    inbound_nat_pools:
+      - name: inboundnatp0
+        frontend_ip_configuration_name: frontendip0
+        protocol: Tcp
+        frontend_port_range_start: 30
+        frontend_port_range_end: 40
+        backend_port: 80
+    load_balancing_rules:
+      - name: lbr
+        frontend_ip_configuration: frontendip0
+        backend_address_pool: backendaddrp0
+        probe: prob0
+        frontend_port: 80
+        backend_port: 8080
+        idle_timeout: 4
+        load_distribution: Default
+        protocol: Tcp
   register: output
 
 - name: Assert that output has not changed
@@ -143,20 +177,34 @@
     resource_group: '{{ resource_group }}'
     name: "{{ lbname_b }}"
     sku: Standard
-    public_ip_address: "{{ pipbname }}"
-    probe_protocol: Tcp
-    probe_port: 80
-    probe_interval: 10
-    probe_fail_count: 3
-    protocol: Tcp
-    load_distribution: Default
-    frontend_port: 81
-    backend_port: 8080
-    idle_timeout: 4
-    natpool_frontend_port_start: 30
-    natpool_frontend_port_end: 40
-    natpool_backend_port: 80
-    natpool_protocol: Tcp
+    frontend_ip_configurations:
+      - name: frontendip0
+        public_ip_address: "{{ pipbname }}"
+    backend_address_pools:
+      - name: backendaddrp0
+    probes:
+      - name: prob0
+        port: 80
+        protocol: Tcp
+        interval: 10
+        fail_count: 3
+    inbound_nat_pools:
+      - name: inboundnatp0
+        frontend_ip_configuration_name: frontendip0
+        protocol: Tcp
+        frontend_port_range_start: 30
+        frontend_port_range_end: 40
+        backend_port: 80
+    load_balancing_rules:
+      - name: lbr
+        frontend_ip_configuration: frontendip0
+        backend_address_pool: backendaddrp0
+        probe: prob0
+        frontend_port: 81
+        backend_port: 8080
+        idle_timeout: 4
+        load_distribution: Default
+        protocol: Tcp
   register: output
 
 - name: Assert that output has changed

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -87,8 +87,7 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip: false
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: false
   register: output
   check_mode: true
@@ -105,8 +104,7 @@
     virtual_network:
       name: "tn{{ rpfx }}"
       resource_group: "{{ resource_group_secondary }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip: false
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: false
   register: output
 
@@ -146,7 +144,7 @@
         private_ip_address: "{{ facts.networkinterfaces[0].ip_configurations[0].private_ip_address }}"
         private_ip_allocation_method: "{{ facts.networkinterfaces[0].ip_configurations[0].private_ip_allocation_method }}"
         primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
-    subnet: "{{ facts.networkinterfaces[0].subnet }}"
+    subnet_name: "{{ facts.networkinterfaces[0].subnet }}"
   register: output
 
 - name: Assert the NIC created
@@ -159,9 +157,8 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: false
-    public_ip: false
   register: output
 
 - name: Assert NIC created
@@ -174,8 +171,7 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip: false
+    subnet_name: "tn{{ rpfx }}"
     security_group: "tn{{ rpfx }}sg"
   register: output
   check_mode: true
@@ -190,8 +186,10 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip_address_name: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
+    ip_configurations:
+      - name: default
+        public_ip_address_name: "tn{{ rpfx }}"
     create_with_security_group: false
   register: output
   check_mode: true
@@ -206,10 +204,9 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     enable_accelerated_networking: true
     create_with_security_group: false
-    public_ip: false
   register: output
   check_mode: true
 
@@ -223,10 +220,9 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: false
     enable_ip_forwarding: true
-    public_ip: false
   register: output
   check_mode: true
 
@@ -240,9 +236,8 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: false
-    public_ip: false
     dns_servers:
       - 8.9.10.11
       - 7.8.9.10
@@ -259,7 +254,7 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     enable_accelerated_networking: true
     enable_ip_forwarding: true
     security_group: "tn{{ rpfx }}sg"
@@ -300,7 +295,7 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     enable_accelerated_networking: true
     security_group: "tn{{ rpfx }}sg"
     enable_ip_forwarding: true
@@ -355,7 +350,7 @@
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     security_group: "tn{{ rpfx }}sg"
     enable_accelerated_networking: true
     enable_ip_forwarding: true
@@ -462,9 +457,8 @@
     resource_group: "{{ resource_group }}"
     name: "{{ nic_name1 }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: true
-    public_ip: false
     ip_configurations:
       - name: ipconfig1
         application_security_groups:
@@ -483,9 +477,8 @@
     resource_group: "{{ resource_group }}"
     name: "{{ nic_name1 }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: true
-    public_ip: false
     ip_configurations:
       - name: ipconfig1
         application_security_groups:
@@ -504,9 +497,8 @@
     resource_group: "{{ resource_group }}"
     name: "{{ nic_name1 }}"
     virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
+    subnet_name: "tn{{ rpfx }}"
     create_with_security_group: true
-    public_ip: false
     ip_configurations:
       - name: ipconfig1
         application_security_groups:
@@ -598,7 +590,6 @@
     virtual_network: "tn{{ rpfx }}"
     subnet_name: "nic-appgw-subnet{{ rpfx }}"
     create_with_security_group: false
-    public_ip: false
     ip_configurations:
       - name: "default"
         primary: true
@@ -621,7 +612,6 @@
     virtual_network: "tn{{ rpfx }}"
     subnet_name: "nic-appgw-subnet{{ rpfx }}"
     create_with_security_group: false
-    public_ip: false
     ip_configurations:
       - name: "default"
         primary: true

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_public_ip.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_public_ip.yml
@@ -31,9 +31,12 @@
   azure_rm_networkinterface:
     resource_group: "{{ resource_group }}"
     name: "{{ interface_name }}"
+    ip_configurations:
+      - name: default
+        primary: true
+        public_ip_address_name: "{{ public_ip_name }}"
     virtual_network: "{{ network_name }}"
     subnet: "{{ subnet_name }}"
-    public_ip_name: "{{ public_ip_name }}"
     security_group: "{{ security_group }}"
 
 - name: Create virtual machine with a single NIC and no boot diagnostics
@@ -233,7 +236,7 @@
   azure_rm_virtualmachine:
     resource_group: "{{ resource_group }}"
     name: "{{ vm_name }}"
-    vm_size: Standard_A1
+    vm_size: Standard_A1_v2
     storage_account: "{{ storage_account }}"
     storage_container: "{{ vm_name }}"
     storage_blob: "{{ vm_name }}.vhd"
@@ -256,7 +259,7 @@
   ansible.builtin.assert:
     that:
       - resize_result is changed
-      - resize_result.ansible_facts.azure_vm.hardware_profile.vm_size == "Standard_A1"
+      - resize_result.ansible_facts.azure_vm.hardware_profile.vm_size == "Standard_A1_v2"
 
 - name: Delete VM
   azure_rm_virtualmachine:

--- a/tests/integration/targets/azure_rm_virtualmachineextension/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachineextension/tasks/main.yml
@@ -39,9 +39,12 @@
   azure_rm_networkinterface:
     resource_group: "{{ resource_group }}"
     name: testNIC
+    ip_configurations:
+      - name: default
+        primary: true
+        public_ip_address_name: testPublicIP
     virtual_network: testVnet1
     subnet: testSubnet
-    public_ip_name: testPublicIP
     security_group_name: testNetworkSecurityGroup
 
 - name: Create a storage account

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -27,7 +27,11 @@
   azure_rm_loadbalancer:
     resource_group: "{{ resource_group }}"
     name: testLB
-    public_ip_address_name: testPublicIP
+    frontend_ip_configurations:
+      - name: frontendipconf0
+        public_ip_address: testPublicIP
+    backend_address_pools:
+      - name: backendaddrp0
     sku: Standard
 
 - name: Create public IP address 1
@@ -41,7 +45,11 @@
   azure_rm_loadbalancer:
     resource_group: "{{ resource_group }}"
     name: testLB1
-    public_ip_address_name: testPublicIP1
+    frontend_ip_configurations:
+      - name: frontendipconf0
+        public_ip_address: testPublicIP1
+    backend_address_pools:
+      - name: backendaddrp1
     sku: Standard
 
 - name: Create network security group within same resource group of VMSS.


### PR DESCRIPTION

##### SUMMARY

I pulled the code from this PR https://github.com/ansible/ansible/pull/65749 and updated the integration test cases to pass. 

Here is the original description:
As found in #65745, these two modules contain options which were supposed to be removed in Ansible 2.9. Since the sanity check didn't find the corresponding module.deprecate() calls, no issue was created and these deprecations were apparently forgotten.

Fixes #77

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer
azure_rm_networkinterface

##### ADDITIONAL INFORMATION
The following integration tests were run
- azure_rm_networkinterface
- azure_rm_virtualmachine
- azure_rm_loadbalancer
- azure_rm_image

And all passed