### PR TITLE
Add the return of 'last_ownership_update_time' in azure_rm_manageddisk_info.py

### DIFF
--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -263,7 +263,6 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
-
 except Exception:
     # handled in azure_rm_common
     pass

--- a/plugins/modules/azure_rm_manageddisk_info.py
+++ b/plugins/modules/azure_rm_manageddisk_info.py
@@ -226,6 +226,13 @@ azure_managed_disk:
             type: int
             returned: always
             sample: None
+        last_ownership_update_time:
+            description:
+                - The UTC time when the ownership state of the disk was last changed.
+                - The time the disk was last attached or detached from a VM or the time when the VM to which the disk was attached was deallocated or started.
+            returned: always
+            type: str
+            sample: "2025-06-27T01:55:10.239311+00:00"
         source_resource_id:
             description:
                 - This is the ARM id of the source snapshot or disk.
@@ -256,6 +263,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
+
 except Exception:
     # handled in azure_rm_common
     pass
@@ -383,6 +391,7 @@ class AzureRMManagedDiskInfo(AzureRMModuleBase):
             upload_size_bytes=create_data.upload_size_bytes,
             logical_sector_size=create_data.logical_sector_size,
             performance_plus=create_data.performance_plus,
+            last_ownership_update_time=managed_disk.last_ownership_update_time,
             gallery_image_reference=dict(
                 id=create_data.gallery_image_reference.id,
                 shared_gallery_image_id=create_data.gallery_image_reference.shared_gallery_image_id,

--- a/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
@@ -158,6 +158,7 @@
       - "output.ansible_info.azure_managed_disk[0].os_type == 'linux'"
       - output.ansible_info.azure_managed_disk[0].public_network_access == "Enabled"
       - output.ansible_info.azure_managed_disk[0].network_access_policy == 'AllowAll'
+      - not output.ansible_info.azure_managed_disk[0].last_ownership_update_time
 
 - name: Set variables
   ansible.builtin.set_fact:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the return of 'last_ownership_update_time' in azure_rm_manageddisk_info.py, try to fixes #1980
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_manageddisk_info.py
