### PR TITLE
[Enhance] `azure_rm_storageaccount`, `azure_rm_storageaccount_info` - Add support for `immutable_storage_with_versioning`

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1085,7 +1085,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=dict()
+            immutable_storage_with_versioning=account_obj.immutable_storage_with_versioning.as_dict() if account_obj.immutable_storage_with_versioning else None
         )
         account_dict['custom_domain'] = None
         if account_obj.custom_domain:
@@ -1161,17 +1161,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             account_dict['identity'] = dict()
             if account_obj.identity:
                 account_dict['identity'] = account_obj.identity.as_dict()
-
-            if account_obj.immutable_storage_with_versioning is not None:
-                account_dict['immutable_storage_with_versioning']['enabled'] = account_obj.immutable_storage_with_versioning.enabled
-                account_dict['immutable_storage_with_versioning']['immutability_policy'] = dict()
-                if account_obj.immutable_storage_with_versioning.immutability_policy is not None:
-                    ipc = account_obj.immutable_storage_with_versioning.immutability_policy
-                    account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = ipc.immutability_period_since_creation_in_days
-                    account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = ipc.allow_protected_append_writes
-                    account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = ipc.state
-                else:
-                    account_dict['immutable_storage_with_versioning']['immutability_policy'] = None
 
         return account_dict
 

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -337,14 +337,16 @@ options:
                 type: bool
             immutability_policy:
                 description:
-                    - Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level.
-                    -  The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy.
+                    - Specifies the default account-level immutability policy which is inherited and
+                      applied to objects that do not possess an explicit immutability policy at the object level.
+                    - The object-level immutability policy has higher precedence than the container-level immutability policy,
+                      which has a higher precedence than the account-level immutability policy.
                 type: dict
                 suboptions:
                     allow_protected_append_writes:
                         description:
-                            - This property can only be changed for disabled and unlocked time-based retention policies.
-                            - When enabled, new blocks can be written to an append blob while maintaining immutability protection and compliance.
+                            - This property can only be changed for C(disabled) and C(unlocked) time-based retention policies.
+                            - When C(enabled), new blocks can be written to an append blob while maintaining immutability protection and compliance.
                             - Only new blocks can be added and any existing blocks cannot be modified or deleted.
                         type: bool
                     state:
@@ -569,8 +571,10 @@ state:
                     sample: true
                 immutability_policy:
                     description:
-                        - Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level.
-                        -  The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy.
+                        - Specifies the default account-level immutability policy which is inherited and
+                          applied to objects that do not possess an explicit immutability policy at the object level.
+                        - The object-level immutability policy has higher precedence than the container-level immutability policy,
+                          which has a higher precedence than the account-level immutability policy.
                     type: dict
                     returned: when-used
                     contains:
@@ -1162,9 +1166,10 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 account_dict['immutable_storage_with_versioning']['enabled'] = account_obj.immutable_storage_with_versioning.enabled
                 account_dict['immutable_storage_with_versioning']['immutability_policy'] = dict()
                 if account_obj.immutable_storage_with_versioning.immutability_policy is not None:
-                    account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = account_obj.immutable_storage_with_versioning.immutability_policy.immutability_period_since_creation_in_days
-                    account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = account_obj.immutable_storage_with_versioning.immutability_policy.allow_protected_append_writes
-                    account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = account_obj.immutable_storage_with_versioning.immutability_policy.state
+                    ipc = account_obj.immutable_storage_with_versioning.immutability_policy
+                    account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = ipc.immutability_period_since_creation_in_days
+                    account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = ipc.allow_protected_append_writes
+                    account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = ipc.state
                 else:
                     account_dict['immutable_storage_with_versioning']['immutability_policy'] = None
 

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -246,8 +246,10 @@ storageaccounts:
                     sample: true
                 immutability_policy:
                     description:
-                        - Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level.
-                        -  The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy.
+                        - Specifies the default account-level immutability policy which is inherited and
+                          applied to objects that do not possess an explicit immutability policy at the object level.
+                        - The object-level immutability policy has higher precedence than the container-level immutability policy,
+                          which has a higher precedence than the account-level immutability policy.
                     type: dict
                     returned: when-used
                     contains:
