### PR TITLE
Support alternative MSGraph cloud endpoints

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -287,7 +287,7 @@ try:
     import azure.mgmt.datafactory.models as DataFactoryModel
     from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
     from azure.identity import AzureCliCredential
-    from kiota_authentication_azure.azureidentity_authentication_provider import AzureIdentityAuthenticationProvider
+    from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
     from msgraph_core import GraphClientFactory, NationalClouds
     from msgraph import GraphRequestAdapter, GraphServiceClient
     from azure.mgmt.batch import BatchManagementClient

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -287,7 +287,9 @@ try:
     import azure.mgmt.datafactory.models as DataFactoryModel
     from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
     from azure.identity import AzureCliCredential
-    from msgraph import GraphServiceClient
+    from kiota_authentication_azure.azureidentity_authentication_provider import AzureIdentityAuthenticationProvider
+    from msgraph_core import GraphClientFactory, NationalClouds
+    from msgraph import GraphRequestAdapter, GraphServiceClient
     from azure.mgmt.batch import BatchManagementClient
     from azure.mgmt.batch import models as BatchManagementModel
     from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
@@ -910,7 +912,16 @@ class AzureRMModuleBase(object):
     #    return client
 
     def get_msgraph_client(self):
-        return GraphServiceClient(self.azure_auth.azure_credential_track2)
+        auth_provider = AzureIdentityAuthenticationProvider(self.azure_auth.azure_credential_track2)
+        cloud_mapping = {
+            azure_cloud.AZURE_CHINA_CLOUD: NationalClouds.China,
+            azure_cloud.AZURE_US_GOV_CLOUD: NationalClouds.US_GOV,
+            azure_cloud.AZURE_GERMAN_CLOUD: NationalClouds.Germany
+        }
+        host = cloud_mapping.get(self._cloud_environment, NationalClouds.Global)
+        client = GraphClientFactory.create_with_default_middleware(host=host)
+        request_adapter = GraphRequestAdapter(auth_provider, client=client)
+        return GraphServiceClient(self.azure_auth.azure_credential_track2, request_adapter)
 
     def get_mgmt_svc_client(self, client_type, base_url=None, api_version=None, suppress_subscription_id=False):
         self.log('Getting management service client {0}'.format(client_type.__name__))

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -921,7 +921,7 @@ class AzureRMModuleBase(object):
         host = cloud_mapping.get(self._cloud_environment, NationalClouds.Global)
         client = GraphClientFactory.create_with_default_middleware(host=host)
         request_adapter = GraphRequestAdapter(auth_provider, client=client)
-        return GraphServiceClient(self.azure_auth.azure_credential_track2, request_adapter)
+        return GraphServiceClient(self.azure_auth.azure_credential_track2, request_adapter=request_adapter)
 
     def get_mgmt_svc_client(self, client_type, base_url=None, api_version=None, suppress_subscription_id=False):
         self.log('Getting management service client {0}'.format(client_type.__name__))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The MSGraph library defaults to the Global endpoint. Some environments live in restricted networks that may only talk to their respective cloud endpoints. This maps a user's cloud_environment choice to the correct MSGraph endpoint.

Required for modules that talk to Entra.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
