### PR TITLE
Limit azure-iot-hub to x86_64 platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ azure-mgmt-devtestlabs==9.0.0
 azure-mgmt-loganalytics==12.0.0
 azure-mgmt-automation==1.0.0
 azure-mgmt-iothub==2.2.0
-azure-iot-hub==2.6.1
+azure-iot-hub==2.6.1;platform_machine=="x86_64"
 azure-mgmt-recoveryservices==2.0.0
 azure-mgmt-recoveryservicesbackup==3.0.0
 azure-mgmt-notificationhubs==7.0.0


### PR DESCRIPTION
##### SUMMARY
As a workaround to Issue #1505 we will limit the dependency of azure-iot-hub to x86_64 since the sub-dependency uamqp doesn't compile on arm.

Fixes #1505 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt
plugins/modules/azure_rm_iotdevice_info.py
plugins/modules/azure_rm_iotdevicemodule.py
plugins/modules/azure_rm_iotdevice.py