### PR TITLE
Add vmskus module - list available skus

### DIFF
--- a/plugins/modules/azure_rm_vmsku_info.py
+++ b/plugins/modules/azure_rm_vmsku_info.py
@@ -1,0 +1,311 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2024
+# Nir Argaman <nargaman@redhat.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: azure_rm_vmsku_info
+
+version_added: "2.4.0"
+
+short_description: Get compute-related SKUs list
+
+description:
+    - Get details for compute-related resource SKUs.
+
+options:
+    location:
+        description:
+            - A region supported by current subscription.
+        type: str
+    resource_type:
+        description:
+            - Resource types e.g. "availabilitySets", "snapshots", "disks", etc.
+        type: str
+    size:
+        description:
+            - Size name, partial name is accepted.
+        type: str
+    zone:
+        description:
+            - Show skus supporting availability zones.
+        type: bool
+        default: False
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Nir Argaman (@nirarg)
+
+'''
+
+EXAMPLES = '''
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: rg_info
+
+- name: List available VM SKUs
+  azure.azcollection.azure_rm_vmsku_info:
+    location: "{{ rg_info.resourcegroups.0.location }}"
+    resource_type: "virtualMachines"
+    size: "standard_B1"
+    zone: true
+  register: available_skus_result
+'''
+
+RETURN = '''
+available_skus:
+    description:
+        - List of compute-related resource SKUs.
+    returned: always
+    type: complex
+    contains:
+        resource_type:
+            description:
+                - The type of resource the SKU applies to.
+            returned: always
+            type: str
+            sample: "virtual_machine"
+        name:
+            description:
+                - The name of SKU.
+            returned: always
+            type: str
+            sample: "Standard_B1s"
+        tier:
+            description:
+                - Specifies the tier of virtual machines in a scale set.
+            returned: always
+            type: str
+            sample: "Standard"
+        size:
+            description:
+            - The Size of the SKU.
+            returned: always
+            type: str
+            sample: "B1s"
+        family:
+            description:
+            - The Family of this particular SKU.
+            returned: always
+            type: str
+            sample: "standardBSFamily"
+        locations:
+            description:
+            - The set of locations that the SKU is available.
+            returned: always
+            type: list
+            sample: ["eastus"]
+        location_info:
+            description:
+                - A list of locations and availability zones in those locations where the SKU is available.
+            returned: always
+            type: complex
+            contains:
+                location:
+                    description:
+                        - Location of the SKU.
+                    type: str
+                    returned: always
+                    sample: "eastus"
+                zones:
+                    description:
+                        - List of availability zones where the SKU is supported.
+                    type: list
+                    returned: always
+                    sample: ["1", "2", "3"]
+                zone_details:
+                    description:
+                        - Details of capabilities available to a SKU in specific zones.
+                    returned: always
+                    type: complex
+                    contains:
+                        capabilities:
+                            description:
+                                - A list of capabilities that are available for the SKU in the specified list of zones.
+                            type: complex
+                            returned: always
+                            contains:
+                                name:
+                                    description:
+                                        - An invariant to describe the feature.
+                                    type: str
+                                    returned: always
+                                    sample: "ultrassdavailable"
+                                value:
+                                    description:
+                                        - An invariant if the feature is measured by quantity.
+                                    type: str
+                                    returned: always
+                                    sample: "True"
+        capabilities:
+            description:
+                - A name value pair to describe the capability.
+            returned: always
+            type: complex
+            contains:
+                name:
+                    description:
+                        - An invariant to describe the feature.
+                    type: str
+                    returned: always
+                    sample: "ultrassdavailable"
+                value:
+                    description:
+                        - An invariant if the feature is measured by quantity.
+                    type: str
+                    returned: always
+                    sample: "True"
+        restrictions:
+            description:
+                - The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.
+            returned: always
+            type: complex
+            contains:
+                type:
+                    description:
+                        - The type of restrictions.
+                    type: str
+                    returned: always
+                    sample: "location"
+                values:
+                    description:
+                        - The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.
+                    type: str
+                    returned: always
+                    sample: ["eastus"]
+                restriction_info:
+                    description:
+                        - The information about the restriction where the SKU cannot be used.
+                    returned: always
+                    type: complex
+                    contains:
+                        locations:
+                            description:
+                                - Locations where the SKU is restricted.
+                            type: list
+                            sample: ["location"]
+                        zones:
+                            description:
+                                - List of availability zones where the SKU is restricted.
+                            type: list
+                            sample: ["1", "2"]
+                reason_code:
+                    description:
+                        - The reason for restriction.
+                    type: str
+                    sample: "QuotaId"
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.mgmt.compute import ComputeManagementClient
+    from azure.core.exceptions import HttpResponseError
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+
+class AzureRMVmskuInfo(AzureRMModuleBase):
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            location=dict(type='str'),
+            resource_type=dict(type='str'),
+            size=dict(type='str'),
+            zone=dict(type='bool', default=False)
+        )
+
+        self.results = dict(
+            available_skus=[],
+            count=0
+        )
+        self.location = None
+        self.resource_type = None
+        self.size = None
+        self.zone = False
+
+        super(AzureRMVmskuInfo, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                               supports_check_mode=True,
+                                               supports_tags=False)
+
+    def list_skus(self):
+        try:
+            compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
+                                                      base_url=self._cloud_environment.endpoints.resource_manager,
+                                                      api_version='2021-07-01')
+            skus_result = compute_client.resource_skus.list()
+            available_skus = []
+            for sku_info in skus_result:
+                if self.location and not _match_location(self.location, sku_info.locations):
+                    continue
+                if not _is_sku_available(sku_info, self.zone):
+                    continue
+                if self.resource_type and not sku_info.resource_type.lower() == self.resource_type.lower():
+                    continue
+                if self.size and not (sku_info.resource_type == 'virtualMachines' and self.size.lower() in sku_info.name.lower()):
+                    continue
+                if self.zone and not (sku_info.location_info and sku_info.location_info[0].zones):
+                    continue
+                available_skus.append(sku_info.as_dict())
+            return available_skus
+        except HttpResponseError as e:
+            # Handle exceptions
+            raise e
+
+    def exec_module(self, **kwargs):
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        available_skus = self.list_skus()
+        self.results['available_skus'] = available_skus
+        self.results['count'] = len(available_skus)
+        return self.results
+
+
+def _match_location(loc, locations):
+    return next((x for x in locations if x.lower() == loc.lower()), None)
+
+
+def _is_sku_available(sku_info, zone):
+    """
+    The SKU is unavailable in the following cases:
+    1. regional restriction and the region is restricted
+    2. parameter "zone" is input which indicates only showing skus with availability zones.
+       Meanwhile, zonal restriction and all zones are restricted
+    """
+    is_available = True
+    is_restrict_zone = False
+    is_restrict_location = False
+    if not sku_info.restrictions:
+        return is_available
+    for restriction in sku_info.restrictions:
+        if restriction.reason_code == 'NotAvailableForSubscription':
+            if restriction.type == 'Zone' and not (
+                    set(sku_info.location_info[0].zones or []) - set(restriction.restriction_info.zones or [])):
+                is_restrict_zone = True
+            if restriction.type == 'Location' and (
+                    sku_info.location_info[0].location in (restriction.restriction_info.locations or [])):
+                is_restrict_location = True
+            if is_restrict_location or (is_restrict_zone and zone):
+                is_available = False
+                break
+    return is_available
+
+
+def main():
+    AzureRMVmskuInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ azure-mgmt-authorization==2.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-batch==16.2.0
 azure-mgmt-cdn==11.0.0
