### PR TITLE
Add cache support to inventory plugin

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -258,7 +258,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._include_filters = self.get_option('include_host_filters')
 
         # Load results from Cache if requested
-        self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
 
         # cache may be True or False at this point to indicate if the inventory is being refreshed

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -20,6 +20,7 @@ DOCUMENTATION = r'''
       - azure.azcollection.azure
       - azure.azcollection.azure_rm
       - constructed
+      - inventory_cache
     description:
         - Query VM details from Azure Resource Manager
         - Requires a YAML configuration file whose name ends with 'azure_rm.(yml|yaml)'
@@ -154,7 +155,7 @@ except ImportError:
     from Queue import Queue, Empty
 
 from collections import namedtuple
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.six import iteritems
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from ansible.errors import AnsibleParserError, AnsibleError
@@ -202,8 +203,7 @@ class AzureRMRestConfiguration(Configuration):
 UrlAction = namedtuple('UrlAction', ['url', 'api_version', 'handler', 'handler_args'])
 
 
-# FUTURE: add Cacheable support once we have a sane serialization format
-class InventoryModule(BaseInventoryPlugin, Constructable):
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     NAME = 'azure.azcollection.azure_rm'
 
@@ -257,11 +257,59 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         self._include_filters = self.get_option('include_host_filters')
 
+        # Load results from Cache if requested
+        result_was_cached, results = self.get_cached_result(path, cache)
+
+        if not result_was_cached:
+            try:
+                self._credential_setup()
+                self._get_hosts()
+                results = self._serialize(self._hosts)
+            except Exception:
+                raise
+
+        self._populate(results)
+
+        # Store results to Cache if requested
+        self.update_cached_result(path, cache, results)
+
+    def _serialize(self, hosts):
+        results = []
+        for h in hosts:
+            results.append(dict(default_inventory_hostname=h.default_inventory_hostname,
+                                hostvars=h.hostvars))
+        return results
+
+    def get_cached_result(self, path, cache):
+        # false when refresh_cache or --flush-cache is used
+        if not cache:
+            return False, None
+        # get the user-specified directive
+        if not self.get_option("cache"):
+            return False, None
+
+        cache_key = self.get_cache_key(path)
         try:
-            self._credential_setup()
-            self._get_hosts()
-        except Exception:
-            raise
+            cached_value = self._cache[cache_key]
+        except KeyError:
+            # if cache expires or cache file doesn"t exist
+            return False, None
+
+        return True, cached_value
+
+    def update_cached_result(self, path, cache, result):
+        if not cache:
+            return
+
+        cache_key = self.get_cache_key(path)
+        # We weren't explicitly told to flush the cache, and there's already a cache entry,
+        # this means that the result we're being passed came from the cache.  As such we don't
+        # want to "update" the cache as that could reset a TTL on the cache entry.
+        if cache and cache_key in self._cache:
+            return
+
+        self._cache[cache_key] = result
+        self.set_cache_plugin()
 
     def _credential_setup(self):
         auth_source = environ.get('ANSIBLE_AZURE_AUTH_SOURCE', None) or self.get_option('auth_source')
@@ -367,6 +415,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         else:
             self._process_queue_serial()
 
+    def _populate(self, results):
         constructable_config_strict = boolean(self.get_option('fail_on_template_errors'))
         if self.get_option('hostvar_expressions') is not None:
             constructable_config_compose = self.get_option('hostvar_expressions')
@@ -377,25 +426,26 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         constructable_hostnames = self.get_option('hostnames')
 
-        for h in self._hosts:
+        for h in results:
+            hostvars = h.get("hostvars")
             # FUTURE: track hostnames to warn if a hostname is repeated (can happen for legacy and for composed inventory_hostname)
             inventory_hostname = self._get_hostname(h, hostnames=constructable_hostnames, strict=constructable_config_strict)
-            if self._filter_exclude_host(inventory_hostname, h.hostvars):
+            if self._filter_exclude_host(inventory_hostname, hostvars):
                 continue
-            if not self._filter_include_host(inventory_hostname, h.hostvars):
+            if not self._filter_include_host(inventory_hostname, hostvars):
                 continue
             self.inventory.add_host(inventory_hostname)
             # FUTURE: configurable default IP list? can already do this via hostvar_expressions
             self.inventory.set_variable(inventory_hostname, "ansible_host",
-                                        next(chain(h.hostvars['public_ipv4_address'], h.hostvars['private_ipv4_addresses']), None))
-            for k, v in iteritems(h.hostvars):
+                                        next(chain(hostvars['public_ipv4_address'], hostvars['private_ipv4_addresses']), None))
+            for k, v in iteritems(hostvars):
                 # FUTURE: configurable hostvar prefix? Makes docs harder...
                 self.inventory.set_variable(inventory_hostname, k, v)
 
             # constructable delegation
-            self._set_composite_vars(constructable_config_compose, h.hostvars, inventory_hostname, strict=constructable_config_strict)
-            self._add_host_to_composed_groups(constructable_config_groups, h.hostvars, inventory_hostname, strict=constructable_config_strict)
-            self._add_host_to_keyed_groups(constructable_config_keyed_groups, h.hostvars, inventory_hostname, strict=constructable_config_strict)
+            self._set_composite_vars(constructable_config_compose, hostvars, inventory_hostname, strict=constructable_config_strict)
+            self._add_host_to_composed_groups(constructable_config_groups, hostvars, inventory_hostname, strict=constructable_config_strict)
+            self._add_host_to_keyed_groups(constructable_config_keyed_groups, hostvars, inventory_hostname, strict=constructable_config_strict)
 
     # FUTURE: fix underlying inventory stuff to allow us to quickly access known groupvars from reconciled host
     def _filter_host(self, filter, inventory_hostname, hostvars):
@@ -426,9 +476,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         for preference in hostnames:
             if preference == 'default':
-                return host.default_inventory_hostname
+                return host.get("default_inventory_hostname")
             try:
-                hostname = self._compose(preference, host.hostvars)
+                hostname = self._compose(preference, host.get("hostvars"))
             except Exception as e:  # pylint: disable=broad-except
                 if strict:
                     raise AnsibleError("Could not compose %s as hostnames - %s" % (preference, to_native(e)))

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -258,20 +258,39 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._include_filters = self.get_option('include_host_filters')
 
         # Load results from Cache if requested
-        result_was_cached, results = self.get_cached_result(path, cache)
+        self.load_cache_plugin()
+        cache_key = self.get_cache_key(path)
 
-        if not result_was_cached:
+        # cache may be True or False at this point to indicate if the inventory is being refreshed
+        # get the user's cache option too to see if we should save the cache if it is changing
+        user_cache_setting = self.get_option('cache')
+
+        # read if the user has caching enabled and the cache isn't being refreshed
+        attempt_to_read_cache = user_cache_setting and cache
+        # update if the user has caching enabled and the cache is being refreshed;
+        # update this value to True if the cache has expired below
+        cache_needs_update = user_cache_setting and not cache
+
+        # attempt to read the cache if inventory isn't being refreshed and the user has caching enabled
+        if attempt_to_read_cache:
+            try:
+                results = self._cache[cache_key]
+            except KeyError:
+                # This occurs if the cache_key is not in the cache or if the cache_key
+                # expired, so the cache needs to be updated
+                cache_needs_update = True
+        if not attempt_to_read_cache or cache_needs_update:
+            # parse the provided inventory source
             try:
                 self._credential_setup()
                 self._get_hosts()
                 results = self._serialize(self._hosts)
             except Exception:
                 raise
+        if cache_needs_update:
+            self._cache[cache_key] = results
 
         self._populate(results)
-
-        # Store results to Cache if requested
-        self.update_cached_result(path, cache, results)
 
     def _serialize(self, hosts):
         results = []
@@ -279,37 +298,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             results.append(dict(default_inventory_hostname=h.default_inventory_hostname,
                                 hostvars=h.hostvars))
         return results
-
-    def get_cached_result(self, path, cache):
-        # false when refresh_cache or --flush-cache is used
-        if not cache:
-            return False, None
-        # get the user-specified directive
-        if not self.get_option("cache"):
-            return False, None
-
-        cache_key = self.get_cache_key(path)
-        try:
-            cached_value = self._cache[cache_key]
-        except KeyError:
-            # if cache expires or cache file doesn"t exist
-            return False, None
-
-        return True, cached_value
-
-    def update_cached_result(self, path, cache, result):
-        if not cache:
-            return
-
-        cache_key = self.get_cache_key(path)
-        # We weren't explicitly told to flush the cache, and there's already a cache entry,
-        # this means that the result we're being passed came from the cache.  As such we don't
-        # want to "update" the cache as that could reset a TTL on the cache entry.
-        if cache and cache_key in self._cache:
-            return
-
-        self._cache[cache_key] = result
-        self.set_cache_plugin()
 
     def _credential_setup(self):
         auth_source = environ.get('ANSIBLE_AZURE_AUTH_SOURCE', None) or self.get_option('auth_source')

--- a/tests/integration/targets/inventory_azure/playbooks/setup.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/setup.yml
@@ -54,6 +54,7 @@
       azure_rm_virtualmachine:
         resource_group: "{{ resource_group }}"
         name: "{{ vm_name_2 }}"
+        started: true
         admin_username: testuser
         ssh_password_enabled: false
         open_ports:

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_cache.yml
@@ -1,0 +1,47 @@
+---
+- name: Config hosts
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Set facts
+      ansible.builtin.include_vars: vars.yml
+
+    - name: Inventory powerstate is running
+      ansible.builtin.assert:
+        that:
+          - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "running"
+
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate
+
+    - name: Power off minimal VM 2
+      azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vm_name_2 }}"
+        started: false
+
+    - name: Inventory powerstate is still running
+      ansible.builtin.assert:
+        that:
+          - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "running"
+
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory
+
+    - name: Inventory powerstate is stopped
+      ansible.builtin.assert:
+        that:
+          - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "stopped"
+
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_1.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_1.yml
@@ -1,0 +1,34 @@
+---
+- name: Config hosts
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Set facts
+      ansible.builtin.include_vars: vars.yml
+
+    - name: Inventory powerstate is stopped
+      ansible.builtin.assert:
+        that:
+          - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "stopped"
+
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate
+
+    - name: Power on minimal VM 2
+      azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vm_name_2 }}"
+        started: true
+
+    - name: Inventory powerstate is still stopped
+      ansible.builtin.assert:
+        that:
+          - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "stopped"
+
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_2.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_2.yml
@@ -7,12 +7,12 @@
     - name: Set facts
       ansible.builtin.include_vars: vars.yml
 
-    - name: Test vm_name_2 in Inventory
+    - name: Inventory powerstate is stopped (cache)
       ansible.builtin.assert:
         that:
           - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "stopped"
 
-    - name: Test vm_name not in Inventory
-      ansible.builtin.assert:
-        that:
-          - vm_name not in hostvars
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_3.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_3.yml
@@ -7,12 +7,12 @@
     - name: Set facts
       ansible.builtin.include_vars: vars.yml
 
-    - name: Test vm_name_2 in Inventory
+    - name: Inventory powerstate is running
       ansible.builtin.assert:
         that:
           - vm_name_2 in hostvars
+          - hostvars[vm_name_2].powerstate == "running"
 
-    - name: Test vm_name not in Inventory
-      ansible.builtin.assert:
-        that:
-          - vm_name not in hostvars
+    - name: Show powerstate
+      ansible.builtin.debug:
+        var: hostvars[vm_name_2].powerstate

--- a/tests/integration/targets/inventory_azure/runme.sh
+++ b/tests/integration/targets/inventory_azure/runme.sh
@@ -24,6 +24,15 @@ ansible-playbook playbooks/empty_inventory_config.yml "$@"
 ansible-playbook playbooks/create_inventory_config.yml "$@"  --extra-vars "template=filter.yml"
 ansible-playbook playbooks/test_inventory_filter.yml "$@"
 
+# using cache
+ansible-playbook playbooks/empty_inventory_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml "$@"  --extra-vars "template=cache.yml"
+ansible-playbook playbooks/test_inventory_cache.yml "$@"
+ansible-playbook playbooks/test_inventory_flush_part_1.yml "$@"
+ansible-playbook playbooks/test_inventory_flush_part_2.yml "$@"
+ansible-playbook --flush-cache playbooks/test_inventory_flush_part_3.yml "$@"
+ansible-playbook playbooks/test_inventory_flush_part_3.yml "$@"
+
 
 # teardown
 ansible-playbook playbooks/teardown.yml "$@"

--- a/tests/integration/targets/inventory_azure/templates/cache.yml
+++ b/tests/integration/targets/inventory_azure/templates/cache.yml
@@ -1,0 +1,14 @@
+---
+plugin: azure.azcollection.azure_rm
+conditional_groups:
+  azure: true
+exclude_host_filters:
+  - location not in ['eastus', 'northcentralus']
+default_host_filters: []
+# fail_on_template_errors should be enabled for debugging and possibly all times.
+fail_on_template_errors: True
+plain_host_names: true
+cache: true
+cache_plugin: ansible.builtin.jsonfile
+cache_timeout: 7200
+cache_connection: /tmp/azure_inventory


### PR DESCRIPTION
##### SUMMARY
The default cache_plugin is memory which won't really help. Change to jsonfile to cache on disk.

cache: true
cache_plugin: ansible.builtin.jsonfile
cache_timeout: 7200
cache_connection: /tmp/azure_inventory

Fixes #700 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION

Even with just 3 hosts we see a time savings

```paste below
(venv-azure-3.11) [admin@okd-master-1 inventory]$ time ansible-inventory -i arc_azure_rm.yml --graph -v
No config file found; using defaults
Using inventory plugin 'ansible_collections.azure.azcollection.plugins.inventory.azure_rm' to process inventory source '/home/admin/inventory/arc_azure_rm.yml'
@all:
  |--@ungrouped:
  |  |--devtools-win11-runner
  |  |--ubuntu-24.04-amd64-azure
  |  |--w11

real	0m3.306s
user	0m2.320s
sys	0m0.181s
(venv-azure-3.11) [admin@okd-master-1 inventory]$ time ansible-inventory -i arc_azure_rm.yml --graph -v
No config file found; using defaults
Using inventory plugin 'ansible_collections.azure.azcollection.plugins.inventory.azure_rm' to process inventory source '/home/admin/inventory/arc_azure_rm.yml'
@all:
  |--@ungrouped:
  |  |--devtools-win11-runner
  |  |--ubuntu-24.04-amd64-azure
  |  |--w11

real	0m2.403s
user	0m2.217s
sys	0m0.169s

```
