### PR TITLE
`azure_rm_loadbalancecer` - Add support `enable_tcp_reset` to `load_balancing_rules`

### DIFF
--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -259,6 +259,11 @@ options:
                 description:
                     - Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group.
                 type: bool
+            enable_tcp_reset:
+                description:
+                    - Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination.
+                    - This element is only used when the protocol is set to TCP.
+                type: bool
             disable_outbound_snat:
                 description:
                     - Configure outbound source network address translation (SNAT).
@@ -560,6 +565,9 @@ load_balancing_rule_spec = dict(
         type='bool',
         default=False
     ),
+    enable_tcp_reset=dict(
+        type='bool'
+    )
 )
 
 
@@ -745,6 +753,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
                 backend_port=item.get('backend_port'),
                 idle_timeout_in_minutes=item.get('idle_timeout'),
                 enable_floating_ip=item.get('enable_floating_ip'),
+                enable_tcp_reset=item.get('enable_tcp_reset'),
                 disable_outbound_snat=item.get('disable_outbound_snat'),
             ) for item in self.load_balancing_rules] if self.load_balancing_rules else None
 

--- a/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
@@ -124,6 +124,7 @@
         idle_timeout: 4
         load_distribution: Default
         protocol: Tcp
+        enable_tcp_reset: true
   register: output
 
 - name: Assert complex load balancer created
@@ -165,6 +166,7 @@
         idle_timeout: 4
         load_distribution: Default
         protocol: Tcp
+        enable_tcp_reset: true
   register: output
 
 - name: Assert that output has not changed
@@ -205,12 +207,24 @@
         idle_timeout: 4
         load_distribution: Default
         protocol: Tcp
+        enable_tcp_reset: false
   register: output
 
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
       - output.changed
+
+- name: Get the load balancer facts
+  azure_rm_loadbalancer_info:
+    resource_group: '{{ resource_group }}'
+    name: "{{ lbname_b }}"
+  register: output
+
+- name: Assert the load balancer facts
+  ansible.builtin.assert:
+    - output.loadbalancers[0].load_balancing_rules[0].enable_tcp_reset is false
+    - output.loadbalancers[0].load_balancing_rules[0].frontend_port == 81
 
 - name: Delete load balancer
   azure_rm_loadbalancer:

--- a/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
@@ -223,8 +223,9 @@
 
 - name: Assert the load balancer facts
   ansible.builtin.assert:
-    - output.loadbalancers[0].load_balancing_rules[0].enable_tcp_reset is false
-    - output.loadbalancers[0].load_balancing_rules[0].frontend_port == 81
+    that:
+      - output.loadbalancers[0].load_balancing_rules[0].enable_tcp_reset is false
+      - output.loadbalancers[0].load_balancing_rules[0].frontend_port == 81
 
 - name: Delete load balancer
   azure_rm_loadbalancer:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support 'enable_tcp_reset' to azure_rm_loadbalancecer.py's load_balancing_rules, try to fixes #1773
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_loadbalancer.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
