### PR TITLE
Add managed identity support to "azure_rm_cosmosdbaccount"

### DIFF
--- a/plugins/modules/azure_rm_cosmosdbaccount_info.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount_info.py
@@ -527,7 +527,9 @@ class AzureRMCosmosDBAccountInfo(AzureRMModuleBase):
             'enable_multiple_write_locations': d.get('enable_multiple_write_locations'),
             'document_endpoint': d.get('document_endpoint'),
             'provisioning_state': d.get('provisioning_state'),
-            'tags': d.get('tags', None)
+            'tags': d.get('tags', None),
+            'identity': d.get('identity', None),
+            'default_identity': d.get('default_identity', None)
         }
 
         if self.retrieve_keys == 'all':

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ azure-storage-blob==12.13.0
 azure-core==1.28.0
 azure-keyvault==4.2.0
 azure-mgmt-keyvault==10.0.0
-azure-mgmt-cosmosdb==6.4.0
+azure-mgmt-cosmosdb==9.5.1
 azure-mgmt-hdinsight==9.0.0
 azure-mgmt-devtestlabs==9.0.0
 azure-mgmt-loganalytics==12.0.0

--- a/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
@@ -1,3 +1,48 @@
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+- name: Set location based on resource group
+  ansible.builtin.set_fact:
+    location: "{{ __rg_info.resourcegroups.0.location }}"
+
+- name: Set secondary location if not already defined
+  ansible.builtin.set_fact:
+    location_secondary: westus
+  when: location_secondary is undefined
+
+- name: Set identities base path
+  ansible.builtin.set_fact:
+    identity_base_path: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}/providers/Microsoft.ManagedIdentity"
+
+- name: Set identities IDs to test. Identities ansible-test-cosmosdbaccount-identity and ansible-test-cosmosdbaccount-identity-2 have to be created previously
+  ansible.builtin.set_fact:
+    user_identity_1: "{{ identity_base_path }}/userAssignedIdentities/ansible-test-cosmosdbaccount-identity"
+    user_identity_2: "{{ identity_base_path }}/userAssignedIdentities/ansible-test-cosmosdbaccount-identity-2"
+    user_identity_3: "{{ identity_base_path }}/userAssignedIdentities/ansible-test-cosmosdbaccount-identity-3"
+
+- name: Set default user identities options
+  ansible.builtin.set_fact:
+    default_identity_1: 'UserAssignedIdentity={{ user_identity_1 }}'
+    default_identity_2: 'UserAssignedIdentity={{ user_identity_2 }}'
+    default_identity_3: 'UserAssignedIdentity={{ user_identity_3 }}'
+
+- name: Create User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    body:
+      location: "{{ location }}"
+    state: present
+  loop:
+    - "ansible-test-cosmosdbaccount-identity"
+    - "ansible-test-cosmosdbaccount-identity-2"
+    - "ansible-test-cosmosdbaccount-identity-3"
+
 - name: Prepare random number
   ansible.builtin.set_fact:
     dbname: "cosmos-{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
@@ -29,13 +74,14 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
-    location: eastus
+    location: "{{ location }}"
     geo_rep_locations:
-      - name: eastus
+      - name: "{{ location }}"
         failover_priority: 0
     database_account_offer_type: Standard
   check_mode: true
   register: output
+
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
@@ -45,12 +91,12 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
-    location: eastus
+    location: "{{ location }}"
     kind: global_document_db
     geo_rep_locations:
-      - name: eastus
+      - name: "{{ location }}"
         failover_priority: 0
-      - name: westus
+      - name: "{{ location_secondary }}"
         failover_priority: 1
     database_account_offer_type: Standard
     is_virtual_network_filter_enabled: true
@@ -60,7 +106,14 @@
           virtual_network_name: "{{ vnname }}"
           subnet_name: "{{ subnetname }}"
         ignore_missing_v_net_service_endpoint: true
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
+    default_identity: '{{ default_identity_1 }}'
   register: output
