### PR TITLE
`azure_rm_manageddisk_info`, `azure_rm_manageddisk` - Add support for display/modification of disk performance `tier` 

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -178,6 +178,7 @@ options:
             - Only settable for I(storage_account_type=Premium_LRS) disks.
             - Allowed values are C(P1), C(P2), C(P3), C(P4), C(P6), C(P10), C(P15), C(P20), C(P30), C(P40), C(P50), C(P60), C(P70), C(P80)
             - See U(https://learn.microsoft.com/en-us/azure/virtual-machines/disks-change-performance) for more information about disk performance tiers.
+            - Does not apply to Ultra disks.
         type: str
         choices:
             - P1
@@ -492,7 +493,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             ),
             tier=dict(
                 type='str',
-                choices=['', 'P1', 'P2', 'P3', 'P4', 'P6', 'P10', 'P15', 'P20', 'P30', 'P40', 'P50', 'P60', 'P70', 'P80']
+                choices=['P1', 'P2', 'P3', 'P4', 'P6', 'P10', 'P15', 'P20', 'P30', 'P40', 'P50', 'P60', 'P70', 'P80']
             ),
         )
         required_if = [

--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -175,8 +175,25 @@ options:
     tier:
         description:
             - Performance tier assigned to this disk.
+            - Only settable for I(storage_account_type=Premium_LRS) disks.
+            - Allowed values are C(P1), C(P2), C(P3), C(P4), C(P6), C(P10), C(P15), C(P20), C(P30), C(P40), C(P50), C(P60), C(P70), C(P80)
             - See U(https://learn.microsoft.com/en-us/azure/virtual-machines/disks-change-performance) for more information about disk performance tiers.
         type: str
+        choices:
+            - P1
+            - P2
+            - P3
+            - P4
+            - P6
+            - P10
+            - P15
+            - P20
+            - P30
+            - P40
+            - P50
+            - P60
+            - P70
+            - P80
 
 extends_documentation_fragment:
     - azure.azcollection.azure

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -137,6 +137,12 @@ azure_managed_disk:
                 - Tags to assign to the managed disk.
             type: dict
             sample: { "tag": "value" }
+        tier:
+            description:
+                - Performance tier assigned to the managed disk.
+                - See U(https://learn.microsoft.com/en-us/azure/virtual-machines/disks-change-performance) for more information about disk performance tiers.
+            type: str
+            sample: "P30"
         time_created:
             description:
                 - The time the disk was created.
@@ -296,6 +302,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
             disk_m_bps_read_write=managed_disk.disk_m_bps_read_write,
             disk_iops_read_only=managed_disk.disk_iops_read_only,
             disk_m_bps_read_only=managed_disk.disk_m_bps_read_only,
+            tier=managed_disk.tier,
         )
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[See issue 1786](https://github.com/ansible-collections/azure/issues/1786) 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_manageddisk_info: display performance tier
azure_rm_manageddisk: modify performance tier
