### PR TITLE
Documentation: misleading `*_host_filter` example

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -101,8 +101,8 @@ keyed_groups:
 exclude_host_filters:
     # excludes hosts in the eastus region
     - location in ['eastus']
-    - tags['tagkey'] is defined and tags['tagkey'] == 'tagkey'
-    - tags['tagkey2'] is defined and tags['tagkey2'] == 'tagkey2'
+    - tags['tagkey'] is defined and tags['tagkey'] == 'tagvalue'
+    - tags['tagkey2'] is defined and tags['tagkey2'] == 'tagvalue2'
     # excludes hosts that are powered off
     - powerstate != 'running'
 
@@ -110,9 +110,9 @@ exclude_host_filters:
 include_host_filters:
     # includes hosts that in the eastus region and power on
     - location in ['eastus'] and powerstate == 'running'
-    # includes hosts in the eastus region and power on OR includes hosts in the eastus2 region and tagkey is tagkey
+    # includes hosts in the eastus region and power on OR includes hosts in the eastus2 region and tagkey value is tagvalue
     - location in ['eastus'] and powerstate == 'running'
-    - location in ['eastus2'] and tags['tagkey'] is defined and tags['tagkey'] == 'tagkey'
+    - location in ['eastus2'] and tags['tagkey'] is defined and tags['tagkey'] == 'tagvalue'
 '''
 
 # FUTURE: do we need a set of sane default filters, separate from the user-defineable ones?


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Confusing documentation as it implies you can only evaluate the key of a specific tag within Azure.

This has been updated so it now implies it evaluates the tag key with a specific value; the main use case for this functionality within this plugin.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

azure.azcollection.azure_rm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```yaml
tags['tagkey'] == 'tagkey' # pulls no machine with the tag key of 'tagkey' and value of 'testvalue'
tags['tagkey'] == 'testvalue' # pulls machine with a tag key of 'tagkey' and value of 'testvalue'
```
