### PR TITLE
Update galaxy.yml to not bundle test credentials

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -69,3 +69,5 @@ build_ignore:
   - '.vscode'
   - 'ansible_collections'
   - 'ansible.cfg'
+  - "*cloud-config-azure.ini"
+  - "*cloud-config-azure.yml"


### PR DESCRIPTION
##### SUMMARY
Ignore cloud-config-azure.yml when building the galaxy package.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Security!

##### ADDITIONAL INFORMATION
do to the following:

```
https://github.com/ansible-collections/azure/blob/dev/tests/utils/ado/ado.sh#L97
```

Microsoft has been publishing there credential with the galaxy package.  This account should be revoked immediately!
