### PR TITLE
Fix Linter errors caused by repeate descriptions

### DIFF
--- a/plugins/modules/azure_rm_adserviceprincipal.py
+++ b/plugins/modules/azure_rm_adserviceprincipal.py
@@ -140,7 +140,7 @@ class AzureRMADServicePrincipal(AzureRMModuleBaseExt):
                                                         supports_tags=False,
                                                         is_ad_resource=True)
 
-        mutually_exclusive  = {}
+        mutually_exclusive = {}
 
     def exec_module(self, **kwargs):
 

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_cache.yml
@@ -13,7 +13,7 @@
           - vm_name_2 in hostvars
           - hostvars[vm_name_2].powerstate == "running"
 
-    - name: Show powerstate
+    - name: Show the VM powerstate for the first time
       ansible.builtin.debug:
         var: hostvars[vm_name_2].powerstate
 
@@ -29,7 +29,7 @@
           - vm_name_2 in hostvars
           - hostvars[vm_name_2].powerstate == "running"
 
-    - name: Show powerstate
+    - name: Show the VM powerstate for the secondary time
       ansible.builtin.debug:
         var: hostvars[vm_name_2].powerstate
 
@@ -42,6 +42,6 @@
           - vm_name_2 in hostvars
           - hostvars[vm_name_2].powerstate == "stopped"
 
-    - name: Show powerstate
+    - name: Show the VM powerstate for the third time
       ansible.builtin.debug:
         var: hostvars[vm_name_2].powerstate

--- a/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_1.yml
+++ b/tests/integration/targets/inventory_azure/playbooks/test_inventory_flush_part_1.yml
@@ -13,7 +13,7 @@
           - vm_name_2 in hostvars
           - hostvars[vm_name_2].powerstate == "stopped"
 
-    - name: Show powerstate
+    - name: Show the VM powerstate for the first time
       ansible.builtin.debug:
         var: hostvars[vm_name_2].powerstate
 
@@ -29,6 +29,6 @@
           - vm_name_2 in hostvars
           - hostvars[vm_name_2].powerstate == "stopped"
 
-    - name: Show powerstate
+    - name: Show the VM powerstate for the secondary time
       ansible.builtin.debug:
         var: hostvars[vm_name_2].powerstate


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the errors caused by repeate descriptions in pipelines