### PR TITLE
Revert "Update azure-cli-core to 2.61.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ packaging
 requests[security]
 xmltodict
 msgraph-sdk==1.0.0
-azure-cli-core==2.61.0
+azure-cli-core==2.34.0
 azure-common==1.1.11
 azure-identity==1.16.1
 azure-mgmt-authorization==2.0.0


### PR DESCRIPTION
Reverts ansible-collections/azure#1593

Ok , so when I tested this I used an already deployed instance and just upgraded the azure-cli-core and I didn't get any errors.

But I have since done a new deployment and I get the following errors...

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
azure-cli 2.61.0 requires azure-mgmt-apimanagement==4.0.0, but you have azure-mgmt-apimanagement 3.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-authorization~=4.0.0, but you have azure-mgmt-authorization 2.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-batch~=17.3.0, but you have azure-mgmt-batch 16.2.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-cdn==12.0.0, but you have azure-mgmt-cdn 11.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-compute~=31.0.0, but you have azure-mgmt-compute 30.6.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-containerinstance==10.1.0, but you have azure-mgmt-containerinstance 9.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-containerregistry==10.3.0, but you have azure-mgmt-containerregistry 9.1.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-containerservice~=30.0.0, but you have azure-mgmt-containerservice 20.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-cosmosdb==9.4.0, but you have azure-mgmt-cosmosdb 6.4.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-devtestlabs~=4.0, but you have azure-mgmt-devtestlabs 9.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-iothub==3.0.0, but you have azure-mgmt-iothub 2.2.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-keyvault==10.3.0, but you have azure-mgmt-keyvault 10.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-loganalytics==13.0.0b4, but you have azure-mgmt-loganalytics 12.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-managedservices~=1.0, but you have azure-mgmt-managedservices 6.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-monitor~=5.0.0, but you have azure-mgmt-monitor 3.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-rdbms~=10.2.0b16, but you have azure-mgmt-rdbms 10.2.0b12 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-recoveryservices~=3.0.0, but you have azure-mgmt-recoveryservices 2.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-recoveryservicesbackup~=9.1.0, but you have azure-mgmt-recoveryservicesbackup 3.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-redis~=14.3.0, but you have azure-mgmt-redis 13.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-resource==23.1.1, but you have azure-mgmt-resource 21.1.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-search~=9.0, but you have azure-mgmt-search 8.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-servicebus~=8.2.0, but you have azure-mgmt-servicebus 7.1.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-sql==4.0.0b16, but you have azure-mgmt-sql 3.0.1 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-storage==21.1.0, but you have azure-mgmt-storage 19.0.0 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-trafficmanager~=1.0.0, but you have azure-mgmt-trafficmanager 1.0.0b1 which is incompatible.
azure-cli 2.61.0 requires azure-mgmt-web==7.2.0, but you have azure-mgmt-web 6.1.0 which is incompatible.
azure-mgmt-datalake-nspkg 3.0.1 requires azure-mgmt-nspkg>=3.0.0, but you have azure-mgmt-nspkg 2.0.0 which is incompatible.

I think this needs to be reverted until we verify all these versions.