### PR TITLE
Add identity support to vmss module

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinescaleset_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset_info.py
@@ -126,6 +126,30 @@ vmss:
                     returned: always
                     type: str
                     sample: Standard_LRS
+        identity:
+            description:
+                - Identity for the Server.
+            type: complex
+            returned: when available
+            contains:
+                type:
+                    description:
+                        - Type of the managed identity
+                    returned: always
+                    sample: UserAssigned
+                    type: str
+                user_assigned_identities:
+                    description:
+                        - User Assigned Managed Identities and its options
+                    returned: always
+                    type: complex
+                    contains:
+                        id:
+                            description:
+                                - Dict of the user assigned identities IDs associated to the Resource
+                            returned: always
+                            type: dict
+                            elements: dict
         image:
             description:
                 - Image specification.
@@ -388,6 +412,7 @@ class AzureRMVirtualMachineScaleSetInfo(AzureRMModuleBase):
                     'virtual_network_name': virtual_network_name,
                     'subnet_name': subnet_name,
                     'load_balancer': load_balancer_name,
+                    'identity': vmss.get('identity', None),
                     'tags': vmss.get('tags')
                 }
 

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1,3 +1,31 @@
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+- name: Set location based on resource group
+  ansible.builtin.set_fact:
+    location: "{{ __rg_info.resourcegroups.0.location }}"
+
+- name: Create User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    body:
+      location: "{{ location }}"
+    state: present
+  loop:
+    - "ansible-test-vmss-identity"
+    - "ansible-test-vmss-identity-2"
+
+- name: Set identities IDs to test. Identities ansible-test-vmss-identity and ansible-test-vmss-identity-2 have to be created previously
+  ansible.builtin.set_fact:
+    user_identity_1: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-vmss-identity"
+    user_identity_2: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-vmss-identity-2"
+
 - name: Prepare random number
   ansible.builtin.set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
@@ -139,6 +167,11 @@
         disk_size_gb: 64
         caching: ReadWrite
         managed_disk_type: Standard_LRS
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
   register: results
 
 - name: Assert that VMSS can be created
@@ -173,6 +206,11 @@
         disk_size_gb: 64
         caching: ReadWrite
         managed_disk_type: Standard_LRS
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
   register: results
 
 - name: Assert that VMSS can be created
@@ -189,6 +227,7 @@
   ansible.builtin.assert:
     that:
       - output_scaleset.vmss[0].orchestration_mode == "Flexible"
+      - user_identity_1 in output_scaleset.vmss[0].identity.user_assigned_identities
 
 - name: Delete VMSS
   azure_rm_virtualmachinescaleset:
@@ -227,7 +266,16 @@
         disk_size_gb: 64
         caching: ReadWrite
         managed_disk_type: Standard_LRS
+    identity:
+      type: SystemAssigned, UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
   register: results
+
+- name: Debug
+  ansible.builtin.debug:
+    var: results
 
 - name: Assert that VMSS was created using Spot Instance default values
   ansible.builtin.assert:
@@ -235,6 +283,7 @@
       - results.ansible_facts.azure_vmss.virtual_machine_profile.priority == 'Spot'
       - results.ansible_facts.azure_vmss.virtual_machine_profile.eviction_policy == 'Deallocate'
       - results.ansible_facts.azure_vmss.virtual_machine_profile.billing_profile.max_price == -1.0
+      - user_identity_1 in results.ansible_facts.azure_vmss.identity.user_assigned_identities
 
 - name: Delete VMSS
   azure_rm_virtualmachinescaleset:
@@ -923,3 +972,15 @@
       name: invalid-image
   register: fail_missing_custom_image_dict
   failed_when: fail_missing_custom_image_dict.msg != "Error could not find image with name invalid-image"
+
+- name: Destroy User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    state: absent
+  loop:
+    - "ansible-test-vmss-identity"
+    - "ansible-test-vmss-identity-2"


### PR DESCRIPTION
##### SUMMARY
Added ability to specify UserAssigned, SystemAssigned or 'SystemAssigned, UserAsssigned' to the virtualmachinescaleset module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachinescaleset.py
plugins/modules/azure_rm_virtualmachinescaleset_info.py
tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml

##### ADDITIONAL INFORMATION
sanity and integration have run.