### PR TITLE
`azure_rm_openshiftcluster` Remove vm_size choices

### DIFF
--- a/plugins/modules/azure_rm_openshiftmanagedcluster.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster.py
@@ -91,10 +91,6 @@ options:
                 description:
                     - Size of agent VMs (immutable).
                 type: str
-                choices:
-                    - Standard_D8s_v3
-                    - Standard_D16s_v3
-                    - Standard_D32s_v3
             subnet_id:
                 description:
                     - The Azure resource ID of the master subnet (immutable).
@@ -116,9 +112,6 @@ options:
                 description:
                     - The size of the worker Vms (immutable).
                 type: str
-                choices:
-                    - Standard_D4s_v3
-                    - Standard_D8s_v3
             disk_size:
                 description:
                     - The disk size of the worker VMs in GB. Must be 128 or greater (immutable).
@@ -474,10 +467,7 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                 type='dict',
                 options=dict(
                     vm_size=dict(
-                        type='str',
-                        choices=['Standard_D8s_v3',
-                                 'Standard_D16s_v3',
-                                 'Standard_D32s_v3'],
+                        type='str'
                     ),
                     subnet_id=dict(
                         type='str',
@@ -498,9 +488,7 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                         type='int',
                     ),
                     vm_size=dict(
-                        type='str',
-                        choices=['Standard_D4s_v3',
-                                 'Standard_D8s_v3'],
+                        type='str'
                     ),
                     subnet_id=dict(
                         type='str',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove vm_size choices,  Because it has multiple options and supports many generations
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_openshiftcluster.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
