### PR TITLE
Fix SDK call to use Configuration class

### DIFF
--- a/plugins/modules/azure_rm_postgresqlconfiguration.py
+++ b/plugins/modules/azure_rm_postgresqlconfiguration.py
@@ -74,6 +74,7 @@ id:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+    from azure.mgmt.rdbms.postgresql.models import Configuration
     from azure.core.exceptions import ResourceNotFoundError
     from azure.core.polling import LROPoller
 except ImportError:
@@ -186,8 +187,10 @@ class AzureRMPostgreSqlConfigurations(AzureRMModuleBase):
             response = self.postgresql_client.configurations.begin_create_or_update(resource_group_name=self.resource_group,
                                                                                     server_name=self.server_name,
                                                                                     configuration_name=self.name,
-                                                                                    parameters=self.value,
-                                                                                    source='user-override')
+                                                                                    parameters=Configuration(
+                                                                                        value=self.value,
+                                                                                        source='user-override'
+                                                                                    ))
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 
@@ -202,7 +205,7 @@ class AzureRMPostgreSqlConfigurations(AzureRMModuleBase):
             response = self.postgresql_client.configurations.begin_create_or_update(resource_group_name=self.resource_group,
                                                                                     server_name=self.server_name,
                                                                                     configuration_name=self.name,
-                                                                                    source='system-default')
+                                                                                    parameters=Configuration(source='system-default'))
         except Exception as e:
             self.log('Error attempting to delete the Configuration instance.')
             self.fail("Error deleting the Configuration instance: {0}".format(str(e)))


### PR DESCRIPTION
Until now, begin_create_or_update function was called with values directly which caused failure due to unexpected format, str instead of dict.
Changes to use Configuration class for the parameter's value

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Wrapped value and source parameters with Configuration  class in begin_create_or_update function

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_postgresqlconfiguration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
