### PR TITLE
Fix auth mode login for azure_rm_storageblob

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -700,8 +700,8 @@ class AzureRMModuleBase(object):
         try:
             self.log("Getting storage account detail")
             account = self.storage_client.storage_accounts.get_properties(resource_group_name=resource_group_name, account_name=storage_account_name)
-            if auth_mode == 'login' and self.azure_auth.credentials.get('credential'):
-                credential = self.azure_auth.credentials['credential']
+            if auth_mode == 'login' and self.azure_auth.credentials.get('credentials'):
+                credential = self.azure_auth.credentials['credentials']
             elif (auth_mode == 'login' and self.azure_auth.credentials.get('tenant')
                   and self.azure_auth.credentials.get('client_id')
                   and self.azure_auth.credentials.get('secret')):


### PR DESCRIPTION
##### SUMMARY
In c7244a96e651fc58942a0916eee8482c0ace7c4e the name of the key holding MSI credentials was renamed so we need to change the key we look for when doing login auth in the storageblob module with MSI credentials.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_storageblob
