### PR TITLE
`azure_rm_aksagentpool` , `azure_rm_aksagentpool_info` - Ignore the 'node_public_ip_prefix_id' compare when updating aks pool

### DIFF
--- a/plugins/modules/azure_rm_aksagentpool.py
+++ b/plugins/modules/azure_rm_aksagentpool.py
@@ -735,7 +735,7 @@ aks_agent_pools:
                 - The Azure Public IP prefix's ID.
             type: str
             returned: always
-            sample: "/subscriptions/xxx-xxx/resourceGroups/myRG/providers/Microsoft.Network/publicIPPrefixes/pip01"
+            sample: null
         proximity_placement_group_id:
             description:
                 - The ID for Proximity Placement Group.
@@ -1043,6 +1043,8 @@ class AzureRMAksAgentPool(AzureRMModuleBase):
                         for item in self.body[key].keys():
                             if self.body[key][item] is not None and self.body[key][item] != agent_pool[key].get(item):
                                 changed = True
+                    elif key == 'node_public_ip_prefix_id':
+                        pass
                     elif self.body[key] is not None and self.body[key] != agent_pool[key] and key not in ['scale_set_priority', 'spot_max_price']:
                         changed = True
                     else:

--- a/plugins/modules/azure_rm_aksagentpool_info.py
+++ b/plugins/modules/azure_rm_aksagentpool_info.py
@@ -288,7 +288,7 @@ aks_agent_pools:
                 - The Azure Public IP prefix's ID.
             type: str
             returned: always
-            sample: "/subscriptions/xxx-xxx/resourceGroups/myRG/providers/Microsoft.Network/publicIPPrefixes/pip01"
+            sample: null
         proximity_placement_group_id:
             description:
                 - The ID for Proximity Placement Group.


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The service does not return this parameter 'node_public_ip_prefix_id', so it is not determined when updating
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_aksagentpool.py
azure_rm_aksagentpool_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
