### PR TITLE
Remove deprectaed code since ansible-2.9 has been EOL

### DIFF
--- a/plugins/modules/azure_rm_aks_info.py
+++ b/plugins/modules/azure_rm_aks_info.py
@@ -119,10 +119,6 @@ class AzureRMManagedClusterInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_aks_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_aks_facts' module has been renamed to 'azure_rm_aks_info'", version=(2.9, ))
-
         for key in self.module_args:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_aksversion_info.py
+++ b/plugins/modules/azure_rm_aksversion_info.py
@@ -96,10 +96,6 @@ class AzureRMAKSVersion(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_aksversion_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_aksversion_facts' module has been renamed to 'azure_rm_aksversion_info'", version=(2.9, ))
-
         for key in self.module_args:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_applicationsecuritygroup_info.py
+++ b/plugins/modules/azure_rm_applicationsecuritygroup_info.py
@@ -134,11 +134,6 @@ class AzureRMApplicationSecurityGroupInfo(AzureRMModuleBase):
     def exec_module(self, **kwargs):
         """Main module execution method"""
 
-        is_old_facts = self.module._name == 'azure_rm_applicationsecuritygroup_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_applicationsecuritygroup_facts' module has been renamed to 'azure_rm_applicationsecuritygroup_info'",
-                                  version=(2.9, ))
-
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             if hasattr(self, key):
                 setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_appserviceplan_info.py
+++ b/plugins/modules/azure_rm_appserviceplan_info.py
@@ -153,10 +153,6 @@ class AzureRMAppServicePlanInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_appserviceplan_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_appserviceplan_facts' module has been renamed to 'azure_rm_appserviceplan_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_automationaccount_info.py
+++ b/plugins/modules/azure_rm_automationaccount_info.py
@@ -282,10 +282,6 @@ class AzureRMAutomationAccountInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_automationaccount_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_automationaccount_facts' module has been renamed to 'azure_rm_automationaccount_info'", version=(2.9, ))
-
         for key in list(self.module_arg_spec):
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_autoscale_info.py
+++ b/plugins/modules/azure_rm_autoscale_info.py
@@ -245,10 +245,6 @@ class AzureRMAutoScaleInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_autoscale_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_autoscale_facts' module has been renamed to 'azure_rm_autoscale_info'", version=(2.9, ))
-
         for key in list(self.module_arg_spec):
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_availabilityset_info.py
+++ b/plugins/modules/azure_rm_availabilityset_info.py
@@ -149,10 +149,6 @@ class AzureRMAvailabilitySetInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_availabilityset_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_availabilityset_facts' module has been renamed to 'azure_rm_availabilityset_info'", version=(2.9, ))
-
         for key in self.module_args:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_cdnendpoint_info.py
+++ b/plugins/modules/azure_rm_cdnendpoint_info.py
@@ -216,10 +216,6 @@ class AzureRMCdnEndpointInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_cdnendpoint_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_cdnendpoint_facts' module has been renamed to 'azure_rm_cdnendpoint_info'", version=(2.9, ))
-
         for key in self.module_args:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_cdnprofile_info.py
+++ b/plugins/modules/azure_rm_cdnprofile_info.py
@@ -149,10 +149,6 @@ class AzureRMCdnprofileInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_cdnprofile_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_cdnprofile_facts' module has been renamed to 'azure_rm_cdnprofile_info'", version=(2.9, ))
-
         for key in self.module_args:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_containerinstance_info.py
+++ b/plugins/modules/azure_rm_containerinstance_info.py
@@ -267,10 +267,6 @@ class AzureRMContainerInstanceInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_containerinstance_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_containerinstance_facts' module has been renamed to 'azure_rm_containerinstance_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_containerregistry_info.py
+++ b/plugins/modules/azure_rm_containerregistry_info.py
@@ -199,10 +199,6 @@ class AzureRMContainerRegistryInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_containerregistry_info'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_containerregistry_facts' module has been renamed to 'azure_rm_containerregistry_info'", version=(2.9, ))
-
         for key in list(self.module_arg_spec) + ['tags']:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_cosmosdbaccount_info.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount_info.py
