### PR TITLE
Update azure-cli-core to 2.61.0 (#1593)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ packaging
 requests[security]
 xmltodict
 msgraph-sdk==1.0.0
-azure-cli-core==2.34.0
+azure-cli-core==2.61.0
 azure-common==1.1.11
 azure-identity==1.16.1
 azure-mgmt-authorization==2.0.0


### PR DESCRIPTION
##### SUMMARY
Re-apply the original pr to bump azure-cli-core to 2.61.0

I had a false failure because of a PBKAC.  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt - Updated dependency

##### ADDITIONAL INFORMATION

https://github.com/ansible-collections/azure/pull/1606#issuecomment-2180547932