### PR TITLE
Add UserAssigned Identity to aks module

### DIFF
--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -1,21 +1,46 @@
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
 - name: Set varialbles
   ansible.builtin.set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(8, True, '') }}"
     noderpfx: "{{ resource_group | hash('md5') | truncate(4, True, '') }}"
+    location: "{{ __rg_info.resourcegroups.0.location }}"
+
+- name: Create User Managed Identity
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    body:
+      location: "{{ location }}"
+    state: present
+  loop:
+    - "ansible-test-aks-identity"
+    - "ansible-test-aks-identity-2"
+
+- name: Set identities IDs to test. Identities ansible-test-aks-identity and ansible-test-aks-identity-2 have to be created previously
+  ansible.builtin.set_fact:
+    user_identity: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-aks-identity"
+    user_identity_2: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-aks-identity-2"
 
 - name: Include aks tasks
   ansible.builtin.include_tasks: minimal-cluster.yml
 
 - name: Find available k8s version
   azure_rm_aksversion_info:
-    location: eastus
+    location: "{{ location }}"
   register: versions
 
 - name: Create an AKS instance (check mode)
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     service_principal:
@@ -56,7 +81,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     service_principal:
@@ -107,7 +132,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     service_principal:
@@ -167,7 +192,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     service_principal:
@@ -198,7 +223,7 @@
 
 - name: Get available version
   azure_rm_aksversion_info:
-    location: eastus
+    location: "{{ location }}"
     version: "{{ versions.azure_aks_versions[0] }}"
   register: version1
 
@@ -206,7 +231,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -246,7 +271,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -282,7 +307,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -323,7 +348,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -360,7 +385,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -408,7 +433,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -449,7 +474,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -497,7 +522,7 @@
   azure_rm_aks:
     name: "aks{{ rpfx }}"
     resource_group: "{{ resource_group }}"
-    location: eastus
+    location: "{{ location }}"
     dns_prefix: "aks{{ rpfx }}"
     kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
     service_principal:
@@ -576,3 +601,15 @@
   ansible.builtin.assert:
     that:
       - "fact.aks | length == 0"
+
+- name: Destroy User Managed Identity
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    state: absent
+  loop:
+    - "ansible-test-aks-identity"
+    - "ansible-test-aks-identity-2"

--- a/tests/integration/targets/azure_rm_aks/tasks/minimal-cluster.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/minimal-cluster.yml
@@ -4,13 +4,13 @@
 
 - name: Find available k8s version
   azure_rm_aksversion_info:
-    location: eastus
+    location: "{{ location }}"
   register: versions
 
 - name: Use minimal parameters and system-assigned identity
   azure_rm_aks:
     name: "minimal{{ rpfx }}"
-    location: eastus
+    location: "{{ location }}"
     resource_group: "{{ resource_group }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     dns_prefix: "aks{{ rpfx }}"
@@ -55,11 +55,13 @@
 - name: Use minimal parameters and system-assigned identity (idempotent)
   azure_rm_aks:
     name: "minimal{{ rpfx }}"
-    location: eastus
+    location: "{{ location }}"
     resource_group: "{{ resource_group }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     dns_prefix: "aks{{ rpfx }}"
     enable_rbac: true
+    identity:
+      type: "SystemAssigned"
     aad_profile:
       managed: true
     agent_pool_profiles:
@@ -83,10 +85,142 @@
     that:
       - not output.changed
 
