### PR TITLE
Support Priority Type Regular on azure_rm_virtualmachinescaleset Module

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -83,6 +83,7 @@ options:
         choices:
             - None
             - Spot
+            - Regular
     eviction_policy:
         description:
             - Specifies the eviction policy for the Azure Spot virtual machine.
@@ -754,7 +755,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             tier=dict(type='str', choices=['Basic', 'Standard']),
             capacity=dict(type='int', default=1),
             upgrade_policy=dict(type='str', choices=['Automatic', 'Manual']),
-            priority=dict(type='str', choices=['None', 'Spot']),
+            priority=dict(type='str', choices=['None', 'Spot', 'Regular']),
             eviction_policy=dict(type='str', choices=['Deallocate', 'Delete']),
             max_price=dict(type='float', default=-1),
             admin_username=dict(type='str'),
@@ -1346,6 +1347,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                         vmss_resource.virtual_machine_profile.billing_profile = self.compute_models.BillingProfile(
                             max_price=self.max_price
                         )
+                    elif self.priority == 'Regular':
+                        vmss_resource.virtual_machine_profile.priority = self.priority
 
                     if self.scale_in_policy:
                         vmss_resource.scale_in_policy = self.gen_scale_in_policy()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Support Priority Type Regular on azure_rm_virtualmachinescaleset Module, try to fixes #2000


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachinescaleset.py

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create VMSS with Regular Instance
  azure_rm_virtualmachinescaleset:
    resource_group: "{{ resource_group }}"
    name: testVMSS
    vm_size: Standard_A1_v2
    admin_username: testuser
    priority: Regular
    single_placement_group: true
    orchestration_mode: Uniform
    ssh_password_enabled: false
    ssh_public_keys:
      - path: /home/testuser/.ssh/authorized_keys
        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAA ********* @qq.com"
    capacity: 1
    virtual_network_name: VMSStestVnet
    subnet_name: VMSStestSubnet
    upgrade_policy: Manual
    tier: Standard
    managed_disk_type: Standard_LRS
    os_disk_caching: ReadWrite
    image:
      offer: 0001-com-ubuntu-server-focal
      publisher: Canonical
      sku: 20_04-lts
      version: latest
```