@@ -424,10 +424,6 @@ class AzureRMCosmosDBAccountInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_cosmosdbaccount_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_cosmosdbaccount_facts' module has been renamed to 'azure_rm_cosmosdbaccount_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
         self.mgmt_client = self.get_mgmt_svc_client(CosmosDBManagementClient,

--- a/plugins/modules/azure_rm_deployment_info.py
+++ b/plugins/modules/azure_rm_deployment_info.py
@@ -155,10 +155,6 @@ class AzureRMDeploymentInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_deployment_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_deployment_facts' module has been renamed to 'azure_rm_deployment_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_devtestlab_info.py
+++ b/plugins/modules/azure_rm_devtestlab_info.py
@@ -177,9 +177,6 @@ class AzureRMDevTestLabInfo(AzureRMModuleBase):
         super(AzureRMDevTestLabInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlab_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlab_facts' module has been renamed to 'azure_rm_devtestlab_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabarmtemplate_info.py
+++ b/plugins/modules/azure_rm_devtestlabarmtemplate_info.py
@@ -154,10 +154,6 @@ class AzureRMDtlArmTemplateInfo(AzureRMModuleBase):
         super(AzureRMDtlArmTemplateInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabarmtemplate_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabarmtemplate_facts' module has been renamed to 'azure_rm_devtestlabarmtemplate_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabartifactsource_info.py
+++ b/plugins/modules/azure_rm_devtestlabartifactsource_info.py
@@ -177,10 +177,6 @@ class AzureRMDtlArtifactSourceInfo(AzureRMModuleBase):
         super(AzureRMDtlArtifactSourceInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabartifactsource_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabartifactsource_facts' module has been renamed to 'azure_rm_devtestlabartifactsource_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabcustomimage_info.py
+++ b/plugins/modules/azure_rm_devtestlabcustomimage_info.py
@@ -154,10 +154,6 @@ class AzureRMDtlCustomImageInfo(AzureRMModuleBase):
         super(AzureRMDtlCustomImageInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabcustomimage_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabcustomimage_facts' module has been renamed to 'azure_rm_devtestlabcustomimage_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabenvironment_info.py
+++ b/plugins/modules/azure_rm_devtestlabenvironment_info.py
@@ -167,10 +167,6 @@ class AzureRMDtlEnvironmentInfo(AzureRMModuleBase):
         super(AzureRMDtlEnvironmentInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabenvironment_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabenvironment_facts' module has been renamed to 'azure_rm_devtestlabenvironment_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabpolicy_info.py
+++ b/plugins/modules/azure_rm_devtestlabpolicy_info.py
@@ -166,9 +166,6 @@ class AzureRMDtlPolicyInfo(AzureRMModuleBase):
         super(AzureRMDtlPolicyInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabpolicy_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabpolicy_facts' module has been renamed to 'azure_rm_devtestlabpolicy_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabschedule_info.py
+++ b/plugins/modules/azure_rm_devtestlabschedule_info.py
@@ -150,9 +150,6 @@ class AzureRMDtlScheduleInfo(AzureRMModuleBase):
         super(AzureRMDtlScheduleInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabschedule_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabschedule_facts' module has been renamed to 'azure_rm_devtestlabschedule_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabvirtualmachine_info.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualmachine_info.py
@@ -251,10 +251,6 @@ class AzureRMDtlVirtualMachineInfo(AzureRMModuleBase):
         super(AzureRMDtlVirtualMachineInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabvirtualmachine_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabvirtualmachine_facts' module has been renamed to 'azure_rm_devtestlabvirtualmachine_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_devtestlabvirtualnetwork_info.py
+++ b/plugins/modules/azure_rm_devtestlabvirtualnetwork_info.py
@@ -144,10 +144,6 @@ class AzureRMDevTestLabVirtualNetworkInfo(AzureRMModuleBase):
         super(AzureRMDevTestLabVirtualNetworkInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_devtestlabvirtualnetwork_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_devtestlabvirtualnetwork_facts' module has been renamed to 'azure_rm_devtestlabvirtualnetwork_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_dnsrecordset_info.py
+++ b/plugins/modules/azure_rm_dnsrecordset_info.py
@@ -203,10 +203,6 @@ class AzureRMRecordSetInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_dnsrecordset_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_dnsrecordset_facts' module has been renamed to 'azure_rm_dnsrecordset_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
@@ -231,10 +227,6 @@ class AzureRMRecordSetInfo(AzureRMModuleBase):
             # if there is a zone name listed, then they want all the record sets in a zone
             results = self.list_zone()
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_dnsrecordset': self.serialize_list(results)
-            }
         self.results['dnsrecordsets'] = self.curated_list(results)
         return self.results
 

--- a/plugins/modules/azure_rm_dnszone_info.py
+++ b/plugins/modules/azure_rm_dnszone_info.py
@@ -163,10 +163,6 @@ class AzureRMDNSZoneInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_dnszone_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_dnszone_facts' module has been renamed to 'azure_rm_dnszone_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_functionapp_info.py
+++ b/plugins/modules/azure_rm_functionapp_info.py
@@ -134,10 +134,6 @@ class AzureRMFunctionAppInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_functionapp_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_functionapp_facts' module has been renamed to 'azure_rm_functionapp_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_hdinsightcluster_info.py
+++ b/plugins/modules/azure_rm_hdinsightcluster_info.py
@@ -221,11 +221,6 @@ class AzureRMHDInsightclusterInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_hdinsightcluster_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_hdinsightcluster_facts' module has been renamed to 'azure_rm_hdinsightcluster_info'",
-                                  version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
         self.mgmt_client = self.get_mgmt_svc_client(HDInsightManagementClient,

--- a/plugins/modules/azure_rm_image_info.py
+++ b/plugins/modules/azure_rm_image_info.py
@@ -232,10 +232,6 @@ class AzureRMImageInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_image_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_image_facts' module has been renamed to 'azure_rm_image_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_loadbalancer_info.py
+++ b/plugins/modules/azure_rm_loadbalancer_info.py
@@ -152,10 +152,6 @@ class AzureRMLoadBalancerInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_loadbalancer_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_loadbalancer_facts' module has been renamed to 'azure_rm_loadbalancer_info'", version=(2.9, ))
-
         for key in self.module_args:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_lock_info.py
+++ b/plugins/modules/azure_rm_lock_info.py
@@ -151,10 +151,6 @@ class AzureRMLockInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_lock_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_lock_facts' module has been renamed to 'azure_rm_lock_info'", version=(2.9, ))
-
         for key in self.module_arg_spec.keys():
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_loganalyticsworkspace_info.py
+++ b/plugins/modules/azure_rm_loganalyticsworkspace_info.py
@@ -181,11 +181,6 @@ class AzureRMLogAnalyticsWorkspaceInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_loganalyticsworkspace_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_loganalyticsworkspace_facts' module has been renamed to 'azure_rm_loganalyticsworkspace_info'",
-                                  version=(2.9, ))
-
         for key in list(self.module_arg_spec.keys()):
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_mariadbconfiguration_info.py
+++ b/plugins/modules/azure_rm_mariadbconfiguration_info.py
@@ -127,9 +127,6 @@ class AzureRMMariaDbConfigurationInfo(AzureRMModuleBase):
         super(AzureRMMariaDbConfigurationInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mariadbconfiguration_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mariadbconfiguration_facts' module has been renamed to 'azure_rm_mariadbconfiguration_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mariadbdatabase_info.py
+++ b/plugins/modules/azure_rm_mariadbdatabase_info.py
@@ -135,9 +135,6 @@ class AzureRMMariaDbDatabaseInfo(AzureRMModuleBase):
         super(AzureRMMariaDbDatabaseInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mariadbdatabase_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mariadbdatabase_facts' module has been renamed to 'azure_rm_mariadbdatabase_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mariadbfirewallrule_info.py
+++ b/plugins/modules/azure_rm_mariadbfirewallrule_info.py
@@ -129,9 +129,6 @@ class AzureRMMariaDbFirewallRuleInfo(AzureRMModuleBase):
         super(AzureRMMariaDbFirewallRuleInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mariadbfirewallrule_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mariadbfirewallrule_facts' module has been renamed to 'azure_rm_mariadbfirewallrule_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mariadbserver_info.py
+++ b/plugins/modules/azure_rm_mariadbserver_info.py
@@ -187,9 +187,6 @@ class AzureRMMariaDbServerInfo(AzureRMModuleBase):
         super(AzureRMMariaDbServerInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mariadbserver_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mariadbserver_facts' module has been renamed to 'azure_rm_mariadbserver_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mysqlconfiguration_info.py
+++ b/plugins/modules/azure_rm_mysqlconfiguration_info.py
@@ -125,9 +125,6 @@ class AzureRMMySqlConfigurationInfo(AzureRMModuleBase):
         super(AzureRMMySqlConfigurationInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mysqlconfiguration_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mysqlconfiguration_facts' module has been renamed to 'azure_rm_mysqlconfiguration_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mysqldatabase_info.py
+++ b/plugins/modules/azure_rm_mysqldatabase_info.py
@@ -133,9 +133,6 @@ class AzureRMMySqlDatabaseInfo(AzureRMModuleBase):
         super(AzureRMMySqlDatabaseInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mysqldatabase_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mysqldatabase_facts' module has been renamed to 'azure_rm_mysqldatabase_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mysqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_mysqlfirewallrule_info.py
@@ -127,9 +127,6 @@ class AzureRMMySqlFirewallRuleInfo(AzureRMModuleBase):
         super(AzureRMMySqlFirewallRuleInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mysqlfirewallrule_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mysqlfirewallrule_facts' module has been renamed to 'azure_rm_mysqlfirewallrule_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_mysqlserver_info.py
+++ b/plugins/modules/azure_rm_mysqlserver_info.py
@@ -209,9 +209,6 @@ class AzureRMMySqlServerInfo(AzureRMModuleBase):
         super(AzureRMMySqlServerInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_mysqlserver_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_mysqlserver_facts' module has been renamed to 'azure_rm_mysqlserver_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_networkinterface_info.py
+++ b/plugins/modules/azure_rm_networkinterface_info.py
@@ -359,11 +359,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_networkinterface_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_networkinterface_facts' module has been renamed to 'azure_rm_networkinterface_info'",
-                                  version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
@@ -379,10 +374,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         else:
             results = self.list_all()
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_networkinterfaces': self.serialize_nics(results)
-            }
         self.results['networkinterfaces'] = self.to_dict_list(results)
         return self.results
 
@@ -411,9 +402,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             return [item for item in response if self.has_tags(item.tags, self.tags)]
         except ResourceNotFoundError as exc:
             self.fail("Error listing all - {0}".format(str(exc)))
-
-    def serialize_nics(self, raws):
-        return [self.serialize_obj(item, AZURE_OBJECT_CLASS) for item in raws] if raws else []
 
     def to_dict_list(self, raws):
         return [nic_to_dict(item) for item in raws] if raws else []

--- a/plugins/modules/azure_rm_postgresqlconfiguration_info.py
+++ b/plugins/modules/azure_rm_postgresqlconfiguration_info.py
@@ -127,10 +127,6 @@ class AzureRMPostgreSQLConfigurationInfo(AzureRMModuleBase):
         super(AzureRMPostgreSQLConfigurationInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_postgresqlconfiguration_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_postgresqlconfiguration_facts' module has been renamed to 'azure_rm_postgresqlconfiguration_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_postgresqldatabase_info.py
+++ b/plugins/modules/azure_rm_postgresqldatabase_info.py
@@ -133,9 +133,6 @@ class AzureRMPostgreSqlDatabasesInfo(AzureRMModuleBase):
         super(AzureRMPostgreSqlDatabasesInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_postgresqldatabase_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_postgresqldatabase_facts' module has been renamed to 'azure_rm_postgresqldatabase_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_postgresqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_postgresqlfirewallrule_info.py
@@ -127,10 +127,6 @@ class AzureRMPostgreSQLFirewallRulesInfo(AzureRMModuleBase):
         super(AzureRMPostgreSQLFirewallRulesInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_postgresqlfirewallrule_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_postgresqlfirewallrule_facts' module has been renamed to 'azure_rm_postgresqlfirewallrule_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_postgresqlserver_info.py
+++ b/plugins/modules/azure_rm_postgresqlserver_info.py
@@ -199,9 +199,6 @@ class AzureRMPostgreSqlServersInfo(AzureRMModuleBase):
         super(AzureRMPostgreSqlServersInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_postgresqlserver_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_postgresqlserver_facts' module has been renamed to 'azure_rm_postgresqlserver_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_privatednszone_info.py
+++ b/plugins/modules/azure_rm_privatednszone_info.py
@@ -141,12 +141,6 @@ class AzurePrivateRMDNSZoneInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_privatednszone_facts'
-        if is_old_facts:
-            self.module.deprecate(
-                "The 'azure_rm_privatednszone_facts' module has been renamed to 'azure_rm_privatednszone_info'",
-                version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 

--- a/plugins/modules/azure_rm_publicipaddress_info.py
+++ b/plugins/modules/azure_rm_publicipaddress_info.py
@@ -225,9 +225,6 @@ class AzureRMPublicIPInfo(AzureRMModuleBase):
                                                   facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_publicipaddress_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_publicipaddress_facts' module has been renamed to 'azure_rm_publicipaddress_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
@@ -245,10 +242,6 @@ class AzureRMPublicIPInfo(AzureRMModuleBase):
 
         raw = self.filter(result)
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_publicipaddresses': self.serialize(raw),
-            }
         self.results['publicipaddresses'] = self.format(raw)
 
         return self.results

--- a/plugins/modules/azure_rm_rediscache_info.py
+++ b/plugins/modules/azure_rm_rediscache_info.py
@@ -259,9 +259,6 @@ class AzureRMRedisCacheInfo(AzureRMModuleBase):
         )
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_rediscache_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_rediscache_facts' module has been renamed to 'azure_rm_rediscache_info'", version=(2.9, ))
 
         for key in self.module_args:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -379,9 +379,6 @@ class AzureRMResourceInfo(AzureRMModuleBase):
         super(AzureRMResourceInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_resource_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_resource_facts' module has been renamed to 'azure_rm_resource_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_resourcegroup_info.py
+++ b/plugins/modules/azure_rm_resourcegroup_info.py
@@ -166,9 +166,6 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
                                                        facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_resourcegroup_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_resourcegroup_facts' module has been renamed to 'azure_rm_resourcegroup_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
@@ -182,8 +179,6 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
             for item in result:
                 item['resources'] = self.list_by_rg(item['name'])
 
-        if is_old_facts:
-            self.results['ansible_facts']['azure_resourcegroups'] = result
         self.results['resourcegroups'] = result
 
         return self.results

--- a/plugins/modules/azure_rm_roleassignment_info.py
+++ b/plugins/modules/azure_rm_roleassignment_info.py
@@ -183,9 +183,6 @@ class AzureRMRoleAssignmentInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
-        is_old_facts = self.module._name == 'azure_rm_roleassignment_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_roleassignment_facts' module has been renamed to 'azure_rm_roleassignment_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_roledefinition_info.py
+++ b/plugins/modules/azure_rm_roledefinition_info.py
@@ -180,9 +180,6 @@ class AzureRMRoleDefinitionInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
-        is_old_facts = self.module._name == 'azure_rm_roledefinition_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_roledefinition_facts' module has been renamed to 'azure_rm_roledefinition_info'", version=(2.9, ))
 
         for key in list(self.module_arg_spec.keys()):
             if hasattr(self, key):

--- a/plugins/modules/azure_rm_routetable_info.py
+++ b/plugins/modules/azure_rm_routetable_info.py
@@ -167,9 +167,6 @@ class AzureRMRouteTableInfo(AzureRMModuleBase):
                                                     facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_routetable_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_routetable_facts' module has been renamed to 'azure_rm_routetable_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_securitygroup_info.py
+++ b/plugins/modules/azure_rm_securitygroup_info.py
@@ -339,10 +339,6 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        is_old_facts = self.module._name == 'azure_rm_securitygroup_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_securitygroup_facts' module has been renamed to 'azure_rm_securitygroup_info'", version=(2.9, ))
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
@@ -351,10 +347,6 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
         else:
             info = self.list_items()
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_securitygroups': info
-            }
         self.results['securitygroups'] = info
 
         return self.results

--- a/plugins/modules/azure_rm_servicebus_info.py
+++ b/plugins/modules/azure_rm_servicebus_info.py
@@ -463,9 +463,6 @@ class AzureRMServiceBusInfo(AzureRMModuleBase):
                                                     facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_servicebus_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_servicebus_facts' module has been renamed to 'azure_rm_servicebus_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_sqldatabase_info.py
+++ b/plugins/modules/azure_rm_sqldatabase_info.py
@@ -199,9 +199,6 @@ class AzureRMSqlDatabaseInfo(AzureRMModuleBase):
         super(AzureRMSqlDatabaseInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_sqldatabase_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_sqldatabase_facts' module has been renamed to 'azure_rm_sqldatabase_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_sqlfirewallrule_info.py
+++ b/plugins/modules/azure_rm_sqlfirewallrule_info.py
@@ -134,9 +134,6 @@ class AzureRMSqlFirewallRuleInfo(AzureRMModuleBase):
         super(AzureRMSqlFirewallRuleInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_sqlfirewallrule_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_sqlfirewallrule_facts' module has been renamed to 'azure_rm_sqlfirewallrule_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_sqlserver_info.py
+++ b/plugins/modules/azure_rm_sqlserver_info.py
@@ -228,9 +228,6 @@ class AzureRMSqlServerInfo(AzureRMModuleBase):
         super(AzureRMSqlServerInfo, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_sqlserver_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_sqlserver_facts' module has been renamed to 'azure_rm_sqlserver_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -648,9 +648,6 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                                                         facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_storageaccount_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_storageaccount_facts' module has been renamed to 'azure_rm_storageaccount_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
@@ -668,11 +665,6 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
 
         filtered = self.filter_tag(results)
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_storageaccounts': self.serialize(filtered),
-                'storageaccounts': self.format_to_dict(filtered),
-            }
         self.results['storageaccounts'] = self.format_to_dict(filtered)
         return self.results
 

--- a/plugins/modules/azure_rm_subnet_info.py
+++ b/plugins/modules/azure_rm_subnet_info.py
@@ -226,9 +226,6 @@ class AzureRMSubnetInfo(AzureRMModuleBase):
         super(AzureRMSubnetInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_subnet_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_subnet_facts' module has been renamed to 'azure_rm_subnet_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_trafficmanagerendpoint_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerendpoint_info.py
@@ -221,10 +221,6 @@ class AzureRMTrafficManagerEndpointInfo(AzureRMModuleBase):
         )
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_trafficmanagerendpoint_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_trafficmanagerendpoint_facts' module has been renamed to 'azure_rm_trafficmanagerendpoint_info'",
-                                  version=(2.9, ))
 
         for key in self.module_args:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_trafficmanagerprofile_info.py
+++ b/plugins/modules/azure_rm_trafficmanagerprofile_info.py
@@ -331,10 +331,6 @@ class AzureRMTrafficManagerProfileInfo(AzureRMModuleBase):
         )
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_trafficmanagerprofile_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_trafficmanagerprofile_facts' module has been renamed to 'azure_rm_trafficmanagerprofile_info'",
-                                  version=(2.9, ))
 
         for key in self.module_args:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -415,9 +415,6 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
                                                         facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualmachine_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualmachine_facts' module has been renamed to 'azure_rm_virtualmachine_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_virtualmachineextension.py
+++ b/plugins/modules/azure_rm_virtualmachineextension.py
@@ -243,9 +243,6 @@ class AzureRMVMExtension(AzureRMModuleBase):
         for key in list(self.module_arg_spec.keys()):
             setattr(self, key, kwargs[key])
 
-        if self.module._name == 'azure_rm_virtualmachine_extension':
-            self.module.deprecate("The 'azure_rm_virtualmachine_extension' module has been renamed to 'azure_rm_virtualmachineextension'", version=(2, 9))
-
         resource_group = None
         to_be_updated = False
 

--- a/plugins/modules/azure_rm_virtualmachineextension_info.py
+++ b/plugins/modules/azure_rm_virtualmachineextension_info.py
@@ -180,10 +180,6 @@ class AzureRMVirtualMachineExtensionInfo(AzureRMModuleBase):
         super(AzureRMVirtualMachineExtensionInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualmachineextension_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualmachineextension_facts' module has been renamed to 'azure_rm_virtualmachineextension_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_virtualmachineimage_info.py
+++ b/plugins/modules/azure_rm_virtualmachineimage_info.py
@@ -149,32 +149,18 @@ class AzureRMVirtualMachineImageInfo(AzureRMModuleBase):
         super(AzureRMVirtualMachineImageInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualmachineimage_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualmachineimage_facts' module has been renamed to 'azure_rm_virtualmachineimage_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
-        if is_old_facts:
-            self.results['ansible_facts'] = dict()
-            if self.location and self.publisher and self.offer and self.sku and self.version:
-                self.results['ansible_facts']['azure_vmimages'] = self.get_item()
-            elif self.location and self.publisher and self.offer and self.sku:
-                self.results['ansible_facts']['azure_vmimages'] = self.list_images()
-            elif self.location and self.publisher:
-                self.results['ansible_facts']['azure_vmimages'] = self.list_offers()
-            elif self.location:
-                self.results['ansible_facts']['azure_vmimages'] = self.list_publishers()
-        else:
-            if self.location and self.publisher and self.offer and self.sku and self.version:
-                self.results['vmimages'] = self.get_item()
-            elif self.location and self.publisher and self.offer and self.sku:
-                self.results['vmimages'] = self.list_images()
-            elif self.location and self.publisher:
-                self.results['vmimages'] = self.list_offers()
-            elif self.location:
-                self.results['vmimages'] = self.list_publishers()
+        if self.location and self.publisher and self.offer and self.sku and self.version:
+            self.results['vmimages'] = self.get_item()
+        elif self.location and self.publisher and self.offer and self.sku:
+            self.results['vmimages'] = self.list_images()
+        elif self.location and self.publisher:
+            self.results['vmimages'] = self.list_offers()
+        elif self.location:
+            self.results['vmimages'] = self.list_publishers()
 
         return self.results
 

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -904,9 +904,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
-        if self.module._name == 'azure_rm_virtualmachine_scaleset':
-            self.module.deprecate("The 'azure_rm_virtualmachine_scaleset' module has been renamed to 'azure_rm_virtualmachinescaleset'", version=(2, 9))
-
         # make sure options are lower case
         self.remove_on_absent = set([resource.lower() for resource in self.remove_on_absent])
 

--- a/plugins/modules/azure_rm_virtualmachinescaleset_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset_info.py
@@ -252,10 +252,6 @@ class AzureRMVirtualMachineScaleSetInfo(AzureRMModuleBase):
         )
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualmachinescaleset_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualmachinescaleset_facts' module has been renamed to 'azure_rm_virtualmachinescaleset_info'",
-                                  version=(2.9, ))
 
         for key in self.module_args:
             setattr(self, key, kwargs[key])
@@ -339,16 +335,7 @@ class AzureRMVirtualMachineScaleSetInfo(AzureRMModuleBase):
 
                 result[index] = updated
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_vmss': result
-            }
-            if self.format == 'curated':
-                # proper result format we want to support in the future
-                # dropping 'ansible_facts' and shorter name 'vmss'
-                self.results['vmss'] = result
-        else:
-            self.results['vmss'] = result
+        self.results['vmss'] = result
 
         return self.results
 

--- a/plugins/modules/azure_rm_virtualmachinescalesetextension_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescalesetextension_info.py
@@ -152,11 +152,6 @@ class AzureRMVirtualMachineScaleSetExtensionInfo(AzureRMModuleBase):
         super(AzureRMVirtualMachineScaleSetExtensionInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualmachinescalesetextension_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualmachinescalesetextension_facts' module has been renamed to" +
-                                  " 'azure_rm_virtualmachinescalesetextension_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_virtualmachinescalesetinstance_info.py
+++ b/plugins/modules/azure_rm_virtualmachinescalesetinstance_info.py
@@ -159,11 +159,6 @@ class AzureRMVirtualMachineScaleSetVMInfo(AzureRMModuleBase):
         super(AzureRMVirtualMachineScaleSetVMInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False, facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualmachinescalesetinstance_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualmachinescalesetinstance_facts' module has been renamed to" +
-                                  " 'azure_rm_virtualmachinescalesetinstance_info'",
-                                  version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -265,9 +265,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
                                                           required_if=self.required_if)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_virtualnetwork_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualnetwork_facts' module has been renamed to 'azure_rm_virtualnetwork_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
@@ -279,10 +276,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         else:
             results = self.list_items()
 
-        if is_old_facts:
-            self.results['ansible_facts'] = {
-                'azure_virtualnetworks': self.serialize(results)
-            }
         self.results['virtualnetworks'] = self.curated(results)
 
         return self.results

--- a/plugins/modules/azure_rm_virtualnetworkpeering_info.py
+++ b/plugins/modules/azure_rm_virtualnetworkpeering_info.py
@@ -192,10 +192,6 @@ class AzureRMVirtualNetworkPeeringInfo(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
-        is_old_facts = self.module._name == 'azure_rm_virtualnetworkpeering_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_virtualnetworkpeering_facts' module has been renamed to 'azure_rm_virtualnetworkpeering_info'",
-                                  version=(2.9, ))
 
         for key in list(self.module_arg_spec.keys()):
             setattr(self, key, kwargs[key])

--- a/plugins/modules/azure_rm_webapp_info.py
+++ b/plugins/modules/azure_rm_webapp_info.py
@@ -298,9 +298,6 @@ class AzureRMWebAppInfo(AzureRMModuleBase):
                                                 facts_module=True)
 
     def exec_module(self, **kwargs):
-        is_old_facts = self.module._name == 'azure_rm_webapp_facts'
-        if is_old_facts:
-            self.module.deprecate("The 'azure_rm_webapp_facts' module has been renamed to 'azure_rm_webapp_info'", version=(2.9, ))
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])


### PR DESCRIPTION
##### SUMMARY
Remove deprectaed code since ansible-2.9 has been EOL

Ansible-2.9 has been End of Life since May 23, 2022.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_aks_info.py
plugins/modules/azure_rm_aksversion_info.py
plugins/modules/azure_rm_applicationsecuritygroup_info.py
plugins/modules/azure_rm_appserviceplan_info.py
plugins/modules/azure_rm_automationaccount_info.py
plugins/modules/azure_rm_autoscale_info.py
plugins/modules/azure_rm_availabilityset_info.py
plugins/modules/azure_rm_cdnendpoint_info.py
plugins/modules/azure_rm_cdnprofile_info.py
plugins/modules/azure_rm_containerinstance_info.py
plugins/modules/azure_rm_containerregistry_info.py
plugins/modules/azure_rm_cosmosdbaccount_info.py
plugins/modules/azure_rm_deployment_info.py
plugins/modules/azure_rm_devtestlab_info.py
plugins/modules/azure_rm_devtestlabarmtemplate_info.py
plugins/modules/azure_rm_devtestlabartifactsource_info.py
plugins/modules/azure_rm_devtestlabcustomimage_info.py
plugins/modules/azure_rm_devtestlabenvironment_info.py
plugins/modules/azure_rm_devtestlabpolicy_info.py
plugins/modules/azure_rm_devtestlabschedule_info.py
plugins/modules/azure_rm_devtestlabvirtualmachine_info.py
plugins/modules/azure_rm_devtestlabvirtualnetwork_info.py
plugins/modules/azure_rm_dnsrecordset_info.py
plugins/modules/azure_rm_dnszone_info.py
plugins/modules/azure_rm_functionapp_info.py
plugins/modules/azure_rm_hdinsightcluster_info.py
plugins/modules/azure_rm_image_info.py
plugins/modules/azure_rm_loadbalancer_info.py
plugins/modules/azure_rm_lock_info.py
plugins/modules/azure_rm_loganalyticsworkspace_info.py
plugins/modules/azure_rm_mariadbconfiguration_info.py
plugins/modules/azure_rm_mariadbdatabase_info.py
plugins/modules/azure_rm_mariadbfirewallrule_info.py
plugins/modules/azure_rm_mariadbserver_info.py
plugins/modules/azure_rm_mysqlconfiguration_info.py
plugins/modules/azure_rm_mysqldatabase_info.py
plugins/modules/azure_rm_mysqlfirewallrule_info.py
plugins/modules/azure_rm_mysqlserver_info.py
plugins/modules/azure_rm_networkinterface_info.py
plugins/modules/azure_rm_postgresqlconfiguration_info.py
plugins/modules/azure_rm_postgresqldatabase_info.py
plugins/modules/azure_rm_postgresqlfirewallrule_info.py
plugins/modules/azure_rm_postgresqlserver_info.py
plugins/modules/azure_rm_privatednszone_info.py
plugins/modules/azure_rm_publicipaddress_info.py
plugins/modules/azure_rm_rediscache_info.py
plugins/modules/azure_rm_resource_info.py
plugins/modules/azure_rm_resourcegroup_info.py
plugins/modules/azure_rm_roleassignment_info.py
plugins/modules/azure_rm_roledefinition_info.py
plugins/modules/azure_rm_routetable_info.py
plugins/modules/azure_rm_securitygroup_info.py
plugins/modules/azure_rm_servicebus_info.py
plugins/modules/azure_rm_sqldatabase_info.py
plugins/modules/azure_rm_sqlfirewallrule_info.py
plugins/modules/azure_rm_sqlserver_info.py
plugins/modules/azure_rm_storageaccount_info.py
plugins/modules/azure_rm_subnet_info.py
plugins/modules/azure_rm_trafficmanagerendpoint_info.py
plugins/modules/azure_rm_trafficmanagerprofile_info.py
plugins/modules/azure_rm_virtualmachine_info.py
plugins/modules/azure_rm_virtualmachineextension.py
plugins/modules/azure_rm_virtualmachineextension_info.py
plugins/modules/azure_rm_virtualmachineimage_info.py
plugins/modules/azure_rm_virtualmachinescaleset.py
plugins/modules/azure_rm_virtualmachinescaleset_info.py
plugins/modules/azure_rm_virtualmachinescalesetextension_info.py
plugins/modules/azure_rm_virtualmachinescalesetinstance_info.py
plugins/modules/azure_rm_virtualnetwork_info.py
plugins/modules/azure_rm_virtualnetworkpeering_info.py
plugins/modules/azure_rm_webapp_info.py

##### ADDITIONAL INFORMATION
```paste below
[ERROR]: Task failed: Module failed: DeprecationSummary.version must be <class 'str'> or <class 'NoneType'> instead of <class 'tuple'>
Origin: /home/admin/.ansible/collections/ansible_collections/azure/azcollection/tests/output/.tmp/integration/azure_rm_containerregistry-gbzc9__b-ÅÑŚÌβŁÈ/tests/integration/targets/azure_rm_containerregistry/tasks/main.yml:82:3

80       - output.credentials['password2'] is not defined
81
82 - name: Gather facts for single Container Registry
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: DeprecationSummary.version must be <class 'str'> or <class 'NoneType'> instead of <class 'tuple'>"}
```