+- name: Use minimal parameters and user-assigned identity
+  azure_rm_aks:
+    name: "minimal{{ rpfx }}"
+    location: "{{ location }}"
+    resource_group: "{{ resource_group }}"
+    kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+    dns_prefix: "aks{{ rpfx }}"
+    enable_rbac: true
+    identity:
+      type: "UserAssigned"
+      user_assigned_identities: "{{ user_identity }}"
+    aad_profile:
+      managed: true
+    agent_pool_profiles:
+      - name: default
+        count: 1
+        vm_size: Standard_B2s
+        mode: System
+    api_server_access_profile:
+      authorized_ip_ranges:
+        - "192.0.2.0"
+        - "198.51.100.0"
+        - "203.0.113.0"
+      enable_private_cluster: false
+    network_profile:
+      load_balancer_sku: standard
+      outbound_type: loadBalancer
+  register: output
+
+- name: Assert the AKS instance is well created
+  ansible.builtin.assert:
+    that:
+      - output.changed
+      - output.provisioning_state == 'Succeeded'
+
+- name: Get AKS fact
+  azure_rm_aks_info:
+    name: "minimal{{ rpfx }}"
+    resource_group: "{{ resource_group }}"
+  register: fact
+
+- name: Assert fact returns the created one
+  ansible.builtin.assert:
+    that:
+      - "fact.aks | length == 1"
+      - fact.aks[0].id == output.id
+      - fact.aks[0].aad_profile.managed == true
+      - user_identity in fact.aks[0].identity.user_assigned_identities
+
+- name: Use minimal parameters and user-assigned identity (idempotent)
+  azure_rm_aks:
+    name: "minimal{{ rpfx }}"
+    location: "{{ location }}"
+    resource_group: "{{ resource_group }}"
+    kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+    dns_prefix: "aks{{ rpfx }}"
+    enable_rbac: true
+    identity:
+      type: "UserAssigned"
+      user_assigned_identities: "{{ user_identity }}"
+    aad_profile:
+      managed: true
+    agent_pool_profiles:
+      - name: default
+        count: 1
+        vm_size: Standard_B2s
+        mode: System
+    api_server_access_profile:
+      authorized_ip_ranges:
+        - "192.0.2.0"
+        - "198.51.100.0"
+        - "203.0.113.0"
+      enable_private_cluster: false
+    network_profile:
+      load_balancer_sku: standard
+      outbound_type: loadBalancer
+  register: output
+
+- name: Assert idempotent
+  ansible.builtin.assert:
+    that:
+      - not output.changed
+
+- name: Use minimal parameters and user-assigned 2 identity
+  azure_rm_aks:
+    name: "minimal{{ rpfx }}"
+    location: "{{ location }}"
+    resource_group: "{{ resource_group }}"
+    kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+    dns_prefix: "aks{{ rpfx }}"
+    enable_rbac: true
+    identity:
+      type: "UserAssigned"
+      user_assigned_identities: "{{ user_identity_2 }}"
+    aad_profile:
+      managed: true
+    agent_pool_profiles:
+      - name: default
+        count: 1
+        vm_size: Standard_B2s
+        mode: System
+    api_server_access_profile:
+      authorized_ip_ranges:
+        - "192.0.2.0"
+        - "198.51.100.0"
+        - "203.0.113.0"
+      enable_private_cluster: false
+    network_profile:
+      load_balancer_sku: standard
+      outbound_type: loadBalancer
+  register: output
+
+- name: Assert the AKS instance is well created
+  ansible.builtin.assert:
+    that:
+      - output.changed
+      - output.provisioning_state == 'Succeeded'
+
+- name: Get AKS fact
+  azure_rm_aks_info:
+    name: "minimal{{ rpfx }}"
+    resource_group: "{{ resource_group }}"
+  register: fact
+
+- name: Assert fact returns the created one
+  ansible.builtin.assert:
+    that:
+      - "fact.aks | length == 1"
+      - fact.aks[0].id == output.id
+      - fact.aks[0].aad_profile.managed == true
+      - user_identity_2 in fact.aks[0].identity.user_assigned_identities
+
 - name: Update api_server_access_profile config
   azure_rm_aks:
     name: "minimal{{ rpfx }}"
-    location: eastus
+    location: "{{ location }}"
     resource_group: "{{ resource_group }}"
     kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
     dns_prefix: "aks{{ rpfx }}"


### PR DESCRIPTION
##### SUMMARY
Adds the ability to assign User Assigned Identity to the Azure Kubernetes Service.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_aks

##### ADDITIONAL INFORMATION
Currently the aks module only supports a service_principal or System Assigned identity.  This adds the ability to assign a User Assigned Identity to the cluster.

Integration tests have been updated to validate this feature.