### PR TITLE
Update azure_rm_cdnprofile to include the Standard and Premium Frontdoor options and bump the azure-mgmt-cdn version to latest 13.1.0

### DIFF
--- a/plugins/modules/azure_rm_afdendpoint.py
+++ b/plugins/modules/azure_rm_afdendpoint.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Python SDK Reference: https://learn.microsoft.com/en-us/python/api/azure-mgmt-cdn/azure.mgmt.cdn.operations.afdendpointsoperations?view=azure-python
+#
+# TODO: Name check the URL
+# 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: azure_rm_afdendpoint
+
+version_added: ""
+
+short_description: Manage an Azure Front Door Endpoint to be used with Standard or Premium Frontdoor
+
+description:
+    - Create, update and delete an Azure Front Door (AFD) Endpoint to be used by a Front Door Service Profile created using azure_rm_cdnprofile.  This differs from the Front Door classic service and only is intended to be used by the Standard or Premium service offering.
+
+options:
+    auto_generated_domain_name_label_scope:
+        description:
+            - Indicates the endpoint name reuse scope. Known values are: "TenantReuse", "SubscriptionReuse", "ResourceGroupReuse", and "NoReuse". Cannot be used to update an existing Endpoint at this time.
+        default: TenantReuse
+        type: str
+    enabled_state:
+        description:
+            - Whether to enable use of this rule.
+        default: Enabled
+        type: str
+    location:
+        description:
+            - Valid Azure location. Defaults to location of the resource group. Cannot be used to update an existing Endpoint at this time.
+        type: str
+    name:
+        description:
+            - Name of the AFD Endpoint.
+        required: true
+        type: str
+    profile_name:
+        description:
+            - Name of the AFD Profile where the Endpoint will be attached to.
+        required: true
+        type: str
+    resource_group:
+        description:
+            - Name of a resource group where the Azure Front Door Endpoint exists or will be created.
+        required: true
+        type: str
+    state:
+        description:
+            - Assert the state of the AFD Endpoint. Use C(present) to create or update an AFD Endpoint and C(absent) to delete it.
+        default: present
+        type: str
+        choices:
+            - absent
+            - present
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+    - azure.azcollection.azure_tags
+
+author:
+    - Jarret Tooley (@jartoo)
+'''
+
+EXAMPLES = '''
+- name: Create an AFD Endpoint
+  azure_rm_afdendpoint:
+    name: myEndpoint
+    profile_name: myProfile
+    resource_group: myResourceGroup
+    state: present
+    tags:
+      testing: testing
+
+- name: Delete the AFD Endpoint
+  azure_rm_afdendpoint:
+    name: myEndPoint
+    profile_name: myProfile
+    resource_group: myResourceGroup
+    state: absent
+'''
+RETURN = '''
+id:
+    description:
+        - ID of the AFD Endpoint.
+    returned: always
+    type: str
+    sample: "id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myResourceGroup/providers/Microsoft.Cdn/profiles/myProfile/endpoints/myEndpoint"
+host_name:
+    description:
+        - Host name of the AFD Endpoint.
+    returned: always
+    type: str
+    sample: "myendpoint.azurefd.net"
+
+'''
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.mgmt.cdn.models import AFDEndpoint, AFDEndpointUpdateParameters
+    from azure.mgmt.cdn import CdnManagementClient
+except ImportError as ec:
+    # This is handled in azure_rm_common
+    pass
+
+
+def endpoint_to_dict(endpoint):
+    return dict(
+        deployment_status = endpoint.deployment_status,
+        enabled_state = endpoint.enabled_state,
+        host_name = endpoint.host_name,
+        id = endpoint.id,
+        location=endpoint.location,
+        name=endpoint.name,
+        provisioning_state=endpoint.provisioning_state,
+        tags=endpoint.tags,
+        type=endpoint.type
+    )
+
+
+class AzureRMEndpoint(AzureRMModuleBase):
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            auto_generated_domain_name_label_scope=dict(
+                type='str',
+                default = 'TenantReuse',
+                choices=["TenantReuse", "SubscriptionReuse", "ResourceGroupReuse", "NoReuse"]
+            ),
+            enabled_state=dict(
+                type='str',
+                default = 'Enabled',
+                choices=['Enabled', 'Disabled']
+            ),
+            location=dict(
+                type='str'
+            ),
+            name=dict(
+                type='str',
+                required=True
+            ),
+            profile_name=dict(
+                type='str',
+                required=True
+            ),
+            resource_group=dict(
+                type='str',
+                required=True
+            ),
+            state=dict(
+                type='str',
+                default='present',
+                choices=['present', 'absent']
+            )
+        )
+        
+        self.auto_generated_domain_name_label_scope = None
+        self.enabled_state = None
+        self.location = None
+        self.tags = None
+
+        self.name = None
+        self.profile_name = None
+        self.resource_group = None
+        self.state = None
+
+        self.endpoint_client = None
+
+        self.results = dict(changed=False)
+
+        super(AzureRMEndpoint, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                supports_check_mode=True,
+                                                supports_tags=True)
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            setattr(self, key, kwargs[key])
+
+        self.endpoint_client = self.get_endpoint_client()
+
+        to_be_updated = False
+
+        if not self.location:
+            resource_group = self.get_resource_group(self.resource_group)
+            self.location = resource_group.location
+
+        response = self.get_endpoint()
+
+        if self.state == 'present':
+
+            if not response:
+                self.log("Need to create the AFD Endpoint")
+
+                if not self.check_mode:
+                    new_response = self.create_endpoint()
+                    self.results['id'] = new_response['id']
+                    self.results['host_name'] = new_response['host_name']
+                    self.log("AFD Endpoint creation done")
+
+                self.results['changed'] = True
+                return self.results
+            
+            else:
+                self.log('Results : {0}'.format(response))
+                self.results['id'] = response['id']                
+                self.results['host_name'] = response['host_name']
+                
+                update_tags, self.tags = self.update_tags(response['tags'])
+
+                if update_tags:
+                    to_be_updated = True
+
+                if response['provisioning_state'] == "Succeeded":
+                    if response['enabled_state'] != self.enabled_state:
+                        to_be_updated = True
+                    
+                    if self.location.lower() != response['location'].lower() and self.location:
+                        # Location is not currently implemented in begin_update()
+                        self.log("AFD Endpoint locations changes are not idempotent, please delete and recreate the Endpoint.")
+
+                    if to_be_updated:
+                        self.log("Need to update the AFD Endpoint")
+                        self.results['changed'] = True
+
+                        if not self.check_mode:
+                            result = self.update_endpoint()
+                            self.results['host_name'] = result['host_name']
+                            self.log("AFD Endpoint update done")    
+
+        elif self.state == 'absent':
+            if not response:
+                self.log("AFD Endpoint {0} does not exist.".format(self.name))
+                self.results['id'] = ""
+            else:
+                self.log("Need to delete the AFD Endpoint")
+                self.results['changed'] = True
+                self.results['id'] = response['id']
+
+                if not self.check_mode:
+                    self.delete_endpoint()
+                    self.log("Azure AFD Endpoint deleted")
+
+        return self.results
+
+    def create_endpoint(self):
+        '''
+        Creates an AFD Endpoint.
+
+        :return: deserialized AFD Endpoint instance state dictionary
+        '''
+        self.log("Creating the AFD Endpoint instance {0}".format(self.name))
+
+        parameters = AFDEndpoint(
+            auto_generated_domain_name_label_scope=self.auto_generated_domain_name_label_scope,
+            enabled_state=self.enabled_state,
+            location=self.location,
+            tags=self.tags
+        )
+
+        try:
+            poller = self.endpoint_client.afd_endpoints.begin_create(
+                endpoint_name=self.name,
+                profile_name=self.profile_name,
+                resource_group_name=self.resource_group,
+                endpoint=parameters)
+            response = self.get_poller_result(poller)
+            return endpoint_to_dict(response)
+        except Exception as exc:
+            self.log('Error attempting to create AFD Endpoint instance.')
+            self.fail("Error Creating AFD Endpoint instance: {0}".format(str(exc)))
+
+    def update_endpoint(self):
+        '''
+        Updates an AFD Endpoint.
+
+        :return: deserialized AFD Endpoint instance state dictionary
+        '''
+        self.log("Updating the AFD Endpoint instance {0}".format(self.name))
+
+        parameters = AFDEndpointUpdateParameters(
+            tags=self.tags,
+            enabled_state=self.enabled_state
+        )
+        
+        try:
+            poller = self.endpoint_client.afd_endpoints.begin_update(
+                endpoint_name=self.name,
+                profile_name=self.profile_name,
+                resource_group_name=self.resource_group,
+                endpoint_update_properties=parameters)
+            response = self.get_poller_result(poller)
+            return endpoint_to_dict(response)
+        except Exception as exc:
+            self.log('Error attempting to update AFD Endpoint instance.')
+            self.fail("Error updating AFD Endpoint instance: {0}".format(str(exc)))
+
+    def delete_endpoint(self):
+        '''
+        Deletes the specified AFD Endpoint in the specified subscription and resource group.
+
+        :return: True
+        '''
+        self.log("Deleting the AFD Endpoint {0}".format(self.name))
+        try:
+            poller = self.endpoint_client.afd_endpoints.begin_delete(
+                resource_group_name=self.resource_group, profile_name=self.profile_name, endpoint_name=self.name)
+            self.get_poller_result(poller)
+            return True
+        except Exception as exc:
+            self.log('Error attempting to delete the AFD Endpoint.')
+            self.fail("Error deleting the AFD Endpoint: {0}".format(str(exc)))
+            return False
+
+    def get_endpoint(self):
+        '''
+        Gets the properties of the specified AFD Endpoint.
+
+        :return: deserialized AFD Endpoint state dictionary
+        '''
+        self.log(
+            "Checking if the AFD Endpoint {0} is present".format(self.name))
+        try:
+            response = self.endpoint_client.afd_endpoints.get(resource_group_name=self.resource_group, profile_name=self.profile_name, endpoint_name=self.name)
+            self.log("Response : {0}".format(response))
+            self.log("AFD Endpoint : {0} found".format(response.name))
+            return endpoint_to_dict(response)
+        except Exception as err:
+            self.log('Did not find the AFD Endpoint.')
+            return False
+
+    def get_endpoint_client(self):
+        if not self.endpoint_client:
+            self.endpoint_client = self.get_mgmt_svc_client(CdnManagementClient,
+                                                       base_url=self._cloud_environment.endpoints.resource_manager,
+                                                       api_version='2023-05-01')
+        return self.endpoint_client
+
+
+def main():
+    """Main execution"""
+    AzureRMEndpoint()
+    
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_afdendpoint_info.py
+++ b/plugins/modules/azure_rm_afdendpoint_info.py
@@ -1,0 +1,272 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Python SDK Reference: https://learn.microsoft.com/en-us/python/api/azure-mgmt-cdn/azure.mgmt.cdn.operations.afdendpointsoperations?view=azure-python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_afdendpoint_info
+
+version_added: ""
+
+short_description: Get Azure Front Door Endpoint facts to be used with Standard or Premium Frontdoor Service
+
+description:
+    - Get facts for a specific Azure Front Door (AFD) Endpoint or all AFD Endpoints.  This differs from the Front Door classic service and only is intended to be used by the Standard or Premium service offering.
+
+options:
+    resource_group:
+        description:
+            - Name of the resource group where this AFD Profile belongs.
+        required: true
+        type: str
+    profile_name:
+        description:
+            - Name of the AFD profile.
+        required: true
+        type: str
+    name:
+        description:
+            - Limit results to a specific AFD Endpoint.
+        type: str
+    tags:
+        description:
+            - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
+        type: list
+        elements: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Jarret Tooley (@jartoo)
+'''
+
+EXAMPLES = '''
+- name: Get facts for all Endpoints in AFD Profile
+  azure_rm_afdendpoint_info:
+    resource_group: myResourceGroup
+    profile_name: myCDNProfile
+    tags:
+      - key
+      - key:value
+
+- name: Get facts of specific AFD Endpoint
+  azure_rm_afdendpoint_info:
+    resource_group: myResourceGroup
+    profile_name: myCDNProfile
+    name: myEndpoint1
+'''
+
+RETURN = '''
+afdendpoints:
+    description: List of AFD Endpoints.
+    returned: always
+    type: complex
+    contains:        
+        auto_generated_domain_name_label_scope:
+            description:
+                - Indicates the endpoint name reuse scope.
+            type: str
+            sample: TenantReuse
+        deployment_status:
+            description:
+                - Current state of the resource.
+            type: str
+            sample: NotStarted
+        enabled_state:
+            description:
+                - Whether to enable use of this rule.
+            type: str
+            sample: Enabled
+        host_name:
+            description:
+                - The host name of the AFD Endpoint structured as endpointName.DNSZone.
+            type: str
+            sample: contoso.azureedge.net
+        id:
+            description:
+                - ID of the AFD Endpoint.
+            type: str
+            sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myCDN/providers/Microsoft.Cdn/profiles/myProfile/endpoints/myEndpoint1"
+        location:
+            description:
+                - Location of the AFD Endpoint.
+            type: str
+            sample: Global
+        name:
+            description:
+                - Name of the AFD Endpoint.
+            returned: always
+            type: str
+            sample: myEndpoint
+        profile_name:
+            description:
+                - Name of the AFD Profile which holds the Endpoint.
+            returned: always
+            type: str
+            sample: myProfile
+        provisioning_state:
+            description:
+                - Provisioning status of the AFD Endpoint.
+            type: str
+            sample: Succeeded
+        resource_group:
+            description:
+                - Name of a resource group where the AFD Endpoint exists.
+            returned: always
+            type: str
+            sample: myResourceGroup
+        tags:
+            description:
+                - The tags of the AFD Endpoint.
+            type: list
+            sample: foo
+        type:
+            description:
+                - Resource type.
+            type: str
+            sample: Microsoft.Cdn/profiles/afdendpoints
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.mgmt.cdn import CdnManagementClient
+except ImportError:
+    # handled in azure_rm_common
+    pass
+
+import re
+
+AZURE_OBJECT_CLASS = 'AFDEndpoint'
+
+
+class AzureRMAFDEndpointInfo(AzureRMModuleBase):
+    """Utility class to get Azure AFD Endpoint facts"""
+
+    def __init__(self):
+
+        self.module_args = dict(
+            name=dict(type='str'),
+            resource_group=dict(
+                type='str',
+                required=True
+            ),
+            profile_name=dict(
+                type='str',
+                required=True
+            ),
+            tags=dict(
+                type='list',
+                elements='str'
+            )
+        )
+
+        self.results = dict(
+            changed=False,
+            afdendpoints=[]
+        )
+
+        self.name = None
+        self.resource_group = None
+        self.profile_name = None
+        self.tags = None
+
+        super(AzureRMAFDEndpointInfo, self).__init__(
+            supports_check_mode=True,
+            derived_arg_spec=self.module_args,
+            supports_tags=False,
+            facts_module=True
+        )
+
+    def exec_module(self, **kwargs):
+
+        for key in self.module_args:
+            setattr(self, key, kwargs[key])
+
+        self.endpoint_client = self.get_mgmt_svc_client(CdnManagementClient,
+                                                   base_url=self._cloud_environment.endpoints.resource_manager,
+                                                   api_version='2023-05-01')
+
+        if self.name:
+            self.results['afdendpoints'] = self.get_item()
+        else:
+            self.results['afdendpoints'] = self.list_by_profile()
+
+        return self.results
+
+    def get_item(self):
+        """Get a single Azure AFD Endpoint"""
+
+        self.log('Get properties for {0}'.format(self.name))
+
+        item = None
+        result = []
+
+        try:
+            item = self.endpoint_client.afd_endpoints.get(
+                self.resource_group, self.profile_name, self.name)
+        except Exception:
+            pass
+
+        if item and self.has_tags(item.tags, self.tags):
+            result = [self.serialize_afdendpoint(item)]
+
+        return result
+
+    def list_by_profile(self):
+        """Get all Azure AFD Endpoints within an AFD profile"""
+
+        self.log('List all AFD Endpoints within an AFD profile')
+
+        try:
+            response = self.endpoint_client.afd_endpoints.list_by_profile(
+                self.resource_group, self.profile_name)
+        except Exception as exc:
+            self.fail('Failed to list all items - {0}'.format(str(exc)))
+
+        results = []
+        for item in response:
+            if self.has_tags(item.tags, self.tags):
+                results.append(self.serialize_afdendpoint(item))
+
+        return results
+
+    def serialize_afdendpoint(self, afdendpoint):
+        '''
+        Convert a AFD Endpoint object to dict.
+        :param afdendpoint: AFD Endpoint object
+        :return: dict
+        '''
+        result = self.serialize_obj(afdendpoint, AZURE_OBJECT_CLASS)
+
+        new_result = {}
+        new_result['auto_generated_domain_name_label_scope'] = afdendpoint.auto_generated_domain_name_label_scope
+        new_result['deployment_status'] = afdendpoint.deployment_status
+        new_result['enabled_state'] = afdendpoint.enabled_state
+        new_result['host_name'] = afdendpoint.host_name
+        new_result['id'] = afdendpoint.id
+        new_result['location'] = afdendpoint.location
+        new_result['name'] = afdendpoint.name
+        new_result['profile_name'] = re.sub('\\/.*', '', re.sub('.*profiles\\/', '', result['id']))
+        new_result['provisioning_state'] = afdendpoint.provisioning_state
+        new_result['resource_group'] = re.sub('\\/.*', '', re.sub('.*resourcegroups\\/', '', result['id']))
+        new_result['tags'] = afdendpoint.tags
+        new_result['type'] = afdendpoint.type
+        return new_result
+
+
+def main():
+    """Main module execution code path"""
+
+    AzureRMAFDEndpointInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -42,6 +42,8 @@ options:
             - standard_akamai
             - standard_chinacdn
             - standard_microsoft
+            - standard_azurefrontdoor
+            - premium_azurefrontdoor
     state:
         description:
             - Assert the state of the CDN profile. Use C(present) to create or update a CDN profile and C(absent) to delete it.
@@ -129,7 +131,7 @@ class AzureRMCdnprofile(AzureRMModuleBase):
             ),
             sku=dict(
                 type='str',
-                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn', 'standard_microsoft']
+                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn', 'standard_microsoft', 'standard_azurefrontdoor', 'premium_azurefrontdoor']
             )
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-identity==1.14.0
 azure-mgmt-authorization==2.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-batch==16.2.0
-azure-mgmt-cdn==11.0.0
+azure-mgmt-cdn==13.1.0
 azure-mgmt-compute==30.6.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-core==1.4.0

--- a/tests/integration/targets/azure_rm_afdendpoint/aliases
+++ b/tests/integration/targets/azure_rm_afdendpoint/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+destructive
+shippable/azure/group6

--- a/tests/integration/targets/azure_rm_afdendpoint/meta/main.yml
+++ b/tests/integration/targets/azure_rm_afdendpoint/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
@@ -1,0 +1,169 @@
+- name: Prepare random name for Profile & EndPoint
+  ansible.builtin.set_fact:
+    profile: "prof-{{ resource_group | hash('md5') | truncate(4, True, '') }}{{ 100000 | random }}"
+    endpoint: "endpoint-{{ resource_group | hash('md5') | truncate(4, True, '') }}{{ 100000 | random }}"
+
+- name: Create Standard Frontdoor Profile
+  azure_rm_cdnprofile:
+    name: "{{ profile }}"
+    location: "Global"
+    resource_group: "{{ resource_group }}"
+    sku: "standard_azurefrontdoor"
+    state: "present"
+
+- name: Create EndPoint
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    enabled_state: "Enabled"
+    auto_generated_domain_name_label_scope: "TenantReuse"
+    tags:
+      test: "tag value"
+    state: "present"
+  register: output
+
+- name: Assert the resource was created and returns expected variables
+  ansible.builtin.assert:
+    that:
+      - output.changed
+      - output.id
+      - output.host_name
+
+- name: Update EndPoint (idempotent test)
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    enabled_state: "Enabled"
+    auto_generated_domain_name_label_scope: "TenantReuse"
+    tags:
+      test: "tag value"
+    state: "present"
+  register: output
+
+- name: Assert the resource has not changed
+  ansible.builtin.assert:
+    that:
+      - not output.changed
+
+- name: Load Endpoint info
+  azure_rm_afdendpoint_info:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+  register: output
+
+- name: Assert the resource has the proper values set
+  ansible.builtin.assert:
+    that:
+      - output.afdendpoints | length == 1
+      - output.afdendpoints[0].auto_generated_domain_name_label_scope == 'TenantReuse'
+      - output.afdendpoints[0].enabled_state == 'Enabled'
+      - output.afdendpoints[0].host_name
+      - output.afdendpoints[0].id
+      - output.afdendpoints[0].profile_name == profile
+      - output.afdendpoints[0].tags.test == 'tag value'
+      - not output.changed
+
+- name: Update EndPoint (with different values)
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    enabled_state: "Disabled"
+    tags:
+      test: "new tag value"
+      newtag: "another value"
+    state: "present"
+  register: output
+
+- name: Assert the resource has changed
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Update EndPoint (idempotent test)
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    enabled_state: "Disabled"
+    tags:
+      test: "new tag value"
+      newtag: "another value"
+    state: "present"
+  register: output
+
+- name: Assert the resource has not changed
+  ansible.builtin.assert:
+    that:
+      - not output.changed
+
+- name: Update EndPoint (replace tags)
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    enabled_state: "Disabled"
+    append_tags: False
+    tags:
+      test2: "a tag value"
+    state: "present"
+  register: output
+
+- name: Assert the resource has changed
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Load Endpoint info
+  azure_rm_afdendpoint_info:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+  register: output
+
+- name: Assert the resource has the proper values set and is missing the previous tag
+  ansible.builtin.assert:
+    that:
+      - output.afdendpoints | length == 1
+      - output.afdendpoints[0].auto_generated_domain_name_label_scope == 'TenantReuse'
+      - output.afdendpoints[0].enabled_state == 'Disabled'
+      - output.afdendpoints[0].tags['test2'] == 'a tag value'
+      - output.afdendpoints[0].tags['newtag'] is not defined
+      - not output.changed
+
+- name: Delete EndPoint
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    state: "absent"
+  register: output
+
+- name: Assert the resource was deleted
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Delete EndPoint (idempotent test)
+  azure_rm_afdendpoint:
+    name: "{{ endpoint }}"
+    profile_name: "{{ profile }}"
+    resource_group: "{{ resource_group }}"
+    state: "absent"
+  register: output
+
+- name: Assert the delete function is idempotent
+  ansible.builtin.assert:
+    that:
+      - not output.changed
+
+- name: Delete Frontdoor Profile
+  azure_rm_cdnprofile:
+    name: "{{ profile }}"
+    location: "Global"
+    resource_group: "{{ resource_group }}"
+    state: "absent"
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds the ability to use the existing azure_rm_cdnprofile module to create both a Standard_AzureFrontDoor and Premium_AzureFrontDoor.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Begins to work on #1041 which will require additional pull requests and new modules.  This does not complete this issue, however.  This also bumps the azure-mgmt-cdn version from 11.0.0 to 13.1.0, which is the latest and will be needed for upcoming pull requests to finish the Front Door (Standard and Premium) functionality.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module: azure_rm_cdnprofile
Change: allows additional SKU options.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
