### PR TITLE
galleryimageversion: Fix occasional crash in create_update_resource

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -817,7 +817,10 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
 
         while response['properties']['provisioningState'] == 'Creating':
             time.sleep(60)
+            old_response = response
             response = self.get_resource()
+            if response is False:
+                response = old_response
 
         return response
 


### PR DESCRIPTION
##### SUMMARY

self.get_resource() returns a response object if the request didn't raise an exception, otherwise it returns False. This causes an occasional crash with "TypeError: 'bool' object is not subscriptable" in the polling loop which expects the response to always be subscriptable.

While polling, if a request fails, just keep the old request and loop again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

azure_rm_galleryimageversion