### PR TITLE
[Enhance] - `azure_rm_trafficmanagerprofile`, `azure_rm_trafficmanagerprofile_info` - Add support for `custom_header`, `expected_status_code_ranges`, `max_return` and `allowed_endpoint_record_types`

### DIFF
--- a/plugins/modules/azure_rm_trafficmanagerprofile.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile.py
@@ -406,7 +406,7 @@ class AzureRMTrafficManagerProfile(AzureRMModuleBaseExt):
                 options=monitor_config_spec
             ),
             max_return=dict(
-                 type='int'
+                type='int'
             ),
             allowed_endpoint_record_types=dict(
                 type='list',
@@ -574,7 +574,8 @@ class AzureRMTrafficManagerProfile(AzureRMModuleBaseExt):
             self.max_return = response['max_return']
 
         if not self.default_compare({}, self.allowed_endpoint_record_types, response['allowed_endpoint_record_types'], '', dict(compare=[])):
-            self.log("Profile allowed_endpoint_record_types Diff - Origin {0} / Update {1}".format(response['allowed_endpoint_record_types'], self.allowed_endpoint_record_types))
+            self.log("Profile allowed_endpoint_record_types Diff - Origin {0} / Update {1}".format(response['allowed_endpoint_record_types'],
+                                                                                                   self.allowed_endpoint_record_types))
             return True
 
         if not self.default_compare({}, self.monitor_config, response['monitor_config'], '', dict(compare=[])):

--- a/plugins/modules/azure_rm_trafficmanagerprofile.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile.py
@@ -87,6 +87,7 @@ options:
                     - Degraded
                     - Inactive
                     - Stopped
+                    - Disabled
             protocol:
                 description:
                     - The protocol C(HTTP), C(HTTPS) or C(TCP) used to probe for endpoint health.
@@ -219,7 +220,8 @@ endpoints:
              nalEndpoints/e1"
             ]
 '''
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, normalize_location_name
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import normalize_location_name
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
@@ -249,7 +251,9 @@ def traffic_manager_profile_to_dict(tmp):
         routing_method=tmp.traffic_routing_method,
         dns_config=dict(),
         monitor_config=dict(),
-        endpoints=[]
+        endpoints=[],
+        max_return=tmp.max_return,
+        allowed_endpoint_record_types=tmp.allowed_endpoint_record_types
     )
     if tmp.dns_config:
         result['dns_config']['relative_name'] = tmp.dns_config.relative_name
@@ -263,8 +267,14 @@ def traffic_manager_profile_to_dict(tmp):
         result['monitor_config']['interval'] = tmp.monitor_config.interval_in_seconds
         result['monitor_config']['timeout'] = tmp.monitor_config.timeout_in_seconds
         result['monitor_config']['tolerated_failures'] = tmp.monitor_config.tolerated_number_of_failures
-        result['monitor_config']['expected_status_code_ranges'] = [dict(min=x.min, max=x.max) for x in tmp.monitor_config.expected_status_code_ranges] if tmp.monitor_config.expected_status_code_ranges else None
-        result['monitor_config']['custom_headers'] = [dict(name=x.name, value=x.value) for x in tmp.monitor_config.custom_headers] if tmp.monitor_config.custom_headers else None
+        if tmp.monitor_config.expected_status_code_ranges is not None:
+            result['monitor_config']['expected_status_code_ranges'] = [dict(min=x.min, max=x.max) for x in tmp.monitor_config.expected_status_code_ranges]
+        else:
+            result['monitor_config']['expected_status_code_ranges'] = None
+        if tmp.monitor_config.custom_headers is not None:
+            result['monitor_config']['custom_headers'] = [dict(name=x.name, value=x.value) for x in tmp.monitor_config.custom_headers]
+        else:
+            result['monitor_config']['custom_headers'] = None
     if tmp.endpoints:
         for endpoint in tmp.endpoints:
             result['endpoints'].append(dict(
@@ -293,8 +303,18 @@ def create_dns_config_instance(dns_config):
 
 def create_monitor_config_instance(monitor_config):
 
-    custom_headers = [MonitorConfigCustomHeadersItem(name=x['name'], value=x['value']) for x in monitor_config['custom_headers']] if monitor_config.get('custom_headers') else None
-    expected_status_code_ranges = [MonitorConfigExpectedStatusCodeRangesItem(min=x['min'], max=x['max']) for x in monitor_config['expected_status_code_ranges']] if monitor_config.get('expected_status_code_ranges') else None
+    custom_headers = []
+    expected_status_code_ranges = []
+    if monitor_config.get('custom_headers') is not None:
+        for item in monitor_config['custom_headers']:
+            custom_headers.append(MonitorConfigCustomHeadersItem(name=item['name'], value=item['value']))
+    else:
+        custom_headers = None
+    if monitor_config.get('expected_status_code_ranges') is not None:
+        for item in monitor_config['expected_status_code_ranges']:
+            expected_status_code_ranges.append(MonitorConfigExpectedStatusCodeRangesItem(min=item['min'], max=item['max']))
+    else:
+        expected_status_code_ranges = None
 
     return MonitorConfig(
         profile_monitor_status=monitor_config.get('profile_monitor_status'),
@@ -315,7 +335,7 @@ dns_config_spec = dict(
 )
 
 monitor_config_spec = dict(
-    profile_monitor_status=dict(type='str', choices=['CheckingEndpoints', 'Online', 'Degraded', 'Disabled', 'Inactive']),
+    profile_monitor_status=dict(type='str', choices=['CheckingEndpoint', 'Online', 'Degraded', 'Disabled', 'Inactive', 'Stopped']),
     protocol=dict(type='str', choices=['HTTP', 'HTTPS', 'TCP']),
     port=dict(type='int'),
     path=dict(type='str'),
@@ -341,7 +361,7 @@ monitor_config_spec = dict(
 )
 
 
-class AzureRMTrafficManagerProfile(AzureRMModuleBase):
+class AzureRMTrafficManagerProfile(AzureRMModuleBaseExt):
 
     def __init__(self):
         self.module_arg_spec = dict(
@@ -385,7 +405,7 @@ class AzureRMTrafficManagerProfile(AzureRMModuleBase):
                 ),
                 options=monitor_config_spec
             ),
-             max_return=dict(
+            max_return=dict(
                  type='int'
             ),
             allowed_endpoint_record_types=dict(
@@ -547,11 +567,20 @@ class AzureRMTrafficManagerProfile(AzureRMModuleBase):
             self.log("DNS Config Diff - Origin {0} / Update {1}".format(response['dns_config'], self.dns_config))
             return True
 
-        for k, v in self.monitor_config.items():
-            if v:
-                if str(v).lower() != str(response['monitor_config'][k]).lower():
-                    self.log("Monitor Config Diff - Origin {0} / Update {1}".format(response['monitor_config'], self.monitor_config))
-                    return True
+        if self.max_return and response['max_return'] != self.max_return:
+            self.log("Profile max_return Diff - Origin {0} / Update {1}".format(response['max_return'], self.max_return))
+            return True
+        else:
+            self.max_return = response['max_return']
+
+        if not self.default_compare({}, self.allowed_endpoint_record_types, response['allowed_endpoint_record_types'], '', dict(compare=[])):
+            self.log("Profile allowed_endpoint_record_types Diff - Origin {0} / Update {1}".format(response['allowed_endpoint_record_types'], self.allowed_endpoint_record_types))
+            return True
+
+        if not self.default_compare({}, self.monitor_config, response['monitor_config'], '', dict(compare=[])):
+            self.log("Monitor Config Diff - Origin {0} / Update {1}".format(response['monitor_config'], self.monitor_config))
+            return True
+
         return False
 
 

--- a/plugins/modules/azure_rm_trafficmanagerprofile_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile_info.py
@@ -434,8 +434,12 @@ class AzureRMTrafficManagerProfileInfo(AzureRMModuleBase):
             timeout=tm.monitor_config.timeout_in_seconds,
             tolerated_failures=tm.monitor_config.tolerated_number_of_failures,
             custom_headers=[dict(name=x.name, value=x.value) for x in tm.monitor_config.custom_headers] if tm.monitor_config.custom_headers else None,
-            expected_status_code_ranges=[dict(min=x.min, max=x.max) for x in tm.monitor_config.expected_status_code_ranges] if tm.monitor_config.expected_status_code_ranges else None
+            expected_status_code_ranges=[]
         )
+        if tm.monitor_config.expected_status_code_ranges:
+            for item in tm.monitor_config.expected_status_code_ranges:
+                new_result['monitor_config']['expected_status_code_ranges'].append(dict(min=item.min, max=item.max)
+
         new_result['endpoints'] = [serialize_endpoint(endpoint) for endpoint in tm.endpoints]
         new_result['tags'] = tm.tags
         return new_result

--- a/plugins/modules/azure_rm_trafficmanagerprofile_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile_info.py
@@ -438,7 +438,7 @@ class AzureRMTrafficManagerProfileInfo(AzureRMModuleBase):
         )
         if tm.monitor_config.expected_status_code_ranges:
             for item in tm.monitor_config.expected_status_code_ranges:
-                new_result['monitor_config']['expected_status_code_ranges'].append(dict(min=item.min, max=item.max)
+                new_result['monitor_config']['expected_status_code_ranges'].append(dict(min=item.min, max=item.max))
 
         new_result['endpoints'] = [serialize_endpoint(endpoint) for endpoint in tm.endpoints]
         new_result['tags'] = tm.tags

--- a/plugins/modules/azure_rm_trafficmanagerprofile_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile_info.py
@@ -100,6 +100,18 @@ tms:
             returned: always
             type: str
             sample: performance
+        max_return:
+            description:
+                - Maximum number of endpoints to be returned for MultiValue routing type.
+            type: int
+            returned: always
+            sample: 10
+        allowed_endpoint_record_types:
+            description:
+                - The list of allowed endpoint record types.
+            type: list
+            returned: always
+            sample: None
         dns_config:
             description:
                 - The DNS settings of the Traffic Manager profile.
@@ -166,6 +178,18 @@ tms:
                     returned: always
                     type: int
                     sample: 3
+                custom_headers:
+                    description:
+                        - List of custom headers.
+                    type: list
+                    returned: always
+                    sample: [{'name': 'key1', 'value': 'value1'}, {'name': 'key2', 'value': 'value2'}]
+                expected_status_code_ranges:
+                    description:
+                        - List of expected status code ranges.
+                    type: list
+                    returned: always
+                    sample: [{'max': 205, 'min': 200}, {'max': 222, 'min': 211}]
         endpoints:
             description:
                 - The list of endpoints in the Traffic Manager profile.
@@ -394,6 +418,8 @@ class AzureRMTrafficManagerProfileInfo(AzureRMModuleBase):
         new_result['location'] = tm.location
         new_result['profile_status'] = tm.profile_status
         new_result['routing_method'] = tm.traffic_routing_method.lower()
+        new_result['max_return'] = tm.max_return
+        new_result['allowed_endpoint_record_types'] = tm.allowed_endpoint_record_types
         new_result['dns_config'] = dict(
             relative_name=tm.dns_config.relative_name,
             fqdn=tm.dns_config.fqdn,
@@ -406,7 +432,9 @@ class AzureRMTrafficManagerProfileInfo(AzureRMModuleBase):
             path=tm.monitor_config.path,
             interval=tm.monitor_config.interval_in_seconds,
             timeout=tm.monitor_config.timeout_in_seconds,
-            tolerated_failures=tm.monitor_config.tolerated_number_of_failures
+            tolerated_failures=tm.monitor_config.tolerated_number_of_failures,
+            custom_headers=[dict(name=x.name, value=x.value) for x in tm.monitor_config.custom_headers] if tm.monitor_config.custom_headers else None,
+            expected_status_code_ranges=[dict(min=x.min, max=x.max) for x in tm.monitor_config.expected_status_code_ranges] if tm.monitor_config.expected_status_code_ranges else None
         )
         new_result['endpoints'] = [serialize_endpoint(endpoint) for endpoint in tm.endpoints]
         new_result['tags'] = tm.tags

--- a/tests/integration/targets/azure_rm_trafficmanagerprofile/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_trafficmanagerprofile/tasks/main.yml
@@ -125,6 +125,81 @@
     that:
       - output.changed
 
+- name: Create the Seconday Traffic Manager profile
+  azure_rm_trafficmanagerprofile:
+    resource_group: "{{ resource_group }}"
+    name: "{{ tmname }}02"
+    location: global
+    profile_status: enabled
+    routing_method: performance
+    dns_config:
+      relative_name: "{{ tmname }}02"
+      ttl: 60
+    max_return: 10
+    monitor_config:
+      protocol: HTTPS
+      port: 80
+      path: '/'
+      expected_status_code_ranges:
+        - min: 200
+          max: 212
+      custom_headers:
+        - name: key1
+          value: value1
+  register: output
+
+- name: Assert the Traffic Manager profile is well created
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Update the Seconday Traffic Manager profile
+  azure_rm_trafficmanagerprofile:
+    resource_group: "{{ resource_group }}"
+    name: "{{ tmname }}02"
+    location: global
+    profile_status: enabled
+    routing_method: performance
+    dns_config:
+      relative_name: "{{ tmname }}02"
+      ttl: 60
+    max_return: 12
+    monitor_config:
+      protocol: HTTPS
+      port: 90
+      path: '/'
+      expected_status_code_ranges:
+        - min: 200
+          max: 212
+        - min: 220
+          max: 230
+      custom_headers:
+        - name: key1
+          value: value1
+        - name: key2
+          value: value2
+  register: output
+
+- name: Assert the Traffic Manager profile is well updated
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Gather Seconday Traffic Manager profile facts
+  azure_rm_trafficmanagerprofile_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ tmname }}02"
+  register: fact
+- debug:
+    var: fact
+- name: Assert fact returns the created one
+  ansible.builtin.assert:
+    that:
+      - fact.tms[0].monitor_config.custom_headers | length == 2
+      - fact.tms[0].monitor_config.expected_status_code_ranges | length == 2
+      - fact.tms[0].monitor_config.port == 90
+      - fact.tms[0].max_return == 12
+
 - name: Create Traffic Manager endpoint(check mode)
   azure_rm_trafficmanagerendpoint:
     resource_group: "{{ resource_group }}"

--- a/tests/integration/targets/azure_rm_trafficmanagerprofile/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_trafficmanagerprofile/tasks/main.yml
@@ -190,8 +190,7 @@
     resource_group: "{{ resource_group }}"
     name: "{{ tmname }}02"
   register: fact
-- debug:
-    var: fact
+
 - name: Assert fact returns the created one
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for `custom_header`, `expected_status_code_ranges`, `max_return` and `allowed_endpoint_record_types`, try to fixes #431
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_trafficmanagerprofile.py
azure_rm_trafficmanagerprofile_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