@@ -859,9 +861,10 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
             account_dict['immutable_storage_with_versioning']['enabled'] = account_obj.immutable_storage_with_versioning.enabled
             account_dict['immutable_storage_with_versioning']['immutability_policy'] = dict()
             if account_obj.immutable_storage_with_versioning.immutability_policy is not None:
-                account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = account_obj.immutable_storage_with_versioning.immutability_policy.immutability_period_since_creation_in_days
-                account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = account_obj.immutable_storage_with_versioning.immutability_policy.allow_protected_append_writes
-                account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = account_obj.immutable_storage_with_versioning.immutability_policy.state
+                ipc = account_obj.immutable_storage_with_versioning.immutability_policy
+                account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = ipc.immutability_period_since_creation_in_days
+                account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = ipc.allow_protected_append_writes
+                account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = ipc.state
         return account_dict
 
     def format_endpoint_dict(self, name, key, endpoint, storagetype, protocol='https'):

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -758,7 +758,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=dict()
+            immutable_storage_with_versioning=account_obj.immutable_storage_with_versioning.as_dict() if account_obj.immutable_storage_with_versioning else None
         )
 
         account_dict['geo_replication_stats'] = None
@@ -857,14 +857,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         account_dict['identity'] = dict()
         if account_obj.identity:
             account_dict['identity'] = account_obj.identity.as_dict()
-        if account_obj.immutable_storage_with_versioning is not None:
-            account_dict['immutable_storage_with_versioning']['enabled'] = account_obj.immutable_storage_with_versioning.enabled
-            account_dict['immutable_storage_with_versioning']['immutability_policy'] = dict()
-            if account_obj.immutable_storage_with_versioning.immutability_policy is not None:
-                ipc = account_obj.immutable_storage_with_versioning.immutability_policy
-                account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = ipc.immutability_period_since_creation_in_days
-                account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = ipc.allow_protected_append_writes
-                account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = ipc.state
+
         return account_dict
 
     def format_endpoint_dict(self, name, key, endpoint, storagetype, protocol='https'):

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -230,6 +230,47 @@ storageaccounts:
             type: bool
             returned: always
             sample: true
+        immutable_storage_with_versioning:
+            description:
+                - The property is immutable and can only be set to true at the account creation time.
+                - When set to true, it enables object level immutability for all the containers in the account by default.
+            type: complex
+            returned: when-used
+            contains:
+                enabled:
+                    description:
+                        - A boolean flag which enables account-level immutability.
+                        - All the containers under such an account have object-level immutability enabled by default.
+                    type: bool
+                    returned: when-used
+                    sample: true
+                immutability_policy:
+                    description:
+                        - Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level.
+                        -  The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy.
+                    type: dict
+                    returned: when-used
+                    contains:
+                        allow_protected_append_writes:
+                            description:
+                                - This property can only be changed for disabled and unlocked time-based retention policies.
+                                - When enabled, new blocks can be written to an append blob while maintaining immutability protection and compliance.
+                                - Only new blocks can be added and any existing blocks cannot be modified or deleted.
+                            type: bool
+                            returned: when-used
+                            sample: true
+                        state:
+                            description:
+                                - The ImmutabilityPolicy state defines the mode of the policy.
+                            type: str
+                            returned: when-used
+                            sample: Unlocked
+                        immutability_period_since_creation_in_days:
+                            description:
+                                - The immutability period for the blobs in the container since the policy creation, in days.
+                            type: int
+                            returned: when-used
+                            sample: true
         enable_nfs_v3:
             description:
                 - NFS 3.0 protocol.
@@ -715,6 +756,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 index_document=None,
                 error_document404_path=None,
             ),
+            immutable_storage_with_versioning=dict()
         )
 
         account_dict['geo_replication_stats'] = None
@@ -813,7 +855,13 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         account_dict['identity'] = dict()
         if account_obj.identity:
             account_dict['identity'] = account_obj.identity.as_dict()
