### PR TITLE
`azure_rm_virtualmachinescaleset` - Fixed an issue where vmss tags could not be updated

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1064,7 +1064,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                         differences.append('Identity')
                         changed = True
 
-                update_tags, vmss_dict['tags'] = self.update_tags(vmss_dict.get('tags', dict()))
+                update_tags, self.tags = self.update_tags(vmss_dict.get('tags', dict()))
                 if update_tags:
                     differences.append('Tags')
                     changed = True
@@ -1395,6 +1395,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     vmss_resource.platform_fault_domain_count = self.platform_fault_domain_count
                     vmss_resource.overprovision = self.overprovision
                     vmss_resource.single_placement_group = self.single_placement_group
+                    vmss_resource.tags = self.tags
 
                     if support_lb_change:
                         if self.load_balancer:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed an issue where vmss tags could not be updated， try to fixes #1653
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachinescalset.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
