### PR TITLE
`azure_rm_openshiftmanagedcluster_info` Fixed errors caused by returning an empty dictionary

### DIFF
--- a/plugins/modules/azure_rm_openshiftmanagedcluster_info.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster_info.py
@@ -325,7 +325,7 @@ class AzureRMOpenShiftManagedClustersInfo(AzureRMModuleBaseExt):
         except Exception as e:
             self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
 
-        return [self.format_item(x) for x in results['value']] if results['value'] else []
+        return [self.format_item(x) for x in results['value']] if results.get('value') else []
 
     def listall(self):
         response = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed errors caused by returning an empty dictionary
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_openshiftmanagedcluster_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
