### PR TITLE
Wait 10 minutes to get the imageversion state

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -855,9 +855,13 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
         else:
             self.fail("Create or Updating fail, no match message return, return info as {0}".format(response))
 
+        i = 0
         while response['properties']['provisioningState'] == 'Creating':
             time.sleep(60)
             response = self.get_resource()
+            i = i + 1
+            if i == 10:
+                self.fail("Create or Updating encountered an exception, wait 10 minutes when the status is still 'creating'")
 
         return response
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Wait 10 minutes to get the imageversion state. If it is always' creating', an error message is displayed"， similar with #1584
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_galleryimageversion.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
