### PR TITLE
Set the timeout period for creating an Image Version

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -219,6 +219,11 @@ options:
                 choices:
                     - Standard_LRS
                     - Standard_ZRS
+    timeout:
+        description:
+            - Set the timeout period for creating an Image Version (unit: minute).
+        type: int
+        default: 10
     state:
         description:
             - Assert the state of the GalleryImageVersion.
@@ -503,6 +508,10 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                     )
                 )
             ),
+            timeout=dict(
+                type='int',
+                default=10
+            ),
             state=dict(
                 type='str',
                 default='present',
@@ -516,6 +525,7 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
         self.name = None
         self.gallery_image_version = None
         self.tags = None
+        self.timeout = None
 
         self.results = dict(changed=False)
         self.mgmt_client = None
@@ -860,7 +870,7 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
             time.sleep(60)
             response = self.get_resource()
             i = i + 1
-            if i == 10:
+            if i == self.timeout:
                 self.fail("Create or Updating encountered an exception, wait 10 minutes when the status is still 'creating'")
 
         return response

--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -221,7 +221,7 @@ options:
                     - Standard_ZRS
     timeout:
         description:
-            - Set the timeout period for creating an Image Version (unit: minute).
+            - Set the timeout (minute) period for creating an Image Version.
         type: int
         default: 10
     state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set the timeout period for creating an Image Version (unit: minute)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_galleryimageversion.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
