### PR TITLE
Support on_premises_extension_attributes to azure_rm_aduser 

### DIFF
--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -437,7 +437,6 @@ class AzureRMADUser(AzureRMModuleBase):
                 if attr_value is not None:
                     extension_attributes[attribute_name] = attr_value
         return extension_attributes
-    
     def to_dict(self, object):
         return dict(
             object_id=object.id,

--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -119,6 +119,17 @@ options:
             - The maximum length is 64 characters.Returned only on $select.
             - Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).
         type: str
+    on_premises_extension_attributes:
+        description:
+            - Contains extensionAttributes1-15 for the user.
+            - These extension attributes are also known as Exchange custom attributes 1-15.
+            - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
+            - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
+            - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
+        type: dict
+        aliases:
+            - extension_attributes
+
 extends_documentation_fragment:
     - azure.azcollection.azure
 
@@ -143,6 +154,10 @@ EXAMPLES = '''
     usage_location: "US"
     mail: "{{ user_principal_name }}@contoso.com"
     company_name: 'Test Company'
+    on_premises_extension_attributes:
+      extension_attribute1: "test_extension_attribute1"
+      extension_attribute2: "test_extension_attribute2"
+      extension_attribute11: "test_extension_attribute11"
 
 - name: Update user with new value for account_enabled
   azure_rm_aduser:
@@ -205,6 +220,16 @@ company_name:
     type: str
     returned: always
     sample: 'Test Company'
+on_premises_extension_attributes:
+    description:
+        - Contains extensionAttributes1-15 for the user.
+        - These extension attributes are also known as Exchange custom attributes 1-15.
+        - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
+        - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
+        - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
+    type: dict
+    returned: always
+    sample: {}
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
@@ -212,6 +237,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 try:
     import asyncio
     from msgraph.generated.models.password_profile import PasswordProfile
+    from msgraph.generated.models.on_premises_extension_attributes import OnPremisesExtensionAttributes
     from msgraph.generated.models.user import User
     from msgraph.generated.users.users_request_builder import UsersRequestBuilder
 except ImportError:
@@ -239,7 +265,8 @@ class AzureRMADUser(AzureRMModuleBase):
             surname=dict(type='str'),
             user_type=dict(type='str'),
             mail=dict(type='str'),
-            company_name=dict(type='str')
+            company_name=dict(type='str'),
+            on_premises_extension_attributes=dict(type='dict', aliases=['extension_attributes'])
         )
 
         self.user_principal_name = None
@@ -259,6 +286,7 @@ class AzureRMADUser(AzureRMModuleBase):
         self.user_type = None
         self.mail = None
         self.company_name = None
+        self.on_premises_extension_attributes = None
         self.log_path = None
         self.log_mode = None
 
@@ -288,6 +316,13 @@ class AzureRMADUser(AzureRMModuleBase):
 
             if self.state == 'present':
 
+                extension_attributes = None
+
+                if self.on_premises_extension_attributes:
+                    extension_attributes=OnPremisesExtensionAttributes(
+                        **self.on_premises_extension_attributes
+	                  )
+
                 if ad_user:  # Update, changed
 
                     password = None
@@ -295,10 +330,9 @@ class AzureRMADUser(AzureRMModuleBase):
                     if self.password_profile:
                         password = PasswordProfile(
                             password=self.password_profile,
-                        )
+                        )      
 
                     should_update = False
-
                     if self.on_premises_immutable_id and ad_user.on_premises_immutable_id != self.on_premises_immutable_id:
                         should_update = True
                     if should_update or self.usage_location and ad_user.usage_location != self.usage_location:
@@ -321,9 +355,11 @@ class AzureRMADUser(AzureRMModuleBase):
                         should_update = True
                     if should_update or self.company_name and ad_user.company_name != self.company_name:
                         should_update = True
+                    if should_update or self.on_premises_extension_attributes and self.on_premises_extension_attributes_to_dict(ad_user.on_premises_extension_attributes) != self.on_premises_extension_attributes:
+                        should_update = True
 
                     if should_update:
-                        asyncio.get_event_loop().run_until_complete(self.update_user(ad_user, password))
+                        asyncio.get_event_loop().run_until_complete(self.update_user(ad_user, password, extension_attributes))
 
                         self.results['changed'] = True
 
@@ -335,7 +371,7 @@ class AzureRMADUser(AzureRMModuleBase):
                         self.results['changed'] = False
 
                 else:  # Create, changed
-                    asyncio.get_event_loop().run_until_complete(self.create_user())
+                    asyncio.get_event_loop().run_until_complete(self.create_user(extension_attributes))
                     self.results['changed'] = True
                     ad_user = self.get_exisiting_user()
 
@@ -391,6 +427,16 @@ class AzureRMADUser(AzureRMModuleBase):
                 raise
         return ad_user
 
+    def on_premises_extension_attributes_to_dict(self, on_premises_extension_attributes):
+        extension_attributes = {}
+        for index in range(1, 16 + 1):
+            attribute_name = f'extension_attribute{index}'
+            if hasattr(on_premises_extension_attributes, attribute_name):
+                attr_value = getattr(on_premises_extension_attributes, attribute_name)
+                if attr_value is not None:
+                    extension_attributes[attribute_name] = attr_value
+        return extension_attributes
+    
     def to_dict(self, object):
         return dict(
             object_id=object.id,
@@ -400,10 +446,11 @@ class AzureRMADUser(AzureRMModuleBase):
             mail=object.mail,
             account_enabled=object.account_enabled,
             user_type=object.user_type,
-            company_name=object.company_name
+            company_name=object.company_name,
+            on_premises_extension_attributes=self.on_premises_extension_attributes_to_dict(object.on_premises_extension_attributes)
         )
 
-    async def update_user(self, ad_user, password):
+    async def update_user(self, ad_user, password, extension_attributes):
         request_body = User(
             on_premises_immutable_id=self.on_premises_immutable_id,
             usage_location=self.usage_location,
@@ -415,11 +462,12 @@ class AzureRMADUser(AzureRMModuleBase):
             password_profile=password,
             user_principal_name=self.user_principal_name,
             mail_nickname=self.mail_nickname,
-            company_name=self.company_name
+            company_name=self.company_name,
+            on_premises_extension_attributes=extension_attributes
         )
         return await self._client.users.by_user_id(ad_user.id).patch(body=request_body)
 
-    async def create_user(self):
+    async def create_user(self, extension_attributes):
         password = PasswordProfile(
             password=self.password_profile
         )
@@ -435,7 +483,8 @@ class AzureRMADUser(AzureRMModuleBase):
             surname=self.surname,
             user_type=self.user_type,
             mail=self.mail,
-            company_name=self.company_name
+            company_name=self.company_name,
+            on_premises_extension_attributes=extension_attributes
         )
         return await self._client.users.post(body=request_body)
 
@@ -446,7 +495,7 @@ class AzureRMADUser(AzureRMModuleBase):
         request_configuration = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(
             query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
                 select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType",
-                        "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName"]
+                        "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName", "OnPremisesExtensionAttributes"]
             ),
         )
         return await self._client.users.by_user_id(object).get(request_configuration=request_configuration)
@@ -457,7 +506,7 @@ class AzureRMADUser(AzureRMModuleBase):
                 query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
                     filter=filter,
                     select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName",
-                            "userType", "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName"],
+                            "userType", "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName", "OnPremisesExtensionAttributes"],
                     count=True
                 ),
                 headers={'ConsistencyLevel': "eventual", }

--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -331,7 +331,7 @@ class AzureRMADUser(AzureRMModuleBase):
                     if self.password_profile:
                         password = PasswordProfile(
                             password=self.password_profile,
-                        )      
+                        )
 
                     should_update = False
                     if self.on_premises_immutable_id and ad_user.on_premises_immutable_id != self.on_premises_immutable_id:

--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -125,7 +125,8 @@ options:
             - These extension attributes are also known as Exchange custom attributes 1-15.
             - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
             - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
-            - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
+            - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph\
+              but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
         type: dict
         aliases:
             - extension_attributes

--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -227,7 +227,8 @@ on_premises_extension_attributes:
         - These extension attributes are also known as Exchange custom attributes 1-15.
         - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
         - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
-        - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
+        - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph\
+          but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
     type: dict
     returned: always
     sample: {}
@@ -320,9 +321,9 @@ class AzureRMADUser(AzureRMModuleBase):
                 extension_attributes = None
 
                 if self.on_premises_extension_attributes:
-                    extension_attributes=OnPremisesExtensionAttributes(
+                    extension_attributes = OnPremisesExtensionAttributes(
                         **self.on_premises_extension_attributes
-	                  )
+                    )
 
                 if ad_user:  # Update, changed
 
@@ -356,9 +357,10 @@ class AzureRMADUser(AzureRMModuleBase):
                         should_update = True
                     if should_update or self.company_name and ad_user.company_name != self.company_name:
                         should_update = True
-                    if should_update or self.on_premises_extension_attributes and self.on_premises_extension_attributes_to_dict(ad_user.on_premises_extension_attributes) != self.on_premises_extension_attributes:
+                    if should_update or (
+                            self.on_premises_extension_attributes and
+                            self.on_premises_extension_attributes_to_dict(ad_user.on_premises_extension_attributes) != self.on_premises_extension_attributes):
                         should_update = True
-
                     if should_update:
                         asyncio.get_event_loop().run_until_complete(self.update_user(ad_user, password, extension_attributes))
 
@@ -437,6 +439,7 @@ class AzureRMADUser(AzureRMModuleBase):
                 if attr_value is not None:
                     extension_attributes[attribute_name] = attr_value
         return extension_attributes
+
     def to_dict(self, object):
         return dict(
             object_id=object.id,
@@ -495,7 +498,8 @@ class AzureRMADUser(AzureRMModuleBase):
         request_configuration = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(
             query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
                 select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType",
-                        "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName", "OnPremisesExtensionAttributes"]
+                        "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName",
+                        "OnPremisesExtensionAttributes"]
             ),
         )
         return await self._client.users.by_user_id(object).get(request_configuration=request_configuration)
@@ -506,7 +510,8 @@ class AzureRMADUser(AzureRMModuleBase):
                 query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
                     filter=filter,
                     select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName",
-                            "userType", "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName", "OnPremisesExtensionAttributes"],
+                            "userType", "onPremisesImmutableId", "usageLocation", "givenName", "surname", "companyName",
+                            "OnPremisesExtensionAttributes"],
                     count=True
                 ),
                 headers={'ConsistencyLevel': "eventual", }

--- a/plugins/modules/azure_rm_aduser_info.py
+++ b/plugins/modules/azure_rm_aduser_info.py
@@ -251,6 +251,7 @@ class AzureRMADUserInfo(AzureRMModuleBase):
                 if attr_value is not None:
                     extension_attributes[attribute_name] = attr_value
         return extension_attributes
+
     def to_dict(self, object):
         return dict(
             object_id=object.id,

--- a/plugins/modules/azure_rm_aduser_info.py
+++ b/plugins/modules/azure_rm_aduser_info.py
@@ -250,7 +250,6 @@ class AzureRMADUserInfo(AzureRMModuleBase):
                 if attr_value is not None:
                     extension_attributes[attribute_name] = attr_value
         return extension_attributes
-    
     def to_dict(self, object):
         return dict(
             object_id=object.id,

--- a/plugins/modules/azure_rm_aduser_info.py
+++ b/plugins/modules/azure_rm_aduser_info.py
@@ -149,7 +149,8 @@ on_premises_extension_attributes:
         - These extension attributes are also known as Exchange custom attributes 1-15.
         - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
         - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
-        - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
+        - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph/
+          but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
     type: dict
     returned: always
     sample: {}
@@ -266,7 +267,8 @@ class AzureRMADUserInfo(AzureRMModuleBase):
     async def get_user(self, object):
         request_configuration = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(
             query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
-                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType", "companyName", "onPremisesExtensionAttributes"]
+                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName",
+                        "userType", "companyName", "onPremisesExtensionAttributes"]
             ),
         )
         return await self._client.users.by_user_id(object).get(request_configuration=request_configuration)
@@ -274,7 +276,8 @@ class AzureRMADUserInfo(AzureRMModuleBase):
     async def get_users(self):
         request_configuration = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(
             query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
-                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType", "companyName", "onPremisesExtensionAttributes"]
+                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName",
+                        "userType", "companyName", "onPremisesExtensionAttributes"]
             ),
         )
         users = []

--- a/plugins/modules/azure_rm_aduser_info.py
+++ b/plugins/modules/azure_rm_aduser_info.py
@@ -143,6 +143,16 @@ company_name:
     type: str
     returned: always
     sample: "Test Company"
+on_premises_extension_attributes:
+    description:
+        - Contains extensionAttributes1-15 for the user.
+        - These extension attributes are also known as Exchange custom attributes 1-15.
+        - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
+        - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
+        - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
+    type: dict
+    returned: always
+    sample: {}
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
@@ -224,7 +234,6 @@ class AzureRMADUserInfo(AzureRMModuleBase):
             elif self.all:
                 # this returns as a list, since we parse multiple pages
                 ad_users = asyncio.get_event_loop().run_until_complete(self.get_users())
-
             self.results['ad_users'] = [self.to_dict(user) for user in ad_users]
 
         except Exception as e:
@@ -232,6 +241,16 @@ class AzureRMADUserInfo(AzureRMModuleBase):
 
         return self.results
 
+    def on_premises_extension_attributes_to_dict(self, on_premises_extension_attributes):
+        extension_attributes = {}
+        for index in range(1, 16 + 1):
+            attribute_name = f'extension_attribute{index}'
+            if hasattr(on_premises_extension_attributes, attribute_name):
+                attr_value = getattr(on_premises_extension_attributes, attribute_name)
+                if attr_value is not None:
+                    extension_attributes[attribute_name] = attr_value
+        return extension_attributes
+    
     def to_dict(self, object):
         return dict(
             object_id=object.id,
@@ -241,13 +260,14 @@ class AzureRMADUserInfo(AzureRMModuleBase):
             mail=object.mail,
             account_enabled=object.account_enabled,
             user_type=object.user_type,
-            company_name=object.company_name
+            company_name=object.company_name,
+            on_premises_extension_attributes=self.on_premises_extension_attributes_to_dict(object.on_premises_extension_attributes)
         )
 
     async def get_user(self, object):
         request_configuration = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(
             query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
-                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType", "companyName"]
+                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType", "companyName", "onPremisesExtensionAttributes"]
             ),
         )
         return await self._client.users.by_user_id(object).get(request_configuration=request_configuration)
@@ -255,7 +275,7 @@ class AzureRMADUserInfo(AzureRMModuleBase):
     async def get_users(self):
         request_configuration = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(
             query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
-                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType", "companyName"]
+                select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName", "userType", "companyName", "onPremisesExtensionAttributes"]
             ),
         )
         users = []
@@ -276,7 +296,7 @@ class AzureRMADUserInfo(AzureRMModuleBase):
                 query_parameters=UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
                     filter=filter,
                     select=["accountEnabled", "displayName", "mail", "mailNickname", "id", "userPrincipalName",
-                            "userType", "companyName"],
+                            "userType", "companyName", "onPremisesExtensionAttributes"],
                     count=True
                 ),
             ))

--- a/tests/integration/targets/azure_rm_aduser/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aduser/tasks/main.yml
@@ -1,35 +1,50 @@
 - name: Prepare facts
   ansible.builtin.set_fact:
-    user_id: "user{{ 999999999999999999994 | random | to_uuid }}@contoso.com"
-    object_id: "{{ 999999999999999999994 | random | to_uuid }}"
-    user_principal_name: "{{ 999999999999999999994 | random | to_uuid }}"
+    user_name: "test_user_{{ 999999999999999999994 | random | to_uuid }}"
+    on_premises_immutable_id: "{{ 999999999999999999994 | random | to_uuid }}"
+    password_profile: "{{ lookup('community.general.random_string', length=12, min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"
+    domain: change_me.com
   run_once: true
 
 - name: Create test user
   azure_rm_aduser:
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
     state: "present"
     account_enabled: true
-    display_name: "Test_{{ user_principal_name }}_Display_Name"
-    password_profile: "password"
-    mail_nickname: "Test_{{ user_principal_name }}_mail_nickname"
-    immutable_id: "{{ object_id }}"
+    display_name: "{{ user_name }}_display_name"
+    password_profile: "{{ password_profile }}"
+    mail_nickname: "{{ user_name }}_mail_nickname"
+    on_premises_immutable_id: "{{ on_premises_immutable_id }}"
     given_name: "First"
     surname: "Last"
     user_type: "Member"
     usage_location: "US"
-    mail: "{{ user_principal_name }}@contoso.com"
+    mail: "{{ user_name }}@{{ domain }}"
+    company_name: "Test Company"
+    on_premises_extension_attributes:
+      extension_attribute1: "test_extension_attribute1"
+      extension_attribute2: "test_extension_attribute2"
+      extension_attribute11: "test_extension_attribute11"
   register: create_user_should_pass
 
 - name: Try to update existing user - idempotent check
   azure_rm_aduser:
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
     state: "present"
-    display_name: "Test_{{ user_principal_name }}_Display_Name"
-    mail_nickname: "Test_{{ user_principal_name }}_mail_nickname"
+    account_enabled: true
+    display_name: "{{ user_name }}_display_name"
+    mail_nickname: "{{ user_name }}_mail_nickname"
+    on_premises_immutable_id: "{{ on_premises_immutable_id }}"
     given_name: "First"
     surname: "Last"
-    mail: "{{ user_principal_name }}@contoso.com"
+    user_type: "Member"
+    usage_location: "US"
+    mail: "{{ user_name }}@{{ domain }}"
+    company_name: "Test Company"
+    on_premises_extension_attributes:
+      extension_attribute1: "test_extension_attribute1"
+      extension_attribute2: "test_extension_attribute2"
+      extension_attribute11: "test_extension_attribute11"
   register: attempted_update_with_no_changes_should_pass
 
 - name: Assert Nothing Changed
@@ -39,42 +54,49 @@
 
 - name: User_principal_name Should Pass
   azure_rm_aduser_info:
-    user_principal_name: "{{ user_id }}"
-  register: get_user_should_pass
+    user_principal_name: "{{ user_name }}@{{ domain }}"
+  register: get_user_by_upn_should_pass
+
+- name: Attribute_name mail Should Pass
+  azure_rm_aduser_info:
+    attribute_name: "mail"
+    attribute_value: "{{ user_name }}@{{ domain }}"
+  register: get_user_by_mail_should_pass
 
 - name: Assert user was created and account is enabled
   ansible.builtin.assert:
     that:
-      - "create_user_should_pass['ad_users'][0]['account_enabled'] == True"
-      - "get_user_should_pass['ad_users'][0]['account_enabled'] == True"
+      - "create_user_should_pass['ad_user']['account_enabled'] == True"
+      - "get_user_by_upn_should_pass['ad_users'][0]['account_enabled'] == True"
+      - "get_user_by_mail_should_pass['ad_users'][0]['account_enabled'] == True"
 
 - name: Update test user
   azure_rm_aduser:
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
     state: "present"
     account_enabled: false
   register: update_user_should_pass
 
 - name: User_principal_name on updated user Should Pass
   azure_rm_aduser_info:
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
   register: get_updated_user_should_pass
 
 - name: Assert user was updated and account is disabled
   ansible.builtin.assert:
     that:
-      - "update_user_should_pass['ad_users'][0]['account_enabled'] == False"
+      - "update_user_should_pass['ad_user']['account_enabled'] == False"
       - "get_updated_user_should_pass['ad_users'][0]['account_enabled'] == False"
 
 - name: Delete test user
   azure_rm_aduser:
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
     state: "absent"
   register: delete_user_should_pass
 
 - name: User_principal_name Should Fail
   azure_rm_aduser_info:
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
   register: get_user_should_fail
   ignore_errors: true
 
@@ -91,19 +113,19 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - "missing_any_identifiers is undefined"
+      - "missing_any_identifiers is defined"
 
 - name: Too many identifiers Should Fail
   azure_rm_aduser_info:
-    user_principal_name: "{{ user_id }}"
-    object_id: "{{ object_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
+    object_id: "{{ on_premises_immutable_id }}"
   register: too_many_identifiers
   ignore_errors: true
 
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - "too_many_identifiers is undefined"
+      - "too_many_identifiers is defined"
 
 - name: Missing attribute_value Should Fail
   azure_rm_aduser_info:
@@ -114,27 +136,27 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - "missing_attribute_value is undefined"
+      - "missing_attribute_value is defined"
 
 - name: Missing attribute_name Should Fail
   azure_rm_aduser_info:
-    attribute_value: SMTP:user@contoso.com
+    attribute_value: SMTP:user@stadtluzern.ch
   register: missing_attribute_name
   ignore_errors: true
 
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - "missing_attribute_name is undefined"
+      - "missing_attribute_name is defined"
 
 - name: Using all with principal name should fail
   azure_rm_aduser_info:
     all: true
-    user_principal_name: "{{ user_id }}"
+    user_principal_name: "{{ user_name }}@{{ domain }}"
   register: using_all_with_principal_name
   ignore_errors: true
 
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - "using_all_with_principal_name is undefined"
+      - "using_all_with_principal_name is defined"


### PR DESCRIPTION
##### SUMMARY
Support on_premises_extension_attributes to azure_rm_aduser  #1500


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
azure_rm_aduser.py
azure_rm_aduser_info.py
test targets > azure_rm_aduser > tasks: main

##### ADDITIONAL INFORMATION
```yaml
DOCUMENTATION = '''
options:
    on_premises_extension_attributes:
        description:
            - Contains extensionAttributes1-15 for the user.
            - These extension attributes are also known as Exchange custom attributes 1-15.
            - For an onPremisesSyncEnabled user, the source of authority for this set of properties is the on-premises and is read-only.
            - For a cloud-only user (where onPremisesSyncEnabled is false), these properties can be set during the creation or update of a user object.
            - For a cloud-only user previously synced from on-premises Active Directory, these properties are read-only in Microsoft Graph but can be fully managed through the Exchange Admin Center or the Exchange Online V2 module in PowerShell.
        type: dict
        aliases:
            - extension_attributes
```