-azure-mgmt-compute==26.1.0
+azure-mgmt-compute==30.6.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-core==1.4.0
 azure-mgmt-containerregistry==9.1.0

--- a/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
@@ -13,6 +13,10 @@ all:
       network: 10.42.2.0/24
       subnet: 10.42.2.0/28
 
+    azure_test_skus:
+      network: 10.42.3.0/24
+      subnet: 10.42.3.0/28
+
     azure_test_minimal:
       network: 10.42.3.0/24
       subnet: 10.42.3.0/28

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_skus.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_skus.yml
@@ -1,0 +1,136 @@
+- name: Set variables
+  ansible.builtin.include_tasks: setup.yml
+
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: rg_info
+
+- name: List available VM SKUs
+  azure.azcollection.azure_rm_vmsku_info:
+    location: "{{ rg_info.resourcegroups.0.location }}"
+    resource_type: "virtualMachines"
+    size: "standard_B1"
+    zone: true
+  register: available_skus_result
+
+- name: Create desired capabilities list
+  ansible.builtin.set_fact:
+    desired_capabilities: [
+      {
+        "name": "MaxResourceVolumeMB",
+        "value": "4096"
+      },
+      {
+        "name": "MemoryGB",
+        "value": "2"
+      }]
+
+- name: Filter available SKUs with desired capabilities
+  ansible.builtin.set_fact:
+    skus_result: |
+      {% set skus_result = [] %}
+      {% for item in available_skus_result.available_skus -%}
+      {% set ns = namespace(use_sku=True) %}
+      {% for capability in item.capabilities -%}
+      {% for desired in desired_capabilities -%}
+      {% if capability.name == desired.name and capability.value != desired.value -%}
+      {% set ns.use_sku = False %}
+      {%- endif %}
+      {%- endfor %}
+      {%- endfor %}
+      {% if ns.use_sku -%}
+      {{ skus_result.append(item.name) }}
+      {%- endif %}
+      {%- endfor %}
+      {{ skus_result }}
+  failed_when: skus_result[0] is not defined
+
+- name: Create VM with first sku in avilable skus list
+  azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name }}"
+    admin_username: "testuser"
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/testuser/.ssh/authorized_keys
+        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+    vm_size: "{{ skus_result[0] }}"
+    virtual_network: "{{ network_name }}"
+    image:
+      offer: 0001-com-ubuntu-server-focal
+      publisher: Canonical
+      sku: 20_04-lts
+      version: latest
+  register: vm_output
+
+- name: Query auto created security group before deleting
+  azure_rm_securitygroup_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name }}01"
+  register: nsg_result
+
+- name: Assert that security group were exist before deleting
+  ansible.builtin.assert:
+    that:
+      - nsg_result.securitygroups | length == 1
+      - nsg_result.securitygroups[0].network_interfaces | length == 1
+
+- name: Delete VM
+  azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name }}"
+    remove_on_absent: all_autocreated
+    state: absent
+
+- name: Query auto created NIC
+  azure_rm_networkinterface_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name }}01"
+  register: nic_result
+
+- name: Query auto created security group
+  azure_rm_securitygroup_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name }}01"
+  register: nsg_result
+
+- name: Query auto created public IP
+  azure_rm_publicipaddress_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name }}01"
+  register: pip_result
+
+- name: Assert that autocreated resources were deleted
+  ansible.builtin.assert:
+    that:
+      # what about the default storage group?
+      - nic_result.networkinterfaces | length == 0
+      - nsg_result.securitygroups | length == 0
+      - pip_result.publicipaddresses | length == 0
+
+- name: Destroy subnet
+  azure_rm_subnet:
+    resource_group: "{{ resource_group }}"
+    virtual_network: "{{ network_name }}"
+    name: "{{ subnet_name }}"
+    state: absent
+
+- name: Destroy virtual network
+  azure_rm_virtualnetwork:
+    resource_group: "{{ resource_group }}"
+    name: "{{ network_name }}"
+    state: absent
+
+- name: Destroy availability set
+  azure_rm_availabilityset:
+    resource_group: "{{ resource_group }}"
+    name: "{{ availability_set }}"
+    state: absent
+
+- name: Destroy storage account
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account }}"
+    force_delete_nonempty: true
+    state: absent


### PR DESCRIPTION
##### SUMMARY
Support for VM shape fact collection from available SKUs would allow for playbook idempotence as automators build out support for their automations based on what SKUs are available within a cloud region as opposed to being configured within a playbook.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
New module added:
azure_rm_vmskus.py

##### ADDITIONAL INFORMATION
In order to add this module, I used the following references:
* [CLI reference code](https://github.com/Azure/azure-cli/blob/4d5adff0a0ce7492282b952520ecc596e749a399/src/azure-cli/azure/cli/command_modules/vm/custom.py#L1345) 
* [Azure Python sdk docs](https://learn.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.v20[…]1_07_01.operations.resourceskusoperations?view=azure-python)

You can run ansible with this module, using the following command:
```
ansible localhost -m azure.azcollection.azure_rm_computeskus -a '{"location": "WestUS3", "resource_type": "virtualMachines", "size": "Standard_B1", "zone": "True"}
```
