### PR TITLE
Indirect node count query file

### DIFF
--- a/extensions/audit/README.MD
+++ b/extensions/audit/README.MD
@@ -1,0 +1,47 @@
+# Indirect Node Counts in Ansible Collections
+
+## Overview
+
+In the context of Ansible automation, **indirect node counts** refer to the practice of calculating or verifying the capacity or availability of computing nodes **through external systems or controllers**, rather than directly querying the nodes themselves. This approach is especially useful in complex, public cloud, or on prem environments .
+
+This file explains:
+- What indirect node counts are
+- Why they are required
+- What they enable
+- Their value
+
+## What Are Indirect Node Counts?
+
+Rather than connecting directly to each node to assess its state  of automation(e.g., Service, DB, VM, etc), **indirect node counts** leverage tools like ** APIs**, or other management layers to obtain usage information.
+
+In an Ansible role or collection, this might involve:
+- Querying a cloud service for the list of DBs or VMs and their status of if they are being automated
+
+## Why Are They Required?
+
+Directly connecting to every node:
+- Is **inefficient** in large-scale environments
+- May be **prohibited** due to security, network segmentation, or policy
+- **Doesn't scale** across multiple clusters or providers
+- Often leads to **incomplete or stale data**
+
+Using indirect node counts via cluster managers:
+- Enables **centralized insight** into resource usage
+- Works well in **managed or disconnected environments**
+- Allows **non-invasive** assessment (e.g., read-only API access)
+
+## What Does It Do?
+
+In practical terms, using indirect node counts in an Ansible collection:
+- Enables **guardrails** to verify into knowing what you are automating
+- Reduces operational risk and improves **predictability** of automation workflows
+
+## Why This Is a Good Practice
+
+| Benefit | Description |
+|--------|-------------|
+| ✅ Scalable | Works across many clusters and environments |
+| ✅ Secure | Limits direct access to sensitive nodes |
+| ✅ Efficient | Avoids per-node polling, uses cached or aggregated data |
+| ✅ Integrated | Leverages our existing Certified and Validated collections |
+| ✅ Reliable | Provides consistent data source for automation decisions |

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,0 +1,62 @@
+---
+azure.azcollection.*:
+  query: >-
+    (
+      {"apimanagement": "MGMT",
+       "authorization": "SECURITY",
+       "automation": "MGMT",
+       "batch": "MGMT",
+       "cache": "DATABASE",
+       "cdn": "CDN",
+       "classiccompute": "COMPUTE",
+       "compute": "COMPUTE",
+       "containerinstance": "CONTAINERS",
+       "containerregistry": "CONTAINERS",
+       "containerservice": "CONTAINERS",
+       "datafactory": "STORAGE",
+       "dbformariadb": "DATABASE",
+       "dbformysql": "DATABASE",
+       "dbforpostgresql": "DATABASE",
+       "devices": "DEVICES",
+       "documentdb": "DATABASE",
+       "eventhub": "ANALYTICS",
+       "hdinsight": "ANALYTICS",
+       "insights": "ANALYTICS",
+       "keyvault": "SECURITY",
+       "maintenance": "MGMT",
+       "managedidentity": "MGMT",
+       "managedservices": "SERVICES",
+       "management": "MGMT",
+       "network": "NETWORK",
+       "operationalinsights": "ANALYTICS",
+       "recoveryservices": "STORAGE",
+       "redhatopenshift": "CONTAINERS",
+       "resources": "UNKNOWN",
+       "servicebus": "SERVICES",
+       "sql": "DATABASE",
+       "storage": "STORAGE",
+       "web": "WEB"
+      } as $mapping |
+      (.aks_agent_pools // .ansible_facts.azure_vm // .ansible_facts.azure_vmss // .bastion_host // .connection // .database // .deployment // .elastic_pool // .firewall_policy // .firewall_rule // .instances // .ip_security_restrictions // .link_service // .long_term_retention_policy // .response // .state // .short_term_retention_policy // .) |
+      (if type=="array" then .[]
+        else if type=="object" then .
+              else empty end
+       end
+       ) as $data |
+        (
+          ($data.id | capture("/providers/[Mm]icrosoft.(?<resourcetype>[^/]+)/")? | .resourcetype)
+            | ascii_downcase
+        ) as $node_type |
+        select($data.id != null) |
+        {
+          name: $data.id,
+          canonical_facts: {
+            id: $data.id
+          },
+          facts: {
+            name: ($data.name // "UNKNOWN"),
+            node_type: $node_type,
+            device_type: ($mapping[$node_type] // "UNKNOWN")
+          }
+        }
+    )


### PR DESCRIPTION

##### SUMMARY
Indirect node count query file used to count resources behind a cloud provider.  Included README.MD explains in great detail why this is needed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
No specifific component.

##### ADDITIONAL INFORMATION
This event_query file is used by Ansible Automation Platform.  It allows for the tracking of resources in cloud providers.