### PR TITLE
Add Managed Identity to iothub

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1327,7 +1327,7 @@ class AzureRMModuleBase(object):
         self.log('Getting iothub client')
         if not self._IoThub_client:
             self._IoThub_client = self.get_mgmt_svc_client(IotHubClient,
-                                                           api_version='2018-04-01',
+                                                           api_version='2023-06-30-preview',
                                                            base_url=self._cloud_environment.endpoints.resource_manager)
         return self._IoThub_client
 

--- a/plugins/modules/azure_rm_iothub_info.py
+++ b/plugins/modules/azure_rm_iothub_info.py
@@ -131,6 +131,30 @@ azure_iothubs:
             type: str
             returned: always
             sample: f1
+        identity:
+            description:
+                - Identity for the Server.
+            type: complex
+            returned: when available
+            contains:
+                type:
+                    description:
+                        - Type of the managed identity
+                    returned: always
+                    sample: UserAssigned
+                    type: str
+                user_assigned_identities:
+                    description:
+                        - User Assigned Managed Identities and its options
+                    returned: always
+                    type: complex
+                    contains:
+                        id:
+                            description:
+                                - Dict of the user assigned identities IDs associated to the Resource
+                            returned: always
+                            type: dict
+                            elements: dict
         cloud_to_device:
             description:
                 - Cloud to device message properties.
@@ -574,6 +598,7 @@ class AzureRMIoTHubFacts(AzureRMModuleBase):
         result['tags'] = hub.tags
         result['unit'] = hub.sku.capacity
         result['sku'] = hub.sku.name.lower()
+        result['identity'] = hub.identity.as_dict() if hub.identity else None
         result['cloud_to_device'] = dict(
             max_delivery_count=properties.cloud_to_device.feedback.max_delivery_count,
             ttl_as_iso8601=str(properties.cloud_to_device.feedback.ttl_as_iso8601)

--- a/tests/integration/targets/azure_rm_iothub/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_iothub/tasks/main.yml
@@ -1,6 +1,31 @@
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
 - name: Set variables
   ansible.builtin.set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(8, True, '') }}"
+    location: "{{ __rg_info.resourcegroups.0.location }}"
+
+- name: Create User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    body:
+      location: "{{ location }}"
+    state: present
+  loop:
+    - "ansible-test-iothub-identity"
+    - "ansible-test-iothub-identity-2"
+
+- name: Set identities IDs to test. Identities ansible-test-iothub-identity and ansible-test-iothub-identity-2 have to be created previously
+  ansible.builtin.set_fact:
+    user_identity_1: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-iothub-identity"
+    user_identity_2: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ansible-test-iothub-identity-2"
 
 - name: Create IoT Hub (check mode)
   azure_rm_iothub:
@@ -40,6 +65,36 @@
     that:
       - iothub.changed
 
+- name: Update IoT Hub (identity)
+  azure_rm_iothub:
+    name: "hub{{ rpfx }}"
+    resource_group: "{{ resource_group }}"
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
+          - "{{ user_identity_2 }}"
+  register: iothub
+
+- name: Assert tht iot hub created
+  ansible.builtin.assert:
+    that:
+      - iothub.changed
+
+- name: Get the IoT Hub facts
+  azure_rm_iothub_info:
+    name: "hub{{ rpfx }}"
+    resource_group: "{{ resource_group }}"
+  register: iothub
+
+- name: Assert the IoT Hub facts
+  ansible.builtin.assert:
+    that:
+      - iothub.iothubs[0].identity.type == 'UserAssigned'
+      - user_identity_1 in iothub.iothubs[0].identity.user_assigned_identities
+      - user_identity_2 in iothub.iothubs[0].identity.user_assigned_identities
+
 - name: Create IoT Hub (idempontent)
   azure_rm_iothub:
     name: "hub{{ rpfx }}"
@@ -48,6 +103,12 @@
       - name: filter1
         action: reject
         ip_mask: 40.60.80.10
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
+          - "{{ user_identity_2 }}"
   register: iothub
 
 - name: Assert the iot hub created
@@ -180,3 +241,15 @@
   ansible.builtin.assert:
     that:
       - iothub.changed
+
+- name: Destroy User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    state: absent
+  loop:
+    - "ansible-test-iothub-identity"
+    - "ansible-test-iothub-identity-2"


### PR DESCRIPTION
##### SUMMARY
Adds the ability to Manage Identity to the iothub module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py
plugins/modules/azure_rm_iothub.py
plugins/modules/azure_rm_iothub_info.py
tests/integration/targets/azure_rm_iothub/tasks/main.yml

##### ADDITIONAL INFORMATION
Integration tests have been updated.

This PR will be dependent on #1611 being committed first