### PR TITLE
`azure_rm_virtualmachine_info` Add `maintenance_redeploy_status`

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -206,6 +206,14 @@ vms:
             returned: always
             type: str
             sample: japaneast
+        maintenance_redeploy_status:
+            description:
+                - If maintenance is scheduled for this server set to something like example, otherwise empty dict
+            returned: always
+            type: dict
+            sample: { "is_customer_initiated_maintenance_allowed": true, "last_operation_result_code": "None", "maintenance_window_end_time":
+                    "2025-06-18T23:59:00.000Z", "maintenance_window_start_time": "2025-06-12T00:00:00.000Z", "pre_maintenance_window_end_time":
+                    "2025-06-11T23:30:00.000Z", "pre_maintenance_window_start_time": "2025-01-30T00:00:00.000Z" }
         name:
             description:
                 - Resource name.
@@ -498,6 +506,11 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
                 break
 
         new_result = {}
+
+        if instance.get('maintenance_redeploy_status') is not None:
+            new_result['maintenance_redeploy_status'] = instance['maintenance_redeploy_status']
+        else:
+            new_result['maintenance_redeploy_status'] = dict()
 
         if instance.get('vm_agent') is not None:
             new_result['vm_agent_version'] = instance['vm_agent'].get('vm_agent_version')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding an additional field to virtualmachine_info:
maintenance_redeploy_status - this is filled if there is scheduled maintenance for a virtual machine
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
azure_rm_virtualmachine_info

##### ADDITIONAL INFORMATION
will add a dict to response
`maintenance_redeploy_status: {}`
if no maintenance is scheduled for your VM

it will look like this:
```
"maintenance_redeploy_status": {
    "is_customer_initiated_maintenance_allowed": true,
    "last_operation_result_code": "None",
    "maintenance_window_end_time": "2025-06-18T23:59:00.000Z",
    "maintenance_window_start_time": "2025-06-12T00:00:00.000Z",
    "pre_maintenance_window_end_time": "2025-06-11T23:30:00.000Z",
    "pre_maintenance_window_start_time": "2025-01-30T00:00:00.000Z"
}
```
if there is a scheduled maintenance in the future. I am unsure where there is yet another timeformat in the response, normal for azure would be ticks (100ns precision) ...

