### PR TITLE
Fix: Authentication Issue: azure.azcollection.azure_rm_storageblob Fails with Disabled Shared Keys

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -706,8 +706,8 @@ class AzureRMModuleBase(object):
                   and self.azure_auth.credentials.get('client_id')
                   and self.azure_auth.credentials.get('secret')):
                 credential = client_secret.ClientSecretCredential(tenant_id=self.azure_auth.credentials.get('tenant'),
-                                                    client_id=self.azure_auth.credentials.get('client_id'),
-                                                    client_secret=self.azure_auth.credentials.get('secret'))
+                                                                  client_id=self.azure_auth.credentials.get('client_id'),
+                                                                  client_secret=self.azure_auth.credentials.get('secret'))
             else:
                 account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name, account_name=storage_account_name)
                 credential = account_keys.keys[0].value

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -703,7 +703,7 @@ class AzureRMModuleBase(object):
             if auth_mode == 'login' and self.azure_auth.credentials.get('credential'):
                 credential = self.azure_auth.credentials['credential']
             elif (auth_mode == 'login' and self.azure_auth.credentials.get('tenant')
-                  and self.azure_auth.credentials.get('client_id') 
+                  and self.azure_auth.credentials.get('client_id')
                   and self.azure_auth.credentials.get('secret')):
                 credential = client_secret.ClientSecretCredential(tenant_id=self.azure_auth.credentials.get('tenant'),
                                                     client_id=self.azure_auth.credentials.get('client_id'),

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -702,6 +702,12 @@ class AzureRMModuleBase(object):
             account = self.storage_client.storage_accounts.get_properties(resource_group_name=resource_group_name, account_name=storage_account_name)
             if auth_mode == 'login' and self.azure_auth.credentials.get('credential'):
                 credential = self.azure_auth.credentials['credential']
+            elif (auth_mode == 'login' and self.azure_auth.credentials.get('tenant')
+                  and self.azure_auth.credentials.get('client_id') 
+                  and self.azure_auth.credentials.get('secret')):
+                credential = client_secret.ClientSecretCredential(tenant_id=self.azure_auth.credentials.get('tenant'),
+                                                    client_id=self.azure_auth.credentials.get('client_id'),
+                                                    client_secret=self.azure_auth.credentials.get('secret'))
             else:
                 account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name, account_name=storage_account_name)
                 credential = account_keys.keys[0].value


### PR DESCRIPTION


##### SUMMARY
PR in order to fix the feature of accessing storage blobs without SAS/key.
It is related with: #1255 

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
- azure.azcollection.azure_rm_storageblob
- plugins/module_utils/azure_rm_common.py

##### ADDITIONAL INFORMATION
Now the access without SAS is supported by environment variables and cli

