### PR TITLE
Fix: Check for presence of key, not for presence of value.

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion_info.py
+++ b/plugins/modules/azure_rm_galleryimageversion_info.py
@@ -241,7 +241,7 @@ class AzureRMGalleryImageVersionsInfo(AzureRMModuleBase):
                 try:
                     response = json.loads(response.body())
                     if isinstance(response, dict):
-                        if response.get('value'):
+                        if 'value' in response:
                             results['response'] = results['response'] + response['value']
                             skiptoken = response.get('nextLink')
                         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1636

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The `listbygalleryimage` function does not handle empty results properly.
An actual empy dictionary `{ 'value': [] }` is returned.
The test is meant to check whether the key is present but instead tests whether its' *content* is present.
Subsequently, the entire response in copied in the else-branch iso. the content of key 'value', leading to the error in the next `format_item` call.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
