### PR TITLE
Expand Inventory filter integration tests

### DIFF
--- a/tests/integration/targets/inventory_azure/playbooks/setup.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/setup.yml
@@ -47,3 +47,24 @@
           sku: 20_04-lts
           version: latest
       register: vm_output
+
+    - name: Create minimal VM 2 with defaults
+      azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vm_name_2 }}"
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        vm_size: Standard_B1ms
+        virtual_network: "{{ network_name }}"
+        image:
+          offer: 0001-com-ubuntu-server-focal
+          publisher: Canonical
+          sku: 20_04-lts
+          version: latest
+        tags:
+          Deployment-Method: Ansible
+          Automation-Method: Ansible
+      register: vm_output_2

--- a/tests/integration/targets/inventory_azure/playbooks/teardown.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/teardown.yml
@@ -15,6 +15,13 @@
         remove_on_absent: all_autocreated
         state: absent
 
+    - name: Delete VM 2
+      azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vm_name_2 }}"
+        remove_on_absent: all_autocreated
+        state: absent
+
     - name: Destroy subnet
       azure_rm_subnet:
         resource_group: "{{ resource_group }}"

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_filter.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_filter.yml
@@ -1,0 +1,21 @@
+---
+- name: Config hosts
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Set facts
+      ansible.builtin.include_vars: vars.yml
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory
+
+    - name: Test vm_name_2 in Inventory
+      ansible.builtin.assert:
+        that:
+          - vm_name_2 in hostvars
+
+    - name: Test vm_name not in Inventory
+      ansible.builtin.assert:
+        that:
+          - vm_name not in hostvars

--- a/tests/integration/targets/inventory_azure/playbooks/vars.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/vars.yml
@@ -5,6 +5,7 @@ uid_short: "{{ (resource_group ~ inventory_hostname) | hash('md5') | truncate(10
 storage_account: "{{ 'stor' ~ uid }}"
 availability_set: "{{ 'avbs' ~ uid_short }}"
 vm_name: "{{ 'vm' ~ uid_short }}"
+vm_name_2: "{{ 'vm2' ~ uid_short }}"
 network_name: "{{ 'vnet' ~ uid_short }}"
 subnet_name: "{{ 'snet' ~ uid_short }}"
 security_group: "{{ 'sg' ~ uid_short }}"

--- a/tests/integration/targets/inventory_azure/runme.sh
+++ b/tests/integration/targets/inventory_azure/runme.sh
@@ -19,6 +19,11 @@ ansible-playbook playbooks/empty_inventory_config.yml "$@"
 ansible-playbook playbooks/create_inventory_config.yml "$@"  --extra-vars "template=basic2.yml"
 ansible-playbook playbooks/test_inventory.yml "$@"
 
+# using host filters
+ansible-playbook playbooks/empty_inventory_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml "$@"  --extra-vars "template=filter.yml"
+ansible-playbook playbooks/test_inventory_filter.yml "$@"
+
 
 # teardown
 ansible-playbook playbooks/teardown.yml "$@"

--- a/tests/integration/targets/inventory_azure/templates/filter.yml
+++ b/tests/integration/targets/inventory_azure/templates/filter.yml
@@ -1,0 +1,14 @@
+---
+plugin: azure.azcollection.azure_rm
+conditional_groups:
+  azure: true
+exclude_host_filters:
+  - location not in ['eastus', 'northcentralus']
+  - powerstate != 'running'
+  - not (tags['Deployment-Method'] | default('Exclude') == 'Ansible' and tags['Automation-Method'] | default('Exclude') == 'Ansible')
+  # Customer tried to use the following filter but dashes in variable names is not allowed.
+  # Workaround was to use the dictionary access method above with defaults.
+  #- not (tags.Deployment-Method == 'Ansible' and tags.Automation-Method == 'Ansible')
+# fail_on_template_errors should be enabled for debugging and possibly all times.
+fail_on_template_errors: True
+plain_host_names: true


### PR DESCRIPTION
Add inventory integration tests that exercise the exclude filter.

##### SUMMARY
Missing integration tests that cover the host filtering feature of the inventory plugin

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION
We had a customer report issues with the inventory plugin and while no bug was found we also didn't have a use case to validate the filtering was working as expected in the plugin.

This PR adds an additional virtual machine and tags that are not present in the first virtual machine.  These filters reproduce what the customer was filtering with and the issues we ran into.