### PR TITLE
Cleanup ado.sh and set default for pr-pipeline to latest versions (python+ansible)

### DIFF
--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -2,7 +2,7 @@ parameters:
   - name: PYTHON_VER
     displayName: 'Python Version'
     type: string
-    default: "3.10"
+    default: "3.13"
     values:
       - "2.7"
       - "3.6"
@@ -15,7 +15,7 @@ parameters:
   - name: ANSIBLE_VER
     displayName: 'Ansible Version'
     type: string
-    default: "2.17"
+    default: "2.18"
     values:
       - "2.15"
       - "2.16" # End Of Life May 2025 https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -209,7 +209,7 @@ jobs:
               ;;
           esac
           echo "Active group number: $group_no"
-        name: "Determine the target ansible test group number"
+        displayName: "Determine the target ansible test group number"
 
   - job: RunTests
     dependsOn: CreateResourceGroups

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -27,7 +27,9 @@ parameters:
     default: 'all'
     values:
       - 'all'
+      - "setup_azure"
       - 'sanity'
+      - "inventory_azure" # Group 1
       - 'azure_rm_adapplication'
       - "azure_rm_acs"
       - "azure_rm_adgroup"
@@ -161,8 +163,6 @@ parameters:
       - "azure_rm_afdorigin"
       - "azure_rm_afdruleset"
       - "azure_rm_afdrules"
-      - "inventory_azure"
-      - "setup_azure"
 
 trigger: none
 pr: none
@@ -192,6 +192,24 @@ jobs:
               az group create -l eastus -n $(setvar.resource_group_secondary)
               az group create -l westus2 -n $(setvar.resource_group_third)
               az group create -l eastus2 -n $(setvar.resource_group_datalake)
+      - name: "Determine the target ansible test group number"
+        bash: |
+          group_no="all"
+          case "${{ parameters.MODULE_NAME }}" in
+            sanity)
+              gropu_no=sanity
+              ;;
+            inventory_azure)
+              group_no=1
+              ;;
+            azure_rm_*)
+              group_no=$(awk -F'shippable/azure/group' '/^shippable\/azure\/group/ { print $2 }' ./tests/integration/targets/${{ parameters.MODULE_NAME }}/aliases)
+              ;;
+            *)
+              # "all" and "setup_azure"
+              ;;
+          esac
+          echo "Active group number: $group_no"
 
   - job: RunTests
     dependsOn: CreateResourceGroups

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -192,8 +192,7 @@ jobs:
               az group create -l eastus -n $(setvar.resource_group_secondary)
               az group create -l westus2 -n $(setvar.resource_group_third)
               az group create -l eastus2 -n $(setvar.resource_group_datalake)
-      - name: "Determine the target ansible test group number"
-        bash: |
+      - bash: |
           group_no="all"
           case "${{ parameters.MODULE_NAME }}" in
             sanity)
@@ -210,6 +209,7 @@ jobs:
               ;;
           esac
           echo "Active group number: $group_no"
+        name: "Determine the target ansible test group number"
 
   - job: RunTests
     dependsOn: CreateResourceGroups

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -4,7 +4,6 @@ parameters:
     type: string
     default: "3.13"
     values:
-      - "2.7"
       - "3.6"
       - "3.8"
       - "3.9"

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -4,9 +4,6 @@ parameters:
     type: string
     default: "3.13"
     values:
-      - "3.6"
-      - "3.8"
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -16,7 +13,6 @@ parameters:
     type: string
     default: "2.18"
     values:
-      - "2.15"
       - "2.16" # End Of Life May 2025 https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
       - "2.17"
       - "2.18"

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -222,58 +222,43 @@ jobs:
     strategy:
       matrix:
         "Python${{ parameters.PYTHON_VER }}_sanity":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: 'sanity'
         "Python${{ parameters.PYTHON_VER }}_1":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '1'
         "Python${{ parameters.PYTHON_VER }}_2":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '2'
         "Python${{ parameters.PYTHON_VER }}_3":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '3'
         "Python${{ parameters.PYTHON_VER }}_4":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '4'
         "Python${{ parameters.PYTHON_VER }}_5":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '5'
         "Python${{ parameters.PYTHON_VER }}_6":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '6'
         "Python${{ parameters.PYTHON_VER }}_7":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '7'
         "Python${{ parameters.PYTHON_VER }}_9":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '9'
         "Python${{ parameters.PYTHON_VER }}_10":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '10'
         "Python${{ parameters.PYTHON_VER }}_11":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '11'
         "Python${{ parameters.PYTHON_VER }}_12":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '12'
         "Python${{ parameters.PYTHON_VER }}_13":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '13'
         "Python${{ parameters.PYTHON_VER }}_14":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '14'
         "Python${{ parameters.PYTHON_VER }}_15":
