### PR TITLE
Update azure_rm_cdnprofile to include the Standard and Premium Frontdoor options

### DIFF
--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -42,6 +42,8 @@ options:
             - standard_akamai
             - standard_chinacdn
             - standard_microsoft
+            - standard_azurefrontdoor
+            - premium_azurefrontdoor
     state:
         description:
             - Assert the state of the CDN profile. Use C(present) to create or update a CDN profile and C(absent) to delete it.
@@ -129,7 +131,7 @@ class AzureRMCdnprofile(AzureRMModuleBase):
             ),
             sku=dict(
                 type='str',
-                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn', 'standard_microsoft']
+                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn', 'standard_microsoft', 'standard_azurefrontdoor', 'premium_azurefrontdoor']
             )
         )
 

--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -133,7 +133,7 @@ class AzureRMCdnprofile(AzureRMModuleBase):
                 type='str',
                 choices=[
                     'standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai',
-                    'standard_chinacdn', 'standard_microsoft', 
+                    'standard_chinacdn', 'standard_microsoft',
                     'standard_azurefrontdoor', 'premium_azurefrontdoor'
                 ]
             )

--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -131,7 +131,11 @@ class AzureRMCdnprofile(AzureRMModuleBase):
             ),
             sku=dict(
                 type='str',
-                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn', 'standard_microsoft', 'standard_azurefrontdoor', 'premium_azurefrontdoor']
+                choices=[
+                    'standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 
+                    'standard_chinacdn', 'standard_microsoft', 
+                    'standard_azurefrontdoor', 'premium_azurefrontdoor'
+                ]
             )
         )
 

--- a/plugins/modules/azure_rm_cdnprofile.py
+++ b/plugins/modules/azure_rm_cdnprofile.py
@@ -132,7 +132,7 @@ class AzureRMCdnprofile(AzureRMModuleBase):
             sku=dict(
                 type='str',
                 choices=[
-                    'standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 
+                    'standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai',
                     'standard_chinacdn', 'standard_microsoft', 
                     'standard_azurefrontdoor', 'premium_azurefrontdoor'
                 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-identity==1.14.0
 azure-mgmt-authorization==2.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-batch==16.2.0
-azure-mgmt-cdn==11.0.0
+azure-mgmt-cdn==13.1.0
 azure-mgmt-compute==30.6.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-core==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-identity==1.14.0
 azure-mgmt-authorization==2.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-batch==16.2.0
-azure-mgmt-cdn==13.1.0
+azure-mgmt-cdn==13.1.1
 azure-mgmt-compute==30.6.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-core==1.4.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds the ability to use the existing azure_rm_cdnprofile module to create both a Standard_AzureFrontDoor and Premium_AzureFrontDoor.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Begins to work on https://github.com/ansible-collections/azure/issues/1041 which will require additional pull requests and new modules. This does not complete this issue, however. This also bumps the azure-mgmt-cdn version from 11.0.0 to 13.1.0, which is the latest and will be needed for upcoming pull requests to finish the Front Door (Standard and Premium) functionality.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module: azure_rm_cdnprofile
Change: allows additional SKU options.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
