### PR TITLE
Import azure eda

### DIFF
--- a/extensions/eda/README.md
+++ b/extensions/eda/README.md
@@ -1,0 +1,87 @@
+
+# How to Configure EDA to use Azure servicebus as a source
+
+## Example azure-rulebook.yml file:
+
+```yaml
+---
+- name: Listen for events from azure
+  hosts: all
+  sources:
+    - azure.azcollection.azure_service_bus:
+        conn_str: **CONNECTION_STRING**
+        queue_name: **QUEUE_NAME**
+  rules:
+    - name: Say Hello
+      condition: event.body.message == "Azure and Ansible is super cool"
+      action:
+        run_playbook:
+          name: hello_playbook.yml
+```
+
+Rulebooks are run via ansible-rulebook or from AAP:
+
+    ansible-rulebook -r azure-rulebook.yml -v -i inventory
+
+## Here is a crude example of sending a message to servicebus with python:
+
+```python
+import os
+import threading
+import json
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+
+CONNECTION_STRING = os.environ["SERVICEBUS_CONNECTION_STRING"]
+QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
+
+
+def send_single_message(sender, data):
+    message = ServiceBusMessage(json.dumps(data))
+    sender.send_messages(message)
+
+
+servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STRING,
+                                                            logging_enable=True)
+data = dict(message="Azure and Ansible is super cool")
+with servicebus_client:
+    sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)
+    with sender:
+        send_single_message(sender, data)
+
+    print("Send message is done.")
+```
+
+## Example debug output from running the above rulebook and receiving the example message
+
+```
+2025-06-23 14:46:44,667 - azure.servicebus._pyamqp.receiver - DEBUG - <- TransferFrame(handle=2, delivery_id=1, delivery_tag=b'5\x14\xda\xf8\xe7CKN\xa3\x0b\x9a\x16yx\xe5\xa2', message_format=0, settled=None, more=False, rcv_settle_mode=None, state=None, resume=None, aborted=None, batchable=True, payload=b'***')
+2025-06-23 14:46:44,667 - azure.servicebus._transport._pyamqp_transport - DEBUG - Received message: seq-num: 15, enqd-utc: datetime.datetime(2025, 6, 23, 18, 46, 44, 637000, tzinfo=datetime.timezone.utc), lockd-til-utc: datetime.datetime(2025, 6, 23, 18, 47, 44, 652000, tzinfo=datetime.timezone.utc), ttl: datetime.timedelta(days=14), dlvry-cnt: 0
+2025-06-23 14:46:44,667 - azure.servicebus._pyamqp.receiver - DEBUG - -> DispositionFrame(role=True, first=1, last=None, settled=True, state=Accepted(), batchable=None)
+
+** 2025-06-23 14:46:44.668293 [received event] **********************************************************************
+2025-06-23 14:46:44,668 - azure.servicebus._pyamqp.cbs - DEBUG - CBS status check: state == <CbsAuthState.OK: 0>, expired == False, refresh required == False
+Ruleset: Listen for events from azure
+2025-06-23 14:46:44,668 - azure.servicebus._pyamqp.session - DEBUG - -> FlowFrame(next_incoming_id=3, incoming_window=65534, next_outgoing_id=1, outgoing_window=65535, handle=3, delivery_count=1, link_credit=1, available=None, drain=None, echo=None, properties=None)
+Event:
+{'body': {'message': 'Azure and Ansible is super cool'},
+ 'meta': {'message_id': '80a59815-3c23-41f2-9889-9893a4b9c2da',
+          'received_at': '2025-06-23T18:46:44.668093Z',
+          'source': {'name': 'azure.azcollection.azure_service_bus',
+                     'type': 'azure.azcollection.azure_service_bus'},
+          'uuid': '07f5c3b7-ebf5-4204-9151-864e44a4829e'}}
+*********************************************************************************************************************
+2025-06-23 14:46:44,668 - ansible_rulebook.rule_set_runner - DEBUG - Posting data to ruleset Listen for events from azure => {'body': {'message': 'Azure and Ansible is super cool'}, 'meta': {'message_id': '80a59815-3c23-41f2-9889-9893a4b9c2da', 'source': {'name': 'azure.azcollection.azure_service_bus', 'type': 'azure.azcollection.azure_service_bus'}, 'received_at': '2025-06-23T18:46:44.668093Z', 'uuid': '07f5c3b7-ebf5-4204-9151-864e44a4829e'}}
+2025-06-23 14:46:44 669 [main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.MemoryMonitorUtil - Memory occupation threshold set to 90%
+2025-06-23 14:46:44 670 [main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.MemoryMonitorUtil - Memory check event count threshold set to 64
+2025-06-23 14:46:44 670 [main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.MemoryMonitorUtil - Exit above memory occupation threshold set to false
+2025-06-23 14:46:44 711 [main] DEBUG org.drools.ansible.rulebook.integration.api.rulesengine.RegisterOnlyAgendaFilter - Activation of effective rule "Say Hello" with facts: {m={meta={message_id=80a59815-3c23-41f2-9889-9893a4b9c2da, source={name=azure.azcollection.azure_service_bus, type=azure.azcollection.azure_service_bus}, received_at=2025-06-23T18:46:44.668093Z, uuid=07f5c3b7-ebf5-4204-9151-864e44a4829e}, body={message=Azure and Ansible is super cool}}}
+2025-06-23 14:46:44,718 - drools.ruleset - DEBUG - Calling rule : Say Hello in session: 1
+2025-06-23 14:46:44,718 - ansible_rulebook.rule_generator - DEBUG - callback calling Say Hello
+2025-06-23 14:46:44,718 - ansible_rulebook.rule_set_runner - DEBUG - None
+2025-06-23 14:46:44,718 - ansible_rulebook.rule_set_runner - DEBUG - Creating action task action::run_playbook::Listen for events from azure::Say Hello
+2025-06-23 14:46:44,718 - ansible_rulebook.rule_set_runner - DEBUG - call_action run_playbook
+2025-06-23 14:46:44,719 - ansible_rulebook.action.run_playbook - DEBUG - ruleset: Listen for events from azure, rule: Say Hello
+2025-06-23 14:46:44,719 - ansible_rulebook.action.run_playbook - DEBUG - private data dir /tmp/edap29wpkf2
+2025-06-23 14:46:44,721 - ansible_rulebook.action.run_playbook - DEBUG - project_data_file: None
+```

