### PR TITLE
Add user assigned identity ability to postgresqlFlexServer

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -947,7 +947,10 @@ class AzureRMModuleBase(object):
             def _ansible_get_models(self, *arg, **kwarg):
                 return self._ansible_models
 
-            setattr(client, '_ansible_models', importlib.import_module(client_type.__module__).models)
+            try:
+                setattr(client, '_ansible_models', importlib.import_module(client_type.__module__).models)
+            except AttributeError:
+                setattr(client, '_ansible_models', importlib.import_module(client_type.__module__)._models)
             client.models = types.MethodType(_ansible_get_models, client)
 
         if self.azure_auth._cert_validation_mode == 'ignore':

--- a/plugins/modules/azure_rm_postgresqlflexibleserver_info.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver_info.py
@@ -282,6 +282,30 @@ servers:
                     returned: always
                     sample: null
                     type: str
+        identity:
+            description:
+                - Identity for the Server.
+            type: complex
+            returned: when available
+            contains:
+                type:
+                    description:
+                        - Type of the managed identity
+                    returned: always
+                    sample: UserAssigned
+                    type: str
+                user_assigned_identities:
+                    description:
+                        - User Assigned Managed Identities and its options
+                    returned: always
+                    type: complex
+                    contains:
+                        id:
+                            description:
+                                - Dict of the user assigned identities IDs associated to the Resource
+                            returned: always
+                            type: dict
+                            elements: dict
         tags:
             description:
                 - Tags assigned to the resource. Dictionary of string:string pairs.
@@ -293,6 +317,7 @@ servers:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+    import azure.mgmt.rdbms.postgresql_flexibleservers.models as PostgreSQLFlexibleModels
     from azure.core.exceptions import ResourceNotFoundError
 except ImportError:
     # This is handled in azure_rm_common
@@ -431,6 +456,10 @@ class AzureRMPostgreSqlFlexibleServersInfo(AzureRMModuleBase):
             result['maintenance_window']['start_minute'] = item.maintenance_window.start_minute
             result['maintenance_window']['start_hour'] = item.maintenance_window.start_hour
             result['maintenance_window']['day_of_week'] = item.maintenance_window.day_of_week
+        if item.identity is not None:
+            result['identity'] = item.identity.as_dict()
+        else:
+            result['identity'] = PostgreSQLFlexibleModels.UserAssignedIdentity(type='None').as_dict()
 
         return result
 

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -11,7 +11,7 @@ azure-mgmt-batch==16.2.0
 azure-mgmt-cdn==11.0.0
 azure-mgmt-compute==26.1.0
 azure-mgmt-containerinstance==9.0.0
-azure-mgmt-core==1.3.0
+azure-mgmt-core==1.4.0
 azure-mgmt-containerregistry==9.1.0
 azure-containerregistry==1.1.0
 azure-mgmt-containerservice==20.0.0
@@ -27,7 +27,7 @@ azure-mgmt-nspkg==2.0.0
 azure-mgmt-privatedns==1.0.0
 azure-mgmt-redis==13.0.0
 azure-mgmt-resource==21.1.0
-azure-mgmt-rdbms==10.0.0
+azure-mgmt-rdbms==10.2.0b12
 azure-mgmt-search==8.0.0
 azure-mgmt-servicebus==7.1.0
 azure-mgmt-sql==3.0.1

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -1,15 +1,43 @@
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
 - name: Prepare random number
   ansible.builtin.set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(8, True, '') }}"
     new_resource_group: "{{ resource_group }}-02"
   run_once: true
 
+- name: Set Azure Region based on resource group location
+  ansible.builtin.set_fact:
+    location: "{{ __rg_info.resourcegroups.0.location }}"
+
 - name: Create a new resource group
   azure_rm_resourcegroup:
     name: "{{ new_resource_group }}"
-    location: southeastasia
+    location: "{{ location }}"
 
-- name: Create post gresql flexible server (check mode)
+- name: Create User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ new_resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    body:
+      location: "{{ location }}"
+    state: present
+  loop:
+    - "ansible-test-pgsql-identity"
+    - "ansible-test-pgsql-identity-2"
+
+- name: Set identities IDs to test. Identities ansible-test-psql-identity and ansible-test-psql-identity-2 have to be created previously
+  ansible.builtin.set_fact:
+    user_identity_1: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ new_resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-pgsql-identity"
+    user_identity_2: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ new_resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-pgsql-identity-2"
+
+- name: Create postgresql flexible server (check mode)
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
@@ -34,9 +62,14 @@
       day_of_week: 3
     availability_zone: 2
     create_mode: Create
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
   check_mode: true
 
