### PR TITLE
Distinguish between upload methods of type `blob` and `page`

### DIFF
--- a/plugins/modules/azure_rm_storageblob.py
+++ b/plugins/modules/azure_rm_storageblob.py
@@ -540,12 +540,19 @@ class AzureRMStorageBlob(AzureRMModuleBase):
             try:
                 client = self.blob_service_client.get_blob_client(container=self.container, blob=self.blob)
                 with open(self.src, "rb") as data:
-                    client.upload_blob(data=data,
-                                       blob_type=self.get_blob_type(self.blob_type),
-                                       metadata=self.tags,
-                                       content_settings=content_settings,
-                                       standard_blob_tier=self.get_blob_tier(self.standard_blob_tier),
-                                       overwrite=self.force)
+                    if self.blob_type == 'page':
+                        client.upload_blob(data=data,
+                                           blob_type=self.get_blob_type(self.blob_type),
+                                           metadata=self.tags,
+                                           content_settings=content_settings,
+                                           overwrite=self.force)
+                    else:
+                        client.upload_blob(data=data,
+                                           blob_type=self.get_blob_type(self.blob_type),
+                                           metadata=self.tags,
+                                           content_settings=content_settings,
+                                           standard_blob_tier=self.get_blob_tier(self.standard_blob_tier),
+                                           overwrite=self.force)
             except Exception as exc:
                 self.fail("Error creating blob {0} - {1}".format(self.blob, str(exc)))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Distinguish between upload methods of type 'blob' and 'page', try to fixes #1794
```e.g.
        :keyword ~azure.storage.blob.StandardBlobTier standard_blob_tier:
            A standard blob tier value to set the blob to. For this version of the library,
            this is only applicable to block blobs on standard storage accounts
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_storageblob.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
