### PR TITLE
Add the required_by constraint condition

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -1358,10 +1358,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             ansible_facts=dict(azure_vm=None)
         )
 
-        required_if = [('os_disk_encryption_set', '*', ['managed_disk_type'])]
+        required_by = {'os_disk_encryption_set': 'managed_disk_type'}
 
         super(AzureRMVirtualMachine, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                    supports_check_mode=True, required_if=required_if)
+                                                    supports_check_mode=True, required_by=required_by)
 
     @property
     def boot_diagnostics_present(self):

--- a/plugins/modules/azure_rm_virtualnetwork_info.py
+++ b/plugins/modules/azure_rm_virtualnetwork_info.py
@@ -251,7 +251,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             virtualnetworks=[]
         )
 
-        self.required_if = [('name', '*', ['resource_group'])]
+        self.required_by = {'name': 'resource_group'}
 
         self.name = None
         self.resource_group = None
@@ -262,7 +262,7 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
                                                           supports_check_mode=True,
                                                           supports_tags=False,
                                                           facts_module=True,
-                                                          required_if=self.required_if)
+                                                          required_by=self.required_by)
 
     def exec_module(self, **kwargs):
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the required_by constraint condition。 Now, The '*' in required_if does not refer to any character, so the constraint relationships in some modules need to be replaced by required_by
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
required_if = ['name': '*', ['resource_group']] -----> required_by = {'name': resource_group'}
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualnetwork_info.py
azure_rm_virtualmachine.py