-- name: Create post gresql flexible server
+- name: Create postgresql flexible server
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
@@ -61,14 +94,25 @@
       day_of_week: 3
     availability_zone: 2
     create_mode: Create
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
   register: output
 
-- name: Assert the post grep sql server create success
+- name: Assert the postgresql flexible server create success
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: Create post gresql flexible server (Idempotent Test)
+- name: Assert User identity assigned
+  ansible.builtin.assert:
+    that:
+      - output.state.identity.type == 'UserAssigned'
+      - user_identity_1 in output.state.identity.user_assigned_identities
+
+- name: Create postgresql flexible server (Idempotent Test)
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
@@ -93,14 +137,19 @@
       day_of_week: 3
     availability_zone: 2
     create_mode: Create
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
   register: output
 
-- name: Assert the post grep sql server create success
+- name: Assert the postgresql server create success
   ansible.builtin.assert:
     that:
       - not output.changed
 
-- name: Update post gresql flexible server with multiple parameters
+- name: Update postgresql flexible server with multiple parameters
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
@@ -128,9 +177,15 @@
     tags:
       key1: value1
       key2: value2
+    identity:
+      type: "UserAssigned"
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_2 }}"
+        append: true
   register: output
 
-- name: Assert the post grep sql server update success
+- name: Assert the postgresql server update success
   ansible.builtin.assert:
     that:
       - output.changed
@@ -141,7 +196,7 @@
     name: postflexible{{ rpfx }}
   register: output
 
-- name: Assert the post gresql server is well created
+- name: Assert the postgresql server is well created
   ansible.builtin.assert:
     that:
       - output.servers[0].tags | length == 2
@@ -150,8 +205,23 @@
       - output.servers[0].maintenance_window.day_of_week == 6
       - output.servers[0].maintenance_window.start_hour == 10
       - output.servers[0].maintenance_window.start_minute == 6
+      - user_identity_1 in output.servers[0].identity.user_assigned_identities
+      - user_identity_2 in output.servers[0].identity.user_assigned_identities
 
-- name: Create a post gresql flexible database(check mode)
+- name: Postgresql server Identity None
+  azure_rm_postgresqlflexibleserver:
+    name: postflexible{{ rpfx }}
+    resource_group: "{{ new_resource_group }}"
+    identity:
+      type: "None"
+  register: output
+
+- name: Assert no managed identities
+  ansible.builtin.assert:
+    that:
+      - output.state.identity.type == 'None'
+
+- name: Create a postgresql flexible database(check mode)
   azure_rm_postgresqlflexibledatabase:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -160,7 +230,7 @@
     charset: UTF8
   check_mode: true
 
-- name: Create a post gresql flexible database
+- name: Create a postgresql flexible database
   azure_rm_postgresqlflexibledatabase:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -169,12 +239,12 @@
     charset: UTF8
   register: output
 
-- name: Assert the post gresql flexible database created success
+- name: Assert the postgresql flexible database created success
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: Create a post gresql flexible database(Idempotent test)
+- name: Create a postgresql flexible database(Idempotent test)
   azure_rm_postgresqlflexibledatabase:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -183,25 +253,25 @@
     charset: UTF8
   register: output
 
-- name: Assert the post gresql flexible database no changed
+- name: Assert the postgresql flexible database no changed
   ansible.builtin.assert:
     that:
       - not output.changed
 
-- name: Get the post gresql flexibe database facts
+- name: Get the postgresql flexibe database facts
   azure_rm_postgresqlflexibledatabase_info:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
     name: database{{ rpfx }}
   register: output
 
-- name: Assert the post gresql flexible database facts
+- name: Assert the postgresql flexible database facts
   ansible.builtin.assert:
     that:
       - output.databases[0].collation == 'en_US.utf8'
       - output.databases[0].charset == 'UTF8'
 
-- name: Delete the post gresql flexibe database
+- name: Delete the postgresql flexibe database
   azure_rm_postgresqlflexibledatabase:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -209,12 +279,12 @@
     state: absent
   register: output
 
