### PR TITLE
`azure_rm_manageddisk_info` - Add `time_created` in return to module

### DIFF
--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -137,6 +137,11 @@ azure_managed_disk:
                 - Tags to assign to the managed disk.
             type: dict
             sample: { "tag": "value" }
+        time_created:
+            description:
+                - The time the disk was created.
+            type: str
+            sample: "2018-01-01T11:08:15.338648900:00"
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
@@ -255,7 +260,8 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
             managed_by=managed_disk.managed_by,
             max_shares=managed_disk.max_shares,
             managed_by_extended=managed_disk.managed_by_extended,
-            zone=managed_disk.zones[0] if managed_disk.zones and len(managed_disk.zones) > 0 else ''
+            zone=managed_disk.zones[0] if managed_disk.zones and len(managed_disk.zones) > 0 else '',
+            time_created=managed_disk.time_created.isoformat() if managed_disk.time_created else None
         )
 
 


### PR DESCRIPTION
##### SUMMARY
Now it returns the time_created that is the time when the disk was created. I found this usefull because is the more "accurate" way of checking when a virtual machine was first deployed as normally it is attached to a disk.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_manageddisk_info

##### ADDITIONAL INFORMATION
The module didn't return the first date when the disk was created. This info can be really usefull to know when the disk was createed and so the virtual machine (not 100% sure but really accurate)

<!--- Paste verbatim command output below, e.g. before and after your change -->
Return example before the change:
```
{
  "ansible_info": {
    "azure_managed_disk": [
      {
        "create_option": "",
        "disk_size_gb": 1,
        "id": "xxxx",
        "location": "xxxx",
        "managed_by": "xxxx",
        "managed_by_extended": null,
        "max_shares": null,
        "name": "xxxx",
        "os_type": "xxx",
        "source_uri": null,
        "storage_account_type": "xxxx",
        "tags": null,
        "zone": ""
      }
    ]
  },
  "changed": false
}
```

Return example after the change
```
{
  "ansible_info": {
    "azure_managed_disk": [
      {
        "create_option": "xx",
        "disk_size_gb": 1,
        "id": "xxxx2",
        "location": "xxxx",
        "managed_by": "xxxx",
        "managed_by_extended": null,
        "max_shares": null,
        "name": "xxxx",
        "os_type": "xxxx",
        "source_uri": null,
        "storage_account_type": "xxxx",
        "tags": null,
        "time_created": "2018-01-01T11:08:15.338248+00:00",
        "zone": ""
      }
    ]
  },
  "changed": false
}
```