+
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
@@ -70,12 +123,12 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
-    location: eastus
+    location: "{{ location }}"
     kind: global_document_db
     geo_rep_locations:
-      - name: eastus
+      - name: "{{ location }}"
         failover_priority: 0
-      - name: westus
+      - name: "{{ location_secondary }}"
         failover_priority: 1
     database_account_offer_type: Standard
     is_virtual_network_filter_enabled: true
@@ -85,7 +138,14 @@
           virtual_network_name: "{{ vnname }}"
           subnet_name: "{{ subnetname }}"
         ignore_missing_v_net_service_endpoint: true
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
+    default_identity: '{{ default_identity_1 }}'
   register: output
+
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
@@ -99,12 +159,12 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
-    location: eastus
+    location: "{{ location }}"
     kind: global_document_db
     geo_rep_locations:
-      - name: eastus
+      - name: "{{ location }}"
         failover_priority: 0
-      - name: westus
+      - name: "{{ location_secondary }}"
         failover_priority: 1
     database_account_offer_type: Standard
     is_virtual_network_filter_enabled: true
@@ -115,7 +175,14 @@
           subnet_name: "{{ subnetname }}"
         ignore_missing_v_net_service_endpoint: true
     enable_automatic_failover: true
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_2 }}"
+    default_identity: '{{ default_identity_1 }}'
   register: output
+
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
@@ -125,12 +192,12 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group_secondary }}"
     name: "{{ db2name }}"
-    location: eastus
+    location: "{{ location }}"
     kind: global_document_db
     geo_rep_locations:
-      - name: eastus
+      - name: "{{ location }}"
         failover_priority: 0
-      - name: westus
+      - name: "{{ location_secondary }}"
         failover_priority: 1
     database_account_offer_type: Standard
     is_virtual_network_filter_enabled: true
@@ -140,7 +207,49 @@
           virtual_network_name: "{{ vnname }}"
           subnet_name: "{{ subnetname }}"
         ignore_missing_v_net_service_endpoint: true
+    identity:
+      type: SystemAssigned, UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
+          - "{{ user_identity_2 }}"
+    default_identity: '{{ default_identity_1 }}'
   register: output
+
+- name: Assert the resource instance is well created
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Update second instance of Database Account - replace user-identity
+  azure_rm_cosmosdbaccount:
+    resource_group: "{{ resource_group_secondary }}"
+    name: "{{ db2name }}"
+    location: "{{ location }}"
+    kind: global_document_db
+    geo_rep_locations:
+      - name: "{{ location }}"
+        failover_priority: 0
+      - name: "{{ location_secondary }}"
+        failover_priority: 1
+    database_account_offer_type: Standard
+    is_virtual_network_filter_enabled: true
+    virtual_network_rules:
+      - subnet:
+          resource_group: "{{ resource_group }}"
+          virtual_network_name: "{{ vnname }}"
+          subnet_name: "{{ subnetname }}"
+        ignore_missing_v_net_service_endpoint: true
+    identity:
+      type: SystemAssigned, UserAssigned
+      user_assigned_identities:
+        id:
+          - "{{ user_identity_1 }}"
+          - "{{ user_identity_3 }}"
+        append: false
+    default_identity: '{{ default_identity_1 }}'
+  register: output
+
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
@@ -151,6 +260,7 @@
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}"
   register: output
+
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
@@ -159,7 +269,7 @@
       - output.accounts[0]['id'] != None
       - output.accounts[0]['resource_group'] == resource_group
       - output.accounts[0]['name'] == dbname
-      - output.accounts[0]['location'] == 'eastus'
+      - output.accounts[0]['location'] == location
       - output.accounts[0]['kind'] != None
       - output.accounts[0]['consistency_policy'] != None
       - output.accounts[0]['failover_policies'] != None
@@ -180,6 +290,26 @@
       - output.accounts[0]['tags'] != None
       - output.accounts[0]['enable_free_tier'] == false
       - output.accounts[0]['public_network_access'] == 'Enabled'
