### PR TITLE
Adding field notes to azure_rm_adapplication

### DIFF
--- a/plugins/modules/azure_rm_adapplication.py
+++ b/plugins/modules/azure_rm_adapplication.py
@@ -132,6 +132,11 @@ options:
             - An application which can be installed on a user's device or computer.
         type: bool
 
+    notes:
+        description:
+            - Notes relevant for the management of the application.
+        type: str
+
     oauth2_allow_implicit_flow:
         description:
             - Whether to allow implicit grant flow for OAuth2.
@@ -547,6 +552,7 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
             key_usage=dict(type='str', default='Verify', choices=['Sign', 'Verify']),
             key_value=dict(type='str', no_log=True),
             native_app=dict(type='bool'),
+            notes=dict(type='str'),
             oauth2_allow_implicit_flow=dict(type='bool'),
             optional_claims=dict(
                 type='dict',
@@ -577,6 +583,7 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
         self.key_usage = None
         self.key_value = None
         self.native_app = None
+        self.notes = None
         self.oauth2_allow_implicit_flow = None
         self.optional_claims = None
         self.password = None
@@ -649,6 +656,7 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 display_name=self.display_name,
                 identifier_uris=self.identifier_uris,
                 key_credentials=key_creds,
+                notes=self.notes,
                 password_credentials=password_creds,
                 required_resource_access=required_accesses,
                 app_roles=app_roles,
@@ -696,6 +704,7 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 display_name=self.display_name,
                 identifier_uris=self.identifier_uris,
                 key_credentials=key_creds,
+                notes=self.notes,
                 password_credentials=password_creds,
                 required_resource_access=required_accesses,
                 # allow_guests_sign_in=self.allow_guests_sign_in,
@@ -774,6 +783,7 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
             sign_in_audience=object.sign_in_audience,
             homepage=object.web.home_page_url,
             identifier_uris=object.identifier_uris,
+            notes=object.notes,
             oauth2_allow_implicit_flow=object.web.implicit_grant_settings.enable_access_token_issuance,
             optional_claims=optional_claims,
             # allow_guests_sign_in=object.allow_guests_sign_in,

--- a/plugins/modules/azure_rm_adapplication_info.py
+++ b/plugins/modules/azure_rm_adapplication_info.py
@@ -228,6 +228,12 @@ app_diff:
             returned: always
             type: str
             sample: absent
+        notes:
+            description:
+                - Notes relevant for the management of the application.
+            type: str
+            returned: always
+            sample: "Test value"
         optional_claims:
             description:
                 - Declare the optional claims for the application.
@@ -344,6 +350,7 @@ class AzureRMADApplicationInfo(AzureRMModuleBase):
             object_id=object.id,
             app_display_name=object.display_name,
             identifier_uris=object.identifier_uris,
+            notes=object.notes,
             sign_in_audience=object.sign_in_audience,
             web_reply_urls=object.web.redirect_uris,
             spa_reply_urls=object.spa.redirect_uris,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding the field **notes** from Graph API documentation (https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0#properties)  to support adding Internal notes to a registered app.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_adapplication

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
In Azure Portal, per registered app, an internal note can be set for additional information. Setting this was not possible via Ansible.
![Ansible_screenshot](https://github.com/user-attachments/assets/989b8bf7-e610-4783-88ce-831c54143bde)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
    - name: Create Azure AD Application
      azure.azcollection.azure_rm_adapplication:
        display_name: "{{ display_name }}"
        tenant: "{{ tenant }}"
        auth_source: cli
        subscription_id: "{{ subscription_id }}"
        notes: "Created via Ansible"

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
ok: [localhost] => {
    "msg": {
        "app_id": "<app id>",
        "app_roles": [],
        "changed": true,
        "display_name": "Ansible created app registration",
        "failed": false,
        "homepage": null,
        "identifier_uris": [],
        "oauth2_allow_implicit_flow": false,
        "object_id": "<object id>",
        "optional_claims": null,
        "public_client_reply_urls": [],
        "sign_in_audience": "AzureADMyOrg",
        "spa_reply_urls": [],
        "web_reply_urls": []
    }
}

After:
ok: [localhost] => {
    "msg": {
        "app_id": "<app id>",
        "app_roles": [],
        "changed": true,
        "display_name": "Ansible created app registration",
        "failed": false,
        "homepage": null,
        "identifier_uris": [],
        **"notes": "Created via Ansible",**
        "oauth2_allow_implicit_flow": false,
        "object_id": "<object id>",
        "optional_claims": null,
        "public_client_reply_urls": [],
        "sign_in_audience": "AzureADMyOrg",
        "spa_reply_urls": [],
        "web_reply_urls": []
    }
}
