### PR TITLE
Remove outdated azure-iot-hub from requirements

### DIFF
--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -45,7 +45,6 @@ azure-mgmt-devtestlabs==9.0.0
 azure-mgmt-loganalytics==12.0.0
 azure-mgmt-automation==1.0.0
 azure-mgmt-iothub==2.2.0
-azure-iot-hub==2.6.1
 azure-mgmt-recoveryservices==2.0.0
 azure-mgmt-recoveryservicesbackup==3.0.0
 azure-mgmt-notificationhubs==7.0.0


### PR DESCRIPTION
##### SUMMARY
PR removes [`azure-iot-hub`](https://github.com/Azure/azure-iot-hub-python/) from the [requirements list](https://github.com/ansible-collections/azure/blob/dev/requirements-azure.txt) as it [depends](https://github.com/Azure/azure-iot-hub-python/blob/main/setup.py#L80) on the now deprecated [`azure-uamqp-python`](https://github.com/Azure/azure-uamqp-python) that is failing to build on popular systems such as [Mac ARM](https://github.com/ansible-collections/azure/issues/1511) and [Linux ARM on Python 3.12+](https://github.com/ansible-collections/azure/issues/1505).

[`azure-iot-hub`](https://github.com/Azure/azure-iot-hub-python/) itself hasn't had any updates in several years and is specific to one part of Azure functionality, IoTHub, that is probably better handled as an opt in at this time until it's been updated to no longer depend on deprecated packages.

Resolves #1505
Resolves #1511

##### ISSUE TYPE
- Bugfix Pull Request