+      - output.accounts[0]['identity']['type'] == 'UserAssigned'
+      - output.accounts[0]['identity']['user_assigned_identities'] | length == 2
+      - output.accounts[0]['identity']['user_assigned_identities']['{{ user_identity_1 }}'] is defined
+      - output.accounts[0]['identity']['user_assigned_identities']['{{ user_identity_2 }}'] is defined
+      - output.accounts[0]['default_identity'] == default_identity_1
+
+- name: Get facts of second account
+  azure_rm_cosmosdbaccount_info:
+    resource_group: "{{ resource_group_secondary }}"
+    name: "{{ db2name }}"
+  register: output
+
+- name: Assert identity is as expected
+  ansible.builtin.assert:
+    that:
+      - output.accounts[0]['identity']['type'] == 'SystemAssigned,UserAssigned'
+      - output.accounts[0]['identity']['user_assigned_identities'] | length == 2
+      - output.accounts[0]['identity']['user_assigned_identities']['{{ user_identity_1 }}'] is defined
+      - output.accounts[0]['identity']['user_assigned_identities']['{{ user_identity_3 }}'] is defined
+      - output.accounts[0]['default_identity'] == default_identity_1
 
 - name: Get facts with keys
   azure_rm_cosmosdbaccount_info:
@@ -225,7 +355,7 @@
       - output.accounts[0]['id'] != None
       - output.accounts[0]['resource_group'] == resource_group
       - output.accounts[0]['name'] == dbname
-      - output.accounts[0]['location'] == 'eastus'
+      - output.accounts[0]['location'] == location
       - output.accounts[0]['kind'] != None
       - output.accounts[0]['consistency_policy'] != None
       - output.accounts[0]['failover_policies'] != None
@@ -246,6 +376,11 @@
       - output.accounts[0]['tags'] != None
       - output.accounts[0]['enable_free_tier'] == false
       - output.accounts[0]['public_network_access'] == 'Enabled'
+      - output.accounts[0]['identity']['type'] == 'UserAssigned'
+      - output.accounts[0]['identity']['user_assigned_identities'] | length == 2
+      - output.accounts[0]['identity']['user_assigned_identities']['{{ user_identity_1 }}'] is defined
+      - output.accounts[0]['identity']['user_assigned_identities']['{{ user_identity_2 }}'] is defined
+      - output.accounts[0]['default_identity'] == default_identity_1
 
 - name: List all accounts
   azure_rm_cosmosdbaccount_info:
@@ -262,7 +397,7 @@
   azure_rm_cosmosdbaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ dbname }}-free4"
-    location: eastus
+    location: "{{ location }}"
     kind: mongo_db
     mongo_version: "4.0"
     enable_free_tier: "{{ free_tier_supported }}"
@@ -271,9 +406,9 @@
       - "1.1.1.1"
       - "2.2.2.2/28"
     geo_rep_locations:
-      - name: eastus
+      - name: "{{ location }}"
         failover_priority: 0
-      - name: westus
+      - name: "{{ location_secondary }}"
         failover_priority: 1
     database_account_offer_type: Standard
     is_virtual_network_filter_enabled: true
@@ -367,3 +502,16 @@
     resource_group: "{{ resource_group }}"
     name: "{{ vnname }}"
     state: absent
+
+- name: Destroy User Managed Identities
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: ManagedIdentity
+    resource_type: userAssignedIdentities
+    resource_name: "{{ item }}"
+    api_version: "2023-01-31"
+    state: absent
+  loop:
+    - "ansible-test-cosmosdbaccount-identity"
+    - "ansible-test-cosmosdbaccount-identity-2"
+    - "ansible-test-cosmosdbaccount-identity-3"


### PR DESCRIPTION
##### SUMMARY
This change add idendtity and default_identity attributes to azure_rm_cosmosdbaccount.
In order to support "Update" operation properly, changed it to use "begin_update" as part of the update operation (instead of "begin_create_or_update")

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_cosmosdbaccount