-
+        if account_obj.immutable_storage_with_versioning is not None:
+            account_dict['immutable_storage_with_versioning']['enabled'] = account_obj.immutable_storage_with_versioning.enabled
+            account_dict['immutable_storage_with_versioning']['immutability_policy'] = dict()
+            if account_obj.immutable_storage_with_versioning.immutability_policy is not None:
+                account_dict['immutable_storage_with_versioning']['immutability_policy']['immutability_period_since_creation_in_days'] = account_obj.immutable_storage_with_versioning.immutability_policy.immutability_period_since_creation_in_days
+                account_dict['immutable_storage_with_versioning']['immutability_policy']['allow_protected_append_writes'] = account_obj.immutable_storage_with_versioning.immutability_policy.allow_protected_append_writes
+                account_dict['immutable_storage_with_versioning']['immutability_policy']['state'] = account_obj.immutable_storage_with_versioning.immutability_policy.state
         return account_dict
 
     def format_endpoint_dict(self, name, key, endpoint, storagetype, protocol='https'):

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -51,6 +51,8 @@
     - "{{ storage_account_name_default }}03"
     - "{{ storage_account_name_default }}04"
     - "{{ storage_account_name_default }}06"
+    - "{{ storage_account_name_default }}07"
+    - "{{ storage_account_name_default }}08"
 
 - name: Create new storage account with defaults (omitted parameters)
   azure_rm_storageaccount:
@@ -181,6 +183,76 @@
       - "output.storageaccounts | length == 1"
       - output.storageaccounts[0].is_hns_enabled == true
       - output.storageaccounts[0].large_file_shares_state == 'Enabled'
+
+- name: Create new storage account with immutable_storage_with_versioning
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account_name_default }}08"
+    account_type: Standard_GRS
+    kind: StorageV2
+    immutable_storage_with_versioning:
+      enabled: true
+      immutability_policy:
+        immutability_period_since_creation_in_days: 10
+        state: Disabled
+        allow_protected_append_writes: false
+  register: output
+
+- name: Assert the storage account well created
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Create new storage account with immutable_storage_with_versioning(Idempotent test)
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account_name_default }}08"
+    account_type: Standard_GRS
+    kind: StorageV2
+    immutable_storage_with_versioning:
+      enabled: true
+      immutability_policy:
+        immutability_period_since_creation_in_days: 10
+        state: Disabled
+        allow_protected_append_writes: false
+  register: output
+
+- name: Assert the storage account no change
+  ansible.builtin.assert:
+    that:
+      - not output.changed
+
+- name: Update the storage account with immutable_storage_with_versioning
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account_name_default }}08"
+    account_type: Standard_GRS
+    kind: StorageV2
+    immutable_storage_with_versioning:
+      enabled: true
+      immutability_policy:
+        immutability_period_since_creation_in_days: 20
+        state: Unlocked
+        allow_protected_append_writes: true
+  register: output
+
+- name: Assert the storage account well updated
+  ansible.builtin.assert:
+    that:
+      - output.changed
+
+- name: Gather facts of storage account
+  azure_rm_storageaccount_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storage_account_name_default }}08"
+  register: output
+
+- name: Assert the storage account facts
+  ansible.builtin.assert:
+    that:
+      - output.storageaccounts[0].immutable_storage_with_versioning.enabled is true
+      - output.storageaccounts[0].immutable_storage_with_versioning.immutability_policy.allow_protected_append_writes is true
+      - output.storageaccounts[0].immutable_storage_with_versioning.immutability_policy.state == 'Unlocked'
 
 - name: Create storage account with static website enabled
   azure_rm_storageaccount:
@@ -741,6 +813,7 @@
     - "{{ storage_account_name_default }}05"
     - "{{ storage_account_name_default }}06"
     - "{{ storage_account_name_default }}07"
+    - "{{ storage_account_name_default }}08"
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for `immutable_storage_with_versioning`, try to fixes #1799
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_storageaccount.py
azure_rm_storageaccount_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
