### PR TITLE
`azure_rm_roleassignment` - Delete scope tail `/` when comparing scopes

### DIFF
--- a/plugins/modules/azure_rm_roleassignment.py
+++ b/plugins/modules/azure_rm_roleassignment.py
@@ -335,7 +335,7 @@ class AzureRMRoleAssignment(AzureRMModuleBase):
                 if self.scope and self.assignee_object_id and self.role_definition_id:
                     response = list(self.authorization_client.role_assignments.list())
                     response = [self.roleassignment_to_dict(role_assignment) for role_assignment in response]
-                    response = [role_assignment for role_assignment in response if role_assignment.get('scope') == self.scope]
+                    response = [role_assignment for role_assignment in response if role_assignment.get('scope') == self.scope.rstrip("/")]
                     response = [role_assignment for role_assignment in response if role_assignment.get('assignee_object_id') == self.assignee_object_id]
                     response = [role_assignment for role_assignment in response if (role_assignment.get('role_definition_id').split('/')[-1].lower()
                                                                                     == self.role_definition_id.split('/')[-1].lower())]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Delete scope tail '/' when comparing scopes, try to fixes #1137 
The scope in the return value does not end with `/`, so the `/` in the configuration value is deleted when comparing.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_roleassignment.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
