### PR TITLE
Lexicalized resource ids should get 'subscription' instead of 'subscription_id'

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -609,7 +609,7 @@ class AzureRMModuleBase(object):
         '''
         resource_dict = parse_resource_id(resource) if not isinstance(resource, dict) else resource
         resource_dict['resource_group'] = resource_dict.get('resource_group', self.resource_group)
-        resource_dict['subscription_id'] = resource_dict.get('subscription_id', self.subscription_id)
+        resource_dict['subscription_id'] = resource_dict.get('subscription', self.subscription_id)
         return resource_dict
 
     def serialize_obj(self, obj, class_name, enum_modules=None):

--- a/plugins/modules/azure_rm_image.py
+++ b/plugins/modules/azure_rm_image.py
@@ -262,7 +262,7 @@ class AzureRMImage(AzureRMModuleBase):
             self.fail("source parameter should be in type string or dictionary")
         if tokenize.get('type') == 'disks':
             disk = format_resource_id(tokenize['name'],
-                                      tokenize.get('subscription_id') or self.subscription_id,
+                                      tokenize.get('subscription') or self.subscription_id,
                                       'Microsoft.Compute',
                                       'disks',
                                       tokenize.get('resource_group') or self.resource_group)
@@ -270,7 +270,7 @@ class AzureRMImage(AzureRMModuleBase):
 
         if tokenize.get('type') == 'snapshots':
             snapshot = format_resource_id(tokenize['name'],
-                                          tokenize.get('subscription_id') or self.subscription_id,
+                                          tokenize.get('subscription') or self.subscription_id,
                                           'Microsoft.Compute',
                                           'snapshots',
                                           tokenize.get('resource_group') or self.resource_group)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Lexicalized resource ids should get 'subscription' instead of 'subscription_id'
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