-          python.version: '${{ parameters.PYTHON_VER }}'
           test.key: '15'
 
     steps:
       - task: UsePythonVersion@0
-        displayName: 'Use Python $(python.version)'
+        displayName: 'Use Python ${{ parameters.PYTHON_VER }}'
         inputs:
-          versionSpec: '$(python.version)'
+          versionSpec: '${{ parameters.PYTHON_VER }}'
 
-      - script: tests/utils/ado/ado.sh $(test.key) ${{ parameters.PYTHON_VER }} ${{ parameters.ANSIBLE_VER }} ${{ parameters.MODULE_NAME }}
+      - script: tests/utils/ado/ado.sh $(test.key) ${{ parameters.ANSIBLE_VER }} ${{ parameters.MODULE_NAME }}
         env:
           SHIPPABLE_BUILD_DIR: $(Build.Repository.LocalPath)
           AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -165,9 +165,7 @@ parameters:
       - "setup_azure"
 
 trigger: none
-
-pr:
-  - dev
+pr: none
 
 pool:
   name: pool-ubuntu-2004

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -5,21 +5,21 @@ set -o pipefail -e
 group="$1"
 
 echo '--------------------------------------------'
-echo "Install Python"
+echo "Inspec default Python"
 echo '--------------------------------------------'
-sudo apt update
-sudo apt install software-properties-common
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt install -y \
-    python"$2" \
-    python3-dateutil \
-    python3-pip
+python --version
+
+# Only for python2
+export PYTHONIOENCODING="UTF-8"
+export LC_ALL="en_US.utf-8"
 
 echo '--------------------------------------------'
-echo "Setup venv"
+echo "Setup venv (using the target python version)"
 echo '--------------------------------------------'
-python$2 -m venv ~/ansible-venv
+pip install virtualenv
+virtualenv --python /usr/bin/python"$2" ~/ansible-venv
 . ~/ansible-venv/bin/activate