-- name: Assert the post gresql flexible database deleted
+- name: Assert the postgresql flexible database deleted
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: Create a post gresql flexible firwall rule (Check mode)
+- name: Create a postgresql flexible firwall rule (Check mode)
   azure_rm_postgresqlflexiblefirewallrule:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -223,7 +293,7 @@
     end_ip_address: 10.0.0.20
   check_mode: true
 
-- name: Create the post gresql flexible firwall rule
+- name: Create the postgresql flexible firwall rule
   azure_rm_postgresqlflexiblefirewallrule:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -232,12 +302,12 @@
     end_ip_address: 10.0.0.20
   register: output
 
-- name: Assert the post grepsql flexible firewall rule created well
+- name: Assert the postgrepsql flexible firewall rule created well
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: Create the post gresql flexible firwall rule (Idempotent test)
+- name: Create the postgresql flexible firwall rule (Idempotent test)
   azure_rm_postgresqlflexiblefirewallrule:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -246,12 +316,12 @@
     end_ip_address: 10.0.0.20
   register: output
 
-- name: Assert the post grepsql flexible firewall rule support idempotent test
+- name: Assert the postgresql flexible firewall rule support idempotent test
   ansible.builtin.assert:
     that:
       - not output.changed
 
-- name: Update the post gresql flexible firwall rule
+- name: Update the postgresql flexible firwall rule
   azure_rm_postgresqlflexiblefirewallrule:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -260,25 +330,25 @@
     end_ip_address: 10.0.0.18
   register: output
 
-- name: Assert the post grepsql flexible server update well
+- name: Assert the postgresql flexible server update well
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: Get the post gresql flexible firwall rule facts
+- name: Get the postgresql flexible firwall rule facts
   azure_rm_postgresqlflexiblefirewallrule_info:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
     name: firewall{{ rpfx }}
   register: output
 
-- name: Assert the post gresql flexible firewall rule facts
+- name: Assert the postgresql flexible firewall rule facts
   ansible.builtin.assert:
     that:
       - output.firewall_rules[0].start_ip_address == '10.0.0.16'
       - output.firewall_rules[0].end_ip_address == '10.0.0.18'
 
-- name: Delete the post gresql flexible firwall rule
+- name: Delete the postgresql flexible firwall rule
   azure_rm_postgresqlflexiblefirewallrule:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
@@ -286,30 +356,30 @@
     state: absent
   register: output
 
-- name: Assert the post grepsql flexible server delete well
+- name: Assert the postgresql flexible server delete well
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: List the post gresql flexible config facts
+- name: List the postgresql flexible config facts
   azure_rm_postgresqlflexibleconfiguration_info:
     resource_group: "{{ new_resource_group }}"
     server_name: postflexible{{ rpfx }}
   register: output
 
-- name: Assert the post gresql flexible server configuration
+- name: Assert the postgresql flexible server configuration
   ansible.builtin.assert:
     that:
       - output.settings | length > 0
 
-- name: Stop the post gresql flexible server
+- name: Stop the postgresql flexible server
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
     is_stop: true
   register: output
 
-- name: Assert the post grep sql server stop success
+- name: Assert the postgresql server stop success
   ansible.builtin.assert:
     that:
       - output.changed
@@ -319,29 +389,41 @@
     minutes: 10
   changed_when: true
 
-- name: Restart post gresql flexible server
+- name: Restart postgresql flexible server
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
     is_restart: true
   register: output
 
-- name: Assert the post grep sql server restart success
+- name: Assert the postgresql server restart success
   ansible.builtin.assert:
     that:
       - output.changed
 
-- name: Delete post gresql flexible server
+- name: Delete postgresql flexible server
   azure_rm_postgresqlflexibleserver:
     resource_group: "{{ new_resource_group }}"
     name: postflexible{{ rpfx }}
     state: absent
   register: output
 
-- name: Assert the post gresql server is well deleted
+- name: Assert the postgresql server is well deleted
   ansible.builtin.assert:
     that:
       - output.changed
+
+- name: Destroy User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ new_resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    state: absent
+  loop:
+    - "ansible-test-psql-identity"
+    - "ansible-test-psql-identity-2"
 
 - name: Delete the new resource group
   azure_rm_resourcegroup:


### PR DESCRIPTION
This adds the same capability that the azure cli supports for assigning userAssignedIdentities to postgresql Flexible Server.

##### SUMMARY
Adds support for User Assigned Identities for postgresql Flexible Server

This adds the same support that the azure cli has.

Fixes: #1527 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_postgresqlflexibleserver
azure_rm_postgresqlflexibleserver_info

