### PR TITLE
fix: Correct spelling for VM info property identity

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -317,7 +317,7 @@ vms:
             returned: always
             type: str
             sample: running
-        idenity:
+        identity:
             description:
                 - The identity of the virtual machine.
             type: dict
@@ -556,7 +556,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
         new_result['proximityPlacementGroup'] = result.get('proximity_placement_group')
         new_result['zones'] = result.get('zones', None)
         new_result['additional_capabilities'] = result.get('additional_capabilities')
-        new_result['idenity'] = result.get('identity')
+        new_result['identity'] = result.get('identity')
         new_result['capacity_reservation'] = dict()
         if result.get('capacity_reservation') is not None:
             new_result['capacity_reservation']['capacity_reservation_group'] = result.get('capacity_reservation', {}).get('capacity_reservation_group')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The virtual machine info module returns an `idenity` property instead of `identity`.
Functionality was introduced in https://github.com/ansible-collections/azure/pull/1674

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
