### PR TITLE
Update azure-cli-core to 2.61.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ packaging
 requests[security]
 xmltodict
 msgraph-sdk==1.0.0
-azure-cli-core==2.34.0
+azure-cli-core==2.61.0
 azure-common==1.1.11
 azure-identity==1.14.0
 azure-mgmt-authorization==2.0.0


### PR DESCRIPTION
##### SUMMARY

In particular, this change unpins `packaging` version in newer versions as the `azure-cli-core==2.34.0` does has a ceiling that prevents used of modern versions. Versions after `2.61.0` have removed this bug. Note that listing `packaging` as a direct dependency without any constraints does not help in any way, as resolver will still attempt to downgrade packaging if old version of `azure-cli-core` is requested.

Fixes: #1474

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dependencies

##### ADDITIONAL INFORMATION
See: https://github.com/Azure/azure-cli/commit/97effd78072b03b6f7f49e651e4972616133519e
See: https://github.com/Azure/azure-cli/issues/18548
See: https://issues.redhat.com/browse/AAP-19993
See: https://issues.redhat.com/browse/ACA-1651