+python --version
 
 echo '--------------------------------------------'
 echo "Clone and setup ansible hacking env"

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -9,7 +9,7 @@ MODULE_NAME="$4"
 
 quit() {
     echo "$@" >&2
-    exit 1
+    exit 0
 }
 
 die() {

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# A number represents the group number, or "sanity"
 GROUP_NO="$1"
 PY_VER="$2"
 ANSIBLE_VER="$3"
@@ -12,7 +13,7 @@ die() {
 }
 
 # Skip if running against a certain 
-if [ "$4" != "all" ]; then
+if [ "$GROUP_NO" != "sanity" ] && [ "$MODULE_NAME" != "all" ] ; then
     grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null || die "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit..."
 fi
 
@@ -28,11 +29,11 @@ echo "Clone and setup ansible hacking env"
 echo '--------------------------------------------'
 git clone https://github.com/ansible/ansible.git ~/ansible
 pushd ~/ansible > /dev/null
-    if [ "$3" = "devel" ]
+    if [ "$ANSIBLE_VER" = "devel" ]
     then
         echo "The branch is devel"
     else
-        git checkout "stable-$3"
+        git checkout "stable-$ANSIBLE_VER"
     fi
     source hacking/env-setup
     pip install paramiko PyYAML Jinja2 httplib2 six
@@ -56,14 +57,14 @@ timeout=180
 echo '--------------------------------------------'
 echo "Disable non-chosen target"
 echo '--------------------------------------------'
-if [ "$4" = "all" ]
+if [ "$MODULE_NAME" = "all" ]
 then
     echo "All module need test"
 else
-    path_dir="${TEST_DIR}/tests/integration/targets/"
-    for item in "$path_dir"*
+    path_dir="${TEST_DIR}/tests/integration/targets"
+    for item in "$path_dir"/*
     do
-        if [ "${item}" != "$path_dir""$4" ]; then
+        if [ "${item}" != "$path_dir/$MODULE_NAME" ]; then
             echo " " >> "${item}"/aliases
             echo "disabled" >> "${item}"/aliases
         fi

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -28,6 +28,10 @@ python -m venv ~/ansible-venv
 . ~/ansible-venv/bin/activate
 python --version
 
+# Try to install setuptools, which is not available for (at least 3.12)
+# (if it failed, still continue)
+pip install setuptools || /bin/true
+
 echo '--------------------------------------------'
 echo "Clone and setup ansible hacking env"
 echo '--------------------------------------------'

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -7,6 +7,11 @@ PY_VER="$2"
 ANSIBLE_VER="$3"
 MODULE_NAME="$4"
 
+quit() {
+    echo "$@" >&2
+    exit 1
+}
+
 die() {
     echo "$@" >&2
     exit 1
@@ -14,7 +19,7 @@ die() {
 
 # Skip if running against a certain 
 if [ "$GROUP_NO" != "sanity" ] && [ "$MODULE_NAME" != "all" ] ; then
-    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null || die "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit..."
+    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null || quit "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit..."
 fi
 
 echo '--------------------------------------------'

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -5,19 +5,9 @@ set -o pipefail -e
 group="$1"
 
 echo '--------------------------------------------'
-echo "Inspec default Python"
-echo '--------------------------------------------'
-python --version
-
-# Only for python2
-export PYTHONIOENCODING="UTF-8"
-export LC_ALL="en_US.utf-8"
-
-echo '--------------------------------------------'
 echo "Setup venv (using the target python version)"
 echo '--------------------------------------------'
-pip install virtualenv
-virtualenv --python /usr/bin/python"$2" ~/ansible-venv
+python -m venv ~/ansible-venv
 . ~/ansible-venv/bin/activate
 python --version
 

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -1,76 +1,59 @@
 #!/usr/bin/env bash
 
-set -o pipefail -eux
+set -o pipefail -e
 
-declare -a args
-IFS='/:' read -ra args <<< "$1"
+group="$1"
 
-group="${args[0]}"
+echo '--------------------------------------------'
+echo "Install Python"
+echo '--------------------------------------------'
+sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt install -y \
+    python"$2" \
+    python3-dateutil \
+    python3-pip
 
-command -v python
-python -V
-if [ "$2" = "2.7" ]
-then
-    echo "The specified environment is Python2.7"
-else
-    alias pip='pip3'
-    sudo apt update
-    sudo apt install software-properties-common
-    sudo add-apt-repository ppa:deadsnakes/ppa
-    sudo apt install python"$2" -y
-    sudo apt install python3-dateutil
-    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python"$2" 1
-    
-    if [ "$2" = "3.10" ]
-    then
-        sudo apt-get install python3.10-distutils
-    fi
-
-    if [ "$2" = "3.11" ]
-    then
-        sudo apt-get install python3.11-distutils
-    fi
-fi
-
-command -v pip
-pip --version
-pip list --disable-pip-version-check
-
-export PATH="${PWD}/bin:${PATH}"
-export PYTHONIOENCODING="UTF-8"
-export LC_ALL="en_US.utf-8"
-
-pip install virtualenv
-virtualenv --python /usr/bin/python"$2" ~/ansible-venv
-
-set +ux
+echo '--------------------------------------------'
+echo "Setup venv"
+echo '--------------------------------------------'
+python$2 -m venv ~/ansible-venv
 . ~/ansible-venv/bin/activate
-set -ux
 
-git clone https://github.com/ansible/ansible.git
-cd "ansible"
-if [ "$3" = "devel" ]
-then
-    echo "The branch is devel"
-else
-    git checkout "stable-$3"
-fi
-source hacking/env-setup
-pip install paramiko PyYAML Jinja2  httplib2 six
+echo '--------------------------------------------'
+echo "Clone and setup ansible hacking env"
+echo '--------------------------------------------'
+git clone https://github.com/ansible/ansible.git ~/ansible
+pushd ~/ansible > /dev/null
+    if [ "$3" = "devel" ]
+    then
+        echo "The branch is devel"
+    else
+        git checkout "stable-$3"
+    fi
+    source hacking/env-setup
+    pip install paramiko PyYAML Jinja2 httplib2 six
+popd > /dev/null
 
+echo '--------------------------------------------'
+echo 'Copy and install our collection to a test directory'
+echo '--------------------------------------------'
 TEST_DIR="${HOME}/.ansible/ansible_collections/azure/azcollection"
 mkdir -p "${TEST_DIR}"
 cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
 cd "${TEST_DIR}"
 mkdir -p shippable/testresults
-
 pip install  -I -r "${TEST_DIR}/requirements.txt"
 pip install  -I -r "${TEST_DIR}/sanity-requirements.txt"
-
 pip install ansible-lint
 
 timeout=180
 
+# See: https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html
+echo '--------------------------------------------'
+echo "Disable non-chosen target"
+echo '--------------------------------------------'
 if [ "$4" = "all" ]
 then
     echo "All module need test"
@@ -78,40 +61,23 @@ else
     path_dir="${TEST_DIR}/tests/integration/targets/"
     for item in "$path_dir"*
     do
-        if [ "${item}" = "$path_dir""$4" ]
-        then
-            echo "PASS"
-        else
+        if [ "${item}" != "$path_dir""$4" ]
             echo " " >> "${item}"/aliases
             echo "disabled" >> "${item}"/aliases
         fi
     done
 fi
+
+echo '--------------------------------------------'
+echo "List dependencies and ansible version"
 echo '--------------------------------------------'
 pip list
 ansible --version
+
 echo '--------------------------------------------'
-
+echo 'Test'
+echo '--------------------------------------------'
 ansible-test env --dump --show --timeout "${timeout}" --color -v
-
-cat <<EOF >> "${TEST_DIR}"/tests/integration/cloud-config-azure.ini
-[default]
-AZURE_CLIENT_ID:${AZURE_CLIENT_ID}
-AZURE_SECRET:${AZURE_SECRET}
-AZURE_SUBSCRIPTION_ID:${AZURE_SUBSCRIPTION_ID}
-AZURE_SUBSCRIPTION_SEC_ID:${AZURE_SUBSCRIPTION_SEC_ID}
-AZURE_TENANT:${AZURE_TENANT}
-RESOURCE_GROUP:${RESOURCE_GROUP}
-RESOURCE_GROUP_SECONDARY:${RESOURCE_GROUP_SECONDARY}
-RESOURCE_GROUP_THIRD:${RESOURCE_GROUP_THIRD}
-RESOURCE_GROUP_DATALAKE:${RESOURCE_GROUP_DATALAKE}
-AZURE_PRINCIPAL_ID:${AZURE_PRINCIPAL_ID}
-AZURE_MANAGED_BY_TENANT_ID:${AZURE_MANAGED_BY_TENANT_ID}
-AZURE_ROLE_DEFINITION_ID:${AZURE_ROLE_DEFINITION_ID}
-EOF
-
-rm -rf "ansible"
-
 if [ "sanity" = "${group}" ]
 then
     ansible-lint --exclude "tests/integration/targets/inventory_azure/playbooks/vars.yml" --force-color -c "tests/lint/ignore-lint.txt"

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
-
-set -o pipefail -e
+set -e
 
 GROUP_NO="$1"
 PY_VER="$2"
 ANSIBLE_VER="$3"
 MODULE_NAME="$4"
 
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
 # Skip if running against a certain 
 if [ "$4" != "all" ]; then
-    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null || { echo "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit."; exit; }
+    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null || die "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit..."
 fi
 
 echo '--------------------------------------------'
@@ -81,5 +85,23 @@ then
     ansible-lint --exclude "tests/integration/targets/inventory_azure/playbooks/vars.yml" --force-color -c "tests/lint/ignore-lint.txt"
     ansible-test sanity --color -v --junit
 else
-    ansible-test integration --color -v --retry-on-error "shippable/azure/group${GROUP_NO}/" --allow-destructive
+    # See: https://github.com/ansible/ansible/blob/23a84902cb9599fe958a86e7a95520837964726a/test/lib/ansible_test/config/cloud-config-azure.ini.template
+    config_file="${TEST_DIR}"/tests/integration/cloud-config-azure.ini
+    cat <<EOF >> "$config_file"
+[default]
+AZURE_CLIENT_ID:${AZURE_CLIENT_ID}
+AZURE_SECRET:${AZURE_SECRET}
+AZURE_SUBSCRIPTION_ID:${AZURE_SUBSCRIPTION_ID}
+AZURE_SUBSCRIPTION_SEC_ID:${AZURE_SUBSCRIPTION_SEC_ID}
+AZURE_TENANT:${AZURE_TENANT}
+RESOURCE_GROUP:${RESOURCE_GROUP}
+RESOURCE_GROUP_SECONDARY:${RESOURCE_GROUP_SECONDARY}
+RESOURCE_GROUP_THIRD:${RESOURCE_GROUP_THIRD}
+RESOURCE_GROUP_DATALAKE:${RESOURCE_GROUP_DATALAKE}
+AZURE_PRINCIPAL_ID:${AZURE_PRINCIPAL_ID}
+AZURE_MANAGED_BY_TENANT_ID:${AZURE_MANAGED_BY_TENANT_ID}
+AZURE_ROLE_DEFINITION_ID:${AZURE_ROLE_DEFINITION_ID}
+EOF
+    ansible-test integration --color -v --retry-on-error "shippable/azure/group${GROUP_NO}/" --allow-destructive || { rm "$config_file"; die "failed to run integration test"; }
+    rm "$config_file"
 fi

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -51,7 +51,7 @@ else
     path_dir="${TEST_DIR}/tests/integration/targets/"
     for item in "$path_dir"*
     do
-        if [ "${item}" != "$path_dir""$4" ]
+        if [ "${item}" != "$path_dir""$4" ]; then
             echo " " >> "${item}"/aliases
             echo "disabled" >> "${item}"/aliases
         fi

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -9,7 +9,7 @@ MODULE_NAME="$4"
 
 # Skip if running against a certain 
 if [ "$4" != "all" ]; then
-    grep "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null && { echo "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit."; exit; }
+    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null && { echo "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit."; exit; }
 fi
 
 echo '--------------------------------------------'

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -3,9 +3,8 @@ set -e
 
 # A number represents the group number, or "sanity"
 GROUP_NO="$1"
-PY_VER="$2"
-ANSIBLE_VER="$3"
-MODULE_NAME="$4"
+ANSIBLE_VER="$2"
+MODULE_NAME="$3"
 
 quit() {
     echo "$@" >&2

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -2,7 +2,15 @@
 
 set -o pipefail -e
 
-group="$1"
+GROUP_NO="$1"
+PY_VER="$2"
+ANSIBLE_VER="$3"
+MODULE_NAME="$4"
+
+# Skip if running against a certain 
+if [ "$4" != "all" ]; then
+    grep "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null && { echo "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit."; exit; }
+fi
 
 echo '--------------------------------------------'
 echo "Setup venv (using the target python version)"
@@ -68,10 +76,10 @@ echo '--------------------------------------------'
 echo 'Test'
 echo '--------------------------------------------'
 ansible-test env --dump --show --timeout "${timeout}" --color -v
-if [ "sanity" = "${group}" ]
+if [ "sanity" = "${GROUP_NO}" ]
 then
     ansible-lint --exclude "tests/integration/targets/inventory_azure/playbooks/vars.yml" --force-color -c "tests/lint/ignore-lint.txt"
     ansible-test sanity --color -v --junit
 else
-    ansible-test integration --color -v --retry-on-error "shippable/azure/group${group}/" --allow-destructive
+    ansible-test integration --color -v --retry-on-error "shippable/azure/group${GROUP_NO}/" --allow-destructive
 fi

--- a/tests/utils/ado/ado.sh
+++ b/tests/utils/ado/ado.sh
@@ -9,7 +9,7 @@ MODULE_NAME="$4"
 
 # Skip if running against a certain 
 if [ "$4" != "all" ]; then
-    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null && { echo "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit."; exit; }
+    grep -w "shippable/azure/group${GROUP_NO}" "./tests/integration/targets/${MODULE_NAME}/aliases" > /dev/null || { echo "Module: $MODULE_NAME doesn't belong to this group ($GROUP_NO). Exit."; exit; }
 fi
 
 echo '--------------------------------------------'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- pr-pipeline:
  - Set default version to latest for python and ansible
  - Explicitly set `pr: none` to disable auto triggering by PR
  - Add a new step ("Determine the target ansible test group number") to echo the active gruop number to guide the test validator to only inspect that matrix job for inspecting the test result
  - Removing `python.version` in matrix setting as it is all the same
- ado.sh:
  - Remove python setup steps as it is setup by the UsePythonVersion ADO task already (note that this effectively removed the capability to test python2, which should be fine per experience). Another reason to remove those python setup is that a local run of the script will mass up the local python installations.
  - Early quit if the module is specified and the current group doesn't contain the module
  - Ensure cloud-config-azure.ini is removed before exit