--- a/extensions/eda/README.md
+++ b/extensions/eda/README.md
@@ -1,6 +1,10 @@
 
 # How to Configure EDA to use Azure servicebus as a source
 
+## First - See the Ansible Rulebook Documentation
+
+Documentation about Ansbile Rulebooks and EDA are available [here](https://ansible.readthedocs.io/projects/rulebook/en/latest/).  See the Getting started and Installation sections before continuing.
+
 ## Example azure-rulebook.yml file:
 
 ```yaml

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -1,15 +1,15 @@
-"""
-azure_service_bus.py
+"""azure_service_bus.py.
 
 An ansible-rulebook event source module for receiving events from an Azure service bus
 
 Arguments:
+---------
     conn_str: The connection string to connect to the Azure service bus
     queue_name: The name of the queue to pull messages from
     logging_enable: Whether to turn on logging. Default to True
 
 Example:
-
+-------
     - ansible.eda.azure_service_bus:
         conn_str: "{{connection_str}}"
         queue_name: "{{queue_name}}"
@@ -18,17 +18,18 @@ Example:
 
 import asyncio
 import concurrent.futures
+import contextlib
 import json
-from typing import Any, Dict
+from typing import Any
 
 from azure.servicebus import ServiceBusClient
 
 
 def receive_events(
-    loop: asyncio.events.AbstractEventLoop, queue: asyncio.Queue, args: Dict[str, Any]
+    loop: asyncio.events.AbstractEventLoop, queue: asyncio.Queue, args: dict[str, Any],
 ):
     servicebus_client = ServiceBusClient.from_connection_string(
-        conn_str=args["conn_str"], logging_enable=bool(args.get("logging_enable", True))
+        conn_str=args["conn_str"], logging_enable=bool(args.get("logging_enable", True)),
     )
 
     with servicebus_client:
@@ -37,17 +38,16 @@ def receive_events(
             for msg in receiver:
                 meta = {"message_id": msg.message_id}
                 body = str(msg)
-                try:
+                with contextlib.suppress(json.JSONDecodeError):
                     body = json.loads(body)
-                except json.JSONDecodeError:
-                    pass
+
                 loop.call_soon_threadsafe(
-                    queue.put_nowait, {"body": body, "meta": meta}
+                    queue.put_nowait, {"body": body, "meta": meta},
                 )
                 receiver.complete_message(msg)
 
 
-async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+async def main(queue: asyncio.Queue, args: dict[str, Any]):
     loop = asyncio.get_running_loop()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as task_pool:

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -26,7 +26,9 @@ from azure.servicebus import ServiceBusClient
 
 
 def receive_events(
-    loop: asyncio.events.AbstractEventLoop, queue: asyncio.Queue, args: dict[str, Any],
+    loop: asyncio.events.AbstractEventLoop,
+    queue: asyncio.Queue,
+    args: dict[str, Any],
 ) -> None:
     """Receive events from service bus."""
     servicebus_client = ServiceBusClient.from_connection_string(
@@ -44,7 +46,8 @@ def receive_events(
                     body = json.loads(body)
 
                 loop.call_soon_threadsafe(
-                    queue.put_nowait, {"body": body, "meta": meta},
+                    queue.put_nowait,
+                    {"body": body, "meta": meta},
                 )
                 receiver.complete_message(msg)
 
@@ -63,9 +66,9 @@ if __name__ == "__main__":
     class MockQueue:
         """A fake queue."""
 
-        async def put_nowait(self, event: dict) -> None:
+        async def put_nowait(self: "MockQueue", event: dict) -> None:
             """Print the event."""
-            print(event) # noqa: T201
+            print(event)  # noqa: T201
 
     args = {
         "conn_str": "Endpoint=sb://foo.servicebus.windows.net/",

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -27,7 +27,7 @@ from azure.servicebus import ServiceBusClient
 
 def receive_events(
     loop: asyncio.events.AbstractEventLoop,
-    queue: asyncio.Queue,
+    queue: asyncio.Queue[Any],
     args: dict[str, Any],  # pylint: disable=W0621
 ) -> None:
     """Receive events from service bus."""
@@ -53,7 +53,7 @@ def receive_events(
 
 
 async def main(
-    queue: asyncio.Queue,
+    queue: asyncio.Queue[Any],
     args: dict[str, Any],  # pylint: disable=W0621
 ) -> None:
     """Receive events from service bus in a loop."""
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     class MockQueue(asyncio.Queue[Any]):
         """A fake queue."""
 
-        def put_nowait(self: "MockQueue", event: dict) -> None:
+        def put_nowait(self: "MockQueue", event: dict[str, Any]) -> None:
             """Print the event."""
             print(event)  # noqa: T201
 

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -28,7 +28,7 @@ from azure.servicebus import ServiceBusClient
 def receive_events(
     loop: asyncio.events.AbstractEventLoop,
     queue: asyncio.Queue,
-    args: dict[str, Any],
+    args: dict[str, Any],  # pylint: disable=W0621
 ) -> None:
     """Receive events from service bus."""
     servicebus_client = ServiceBusClient.from_connection_string(
@@ -52,7 +52,10 @@ def receive_events(
                 receiver.complete_message(msg)
 
 
-async def main(queue: asyncio.Queue, args: dict[str, Any]) -> None:
+async def main(
+    queue: asyncio.Queue,
+    args: dict[str, Any],  # pylint: disable=W0621
+) -> None:
     """Receive events from service bus in a loop."""
     loop = asyncio.get_running_loop()
 

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -16,8 +16,6 @@ Example:
 
 """
 
-from __future__ import annotations
-
 import asyncio
 import concurrent.futures
 import contextlib
@@ -71,7 +69,7 @@ if __name__ == "__main__":
     class MockQueue:
         """A fake queue."""
 
-        async def put_nowait(self: MockQueue, event: dict) -> None:
+        async def put_nowait(self: "MockQueue", event: dict) -> None:
             """Print the event."""
             print(event)  # noqa: T201
 

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     class MockQueue(asyncio.Queue[Any]):
         """A fake queue."""
 
-        async def put_nowait(self: "MockQueue", event: dict) -> None:
+        def put_nowait(self: "MockQueue", event: dict) -> None:
             """Print the event."""
             print(event)  # noqa: T201
 

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -27,9 +27,11 @@ from azure.servicebus import ServiceBusClient
 
 def receive_events(
     loop: asyncio.events.AbstractEventLoop, queue: asyncio.Queue, args: dict[str, Any],
-):
+) -> None:
+    """Receive events from service bus."""
     servicebus_client = ServiceBusClient.from_connection_string(
-        conn_str=args["conn_str"], logging_enable=bool(args.get("logging_enable", True)),
+        conn_str=args["conn_str"],
+        logging_enable=bool(args.get("logging_enable", True)),
     )
 
     with servicebus_client:
@@ -47,7 +49,8 @@ def receive_events(
                 receiver.complete_message(msg)
 
 
-async def main(queue: asyncio.Queue, args: dict[str, Any]):
+async def main(queue: asyncio.Queue, args: dict[str, Any]) -> None:
+    """Receive events from service bus in a loop."""
     loop = asyncio.get_running_loop()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as task_pool:
@@ -55,10 +58,14 @@ async def main(queue: asyncio.Queue, args: dict[str, Any]):
 
 
 if __name__ == "__main__":
+    """MockQueue if running directly."""
 
     class MockQueue:
-        def put_nowait(self, event):
-            print(event)
+        """A fake queue."""
+
+        async def put_nowait(self, event: dict) -> None:
+            """Print the event."""
+            print(event) # noqa: T201
 
     args = {
         "conn_str": "Endpoint=sb://foo.servicebus.windows.net/",

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -1,21 +1,3 @@
-"""azure_service_bus.py.
-
-An ansible-rulebook event source module for receiving events from an Azure service bus
-
-Arguments:
----------
-    conn_str: The connection string to connect to the Azure service bus
-    queue_name: The name of the queue to pull messages from
-    logging_enable: Whether to turn on logging. Default to True
-
-Example:
--------
-    - ansible.eda.azure_service_bus:
-        conn_str: "{{connection_str}}"
-        queue_name: "{{queue_name}}"
-
-"""
-
 import asyncio
 import concurrent.futures
 import contextlib
@@ -23,6 +5,37 @@ import json
 from typing import Any
 
 from azure.servicebus import ServiceBusClient
+
+DOCUMENTATION = r"""
+---
+short_description: Receive events from an Azure service bus.
+description:
+  - An ansible-rulebook event source module for receiving events from an Azure service bus.
+  - In order to get the service bus and the connection string, refer to
+    https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-python-how-to-use-queues?tabs=passwordless
+options:
+  conn_str:
+    description:
+      - The connection string to connect to the Azure service bus.
+    type: str
+    required: true
+  queue_name:
+    description:
+      - The name of the queue to pull messages from.
+    type: str
+    required: true
+  logging_enable:
+    description:
+      - Whether to turn on logging.
+    type: bool
+    default: true
+"""
+
+EXAMPLES = r"""
+- ansible.eda.azure_service_bus:
+    conn_str: "{{connection_str}}"
+    queue_name: "{{queue_name}}"
+"""
 
 
 def receive_events(

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -1,0 +1,67 @@
+"""
+azure_service_bus.py
+
+An ansible-rulebook event source module for receiving events from an Azure service bus
+
+Arguments:
+    conn_str: The connection string to connect to the Azure service bus
+    queue_name: The name of the queue to pull messages from
+    logging_enable: Whether to turn on logging. Default to True
+
+Example:
+
+    - ansible.eda.azure_service_bus:
+        conn_str: "{{connection_str}}"
+        queue_name: "{{queue_name}}"
+
+"""
+
+import asyncio
+import concurrent.futures
+import json
+from typing import Any, Dict
+
+from azure.servicebus import ServiceBusClient
+
+
+def receive_events(
+    loop: asyncio.events.AbstractEventLoop, queue: asyncio.Queue, args: Dict[str, Any]
+):
+    servicebus_client = ServiceBusClient.from_connection_string(
+        conn_str=args["conn_str"], logging_enable=bool(args.get("logging_enable", True))
+    )
+
+    with servicebus_client:
+        receiver = servicebus_client.get_queue_receiver(queue_name=args["queue_name"])
+        with receiver:
+            for msg in receiver:
+                meta = {"message_id": msg.message_id}
+                body = str(msg)
+                try:
+                    body = json.loads(body)
+                except json.JSONDecodeError:
+                    pass
+                loop.call_soon_threadsafe(
+                    queue.put_nowait, {"body": body, "meta": meta}
+                )
+                receiver.complete_message(msg)
+
+
+async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+    loop = asyncio.get_running_loop()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as task_pool:
+        await loop.run_in_executor(task_pool, receive_events, loop, queue, args)
+
+
+if __name__ == "__main__":
+
+    class MockQueue:
+        def put_nowait(self, event):
+            print(event)
+
+    args = {
+        "conn_str": "Endpoint=sb://foo.servicebus.windows.net/",
+        "queue_name": "eda-queue",
+    }
+    asyncio.run(main(MockQueue(), args))

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -16,6 +16,8 @@ Example:
 
 """
 
+from __future__ import annotations
+
 import asyncio
 import concurrent.futures
 import contextlib
@@ -69,7 +71,7 @@ if __name__ == "__main__":
     class MockQueue:
         """A fake queue."""
 
-        async def put_nowait(self: "MockQueue", event: dict) -> None:
+        async def put_nowait(self: MockQueue, event: dict) -> None:
             """Print the event."""
             print(event)  # noqa: T201
 

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -66,7 +66,7 @@ async def main(
 if __name__ == "__main__":
     """MockQueue if running directly."""
 
-    class MockQueue:
+    class MockQueue(asyncio.Queue[Any]):
         """A fake queue."""
 
         async def put_nowait(self: "MockQueue", event: dict) -> None:

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -32,7 +32,7 @@ options:
 """
 
 EXAMPLES = r"""
-- ansible.eda.azure_service_bus:
+- azure.azcollection.azure_service_bus:
     conn_str: "{{connection_str}}"
     queue_name: "{{queue_name}}"
 """

--- a/extensions/eda/plugins/event_source/schemas/azure_service_bus.json
+++ b/extensions/eda/plugins/event_source/schemas/azure_service_bus.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://redhat.com/ansible_events/sources/azure_service_bus.json",
+    "title": "Azure Service Bus plugin for EDA",
+    "description": "An ansible-rulebook event source module for receiving events from an Azure service bus",
+    "type": "object",
+    "properties": {
+        "conn_str": {
+            "description": "The connection string",
+            "type": "string",
+            "title": "Connection String"
+        },
+        "queue_name": {
+            "description": "The queue name",
+            "type": "string",
+            "title": "Queue Name"
+        },
+        "logging_enable": {
+            "description": "Turn on logging",
+            "type": "boolean",
+            "default": true,
+            "title": "Enable Logging"
+        }
+    },
+    "required": [
+        "conn_str",
+        "queue_name"
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ azure-mgmt-eventhub==11.1.0
 azure-mgmt-resourcehealth==1.0.0b6
 oras
 netaddr
+azure-servicebus

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,3 @@
+To run the unit tests use the following command:
+
+ansible-test units --docker -v

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -7,7 +7,7 @@ import pytest
 from extensions.eda.plugins.event_source.azure_service_bus import main as azure_main
 
 
-class MockQueue(asyncio.Queue):
+class MockQueue(asyncio.Queue[Any]):
     def __init__(self) -> None:
         self.queue: list[Any] = []
 

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from plugins.event_source.azure_service_bus import main as azure_main
+from extensions.eda.plugins.event_sources.azure_service_bus import main as azure_main
 
 
 class MockQueue:
@@ -22,7 +22,7 @@ def myqueue():
 def test_receive_from_azure_service_bus(myqueue):
     client = MagicMock()
     with patch(
-        "plugins.event_source.azure_service_bus.ServiceBusClient."
+        "extensions.eda.plugins.event_sources.azure_service_bus.ServiceBusClient."
         "from_connection_string",
         return_value=client,
     ):

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,10 +8,10 @@ from extensions.eda.plugins.event_source.azure_service_bus import main as azure_
 
 
 class MockQueue:
-    def __init__(self):
-        self.queue = []
+    def __init__(self) -> None:
+        self.queue: list[Any] = []
 
-    def put_nowait(self, event):
+    def put_nowait(self, event) -> None:
         self.queue.append(event)
 
 
@@ -19,7 +20,7 @@ def myqueue():
     return MockQueue()
 
 
-def test_receive_from_azure_service_bus(myqueue):
+def test_receive_from_azure_service_bus(myqueue) -> None:
     client = MagicMock()
     with patch(
         "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient."
@@ -28,11 +29,11 @@ def test_receive_from_azure_service_bus(myqueue):
     ):
         payload1 = MagicMock()
         payload1.message_id = 1
-        payload1.__str__.return_value = "Hello World"
+        payload1.__str__.return_value = "Hello World"  # type: ignore[attr-defined]
 
         payload2 = MagicMock()
         payload2.message_id = 2
-        payload2.__str__.return_value = '{"Say":"Hello World"}'
+        payload2.__str__.return_value = '{"Say":"Hello World"}'  # type: ignore[attr-defined]
 
         receiver = MagicMock()
         receiver.__iter__.return_value = [payload1, payload2]

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -7,20 +7,20 @@ import pytest
 from extensions.eda.plugins.event_source.azure_service_bus import main as azure_main
 
 
-class MockQueue:
+class MockQueue(asyncio.Queue):
     def __init__(self) -> None:
         self.queue: list[Any] = []
 
-    def put_nowait(self, event) -> None:
-        self.queue.append(event)
+    def put_nowait(self, item: Any) -> None:
+        self.queue.append(item)
 
 
 @pytest.fixture
-def myqueue():
+def myqueue() -> MockQueue:
     return MockQueue()
 
 
-def test_receive_from_azure_service_bus(myqueue) -> None:
+def test_receive_from_azure_service_bus(myqueue: MockQueue) -> None:
     client = MagicMock()
     with patch(
         "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient."

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from extensions.eda.plugins.event_sources.azure_service_bus import main as azure_main
+from extensions.eda.plugins.event_source.azure_service_bus import main as azure_main
 
 
 class MockQueue:
@@ -22,7 +22,7 @@ def myqueue():
 def test_receive_from_azure_service_bus(myqueue):
     client = MagicMock()
     with patch(
-        "extensions.eda.plugins.event_sources.azure_service_bus.ServiceBusClient."
+        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient."
         "from_connection_string",
         return_value=client,
     ):

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -1,0 +1,54 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.event_source.azure_service_bus import main as azure_main
+
+
+class MockQueue:
+    def __init__(self):
+        self.queue = []
+
+    def put_nowait(self, event):
+        self.queue.append(event)
+
+
+@pytest.fixture
+def myqueue():
+    return MockQueue()
+
+
+def test_receive_from_azure_service_bus(myqueue):
+    client = MagicMock()
+    with patch(
+        "plugins.event_source.azure_service_bus.ServiceBusClient."
+        "from_connection_string",
+        return_value=client,
+    ):
+        payload1 = MagicMock()
+        payload1.message_id = 1
+        payload1.__str__.return_value = "Hello World"
+
+        payload2 = MagicMock()
+        payload2.message_id = 2
+        payload2.__str__.return_value = '{"Say":"Hello World"}'
+
+        receiver = MagicMock()
+        receiver.__iter__.return_value = [payload1, payload2]
+        client.get_queue_receiver.return_value = receiver
+        asyncio.run(
+            azure_main(
+                myqueue,
+                {
+                    "conn_str": "Endpoint=sb://foo.servicebus.windows.net/",
+                    "queue_name": "eda-queue",
+                },
+            )
+        )
+        assert myqueue.queue[0] == {"body": "Hello World", "meta": {"message_id": 1}}
+        assert myqueue.queue[1] == {
+            "body": {"Say": "Hello World"},
+            "meta": {"message_id": 2},
+        }
+        assert len(myqueue.queue) == 2

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,1 @@
+azure-servicebus


### PR DESCRIPTION
##### SUMMARY
Move the Azure Event bus plugin from ansible.eda, into the azure.az collection

Relocate the Azure Event Bus plugin from the ansible.eda collection to the azure.azcollection for improved modularity and clearer domain ownership.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
extensions/eda/plugins/event_source/azure_service_bus.py
extensions/eda/plugins/event_source/schemas/azure_service_bus.json
requirements.txt
tests/unit/README.md
tests/unit/event_source/test_azure_service_bus.py
tests/unit/requirements.txt

##### ADDITIONAL INFORMATION
ansible-test units --docker

```paste below
Unit test controller with Python 3.11
============================= test session starts ==============================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /root/ansible_collections/azure/azcollection
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: mock-3.14.0, xdist-3.6.1
created: 16/16 workers
16 workers [1 item]

.                                                                        [100%]
- generated xml file: /root/ansible_collections/azure/azcollection/tests/output/junit/python3.11-controller-units.xml -
============================== 1 passed in 1.73s ===============================
Unit test controller with Python 3.12
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0
rootdir: /root/ansible_collections/azure/azcollection
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: mock-3.14.0, xdist-3.6.1
created: 16/16 workers
16 workers [1 item]

.                                                                        [100%]
- generated xml file: /root/ansible_collections/azure/azcollection/tests/output/junit/python3.12-controller-units.xml -
============================== 1 passed in 1.77s ===============================
Unit test controller with Python 3.13
============================= test session starts ==============================
platform linux -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /root/ansible_collections/azure/azcollection
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: mock-3.14.0, xdist-3.6.1
created: 16/16 workers
16 workers [1 item]

.                                                                        [100%]
- generated xml file: /root/ansible_collections/azure/azcollection/tests/output/junit/python3.13-controller-units.xml -
============================== 1 passed in 1.83s ===============================

```
