### PR TITLE
Ansible.builtin.changed

### DIFF
--- a/tests/integration/targets/azure_rm_acs/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_acs/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Assert the ACS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.provisioning_state == 'Succeeded'
 
 - name: Scale the ACS instance from 1 to 2 - DCOS
@@ -49,7 +49,7 @@
 - name: Assert the ACS instance is well scaled
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.agent_pool_profiles[0].count == 2
 
 - name: Delete the DCOS ACS instance - DCOS
@@ -97,7 +97,7 @@
 - name: Assert the ACS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.provisioning_state == 'Succeeded'
 
 - name: Scale the ACS instance from 1 to 2 - Swarm
@@ -124,7 +124,7 @@
 - name: Assert the ACS instance is well scaled
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.agent_pool_profiles[0].count == 2
 
 - name: Delete the ACS instance - Swarm

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Assert create successfully
   ansible.builtin.assert:
-    that: create_output.changed
+    that: create_output is changed
 
 - name: Create application by app_id again idempotent test
   azure_rm_adapplication:
@@ -25,7 +25,7 @@
 
 - name: Assert application by app_id the idempotent success
   ansible.builtin.assert:
-    that: not output_app_id.changed
+    that: output_app_id is not changed
 
 - name: Create application with more parameters
   azure_rm_adapplication:
@@ -56,7 +56,7 @@
 
 - name: Assert secondary resource create success
   ansible.builtin.assert:
-    that: second_output.changed
+    that: second_output is changed
 
 - name: Get ad app info by object id
   azure_rm_adapplication_info:
@@ -101,7 +101,7 @@
 
 - name: Assert the application delete success
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete ad app by app id again
   azure_rm_adapplication:
@@ -112,7 +112,7 @@
 
 - name: Assert the secondary application delete no changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Get ad app info by app id
   azure_rm_adapplication_info:

--- a/tests/integration/targets/azure_rm_adgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adgroup/tasks/main.yml
@@ -30,8 +30,8 @@
 - name: Assert Otherwise Changed Returns are Equal
   ansible.builtin.assert:
     that:
-      - group_create_changed_shouldpass.changed == True
-      - group_create_unchanged_shouldpass.changed == False
+      - group_create_changed_shouldpass is changed
+      - group_create_unchanged_shouldpass is not changed
       - group_create_changed_shouldpass.display_name == group_create_unchanged_shouldpass.display_name
       - group_create_changed_shouldpass.mail_enabled == group_create_unchanged_shouldpass.mail_enabled
       - group_create_changed_shouldpass.mail_nickname == group_create_unchanged_shouldpass.mail_nickname
@@ -90,7 +90,7 @@
 - name: Validate nothing changed from already present member
   ansible.builtin.assert:
     that:
-      - add_already_present_member_to_group_shouldpass.changed == false
+      - add_already_present_member_to_group_shouldpass is not changed
 
 - name: Ensure member is not in group using object_id
   azure_rm_adgroup:
@@ -118,7 +118,7 @@
 - name: Validate nothing changed from already absent member
   ansible.builtin.assert:
     that:
-      - remove_already_absent_member_from_group_shouldpass.changed == false
+      - remove_already_absent_member_from_group_shouldpass is not changed
 
 - name: Return a specific group using object_id
   azure_rm_adgroup_info:

--- a/tests/integration/targets/azure_rm_adpassword/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adpassword/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Assert the password created
   ansible.builtin.assert:
     that:
-      - ad_fact.changed
+      - ad_fact is changed
 
 - name: Create second ad password by app_object_id
   azure_rm_adpassword:
@@ -23,7 +23,7 @@
 - name: Assert the secondary password created
   ansible.builtin.assert:
     that:
-      - ad_fact02.changed
+      - ad_fact02 is changed
 
 - name: Create ad service principal
   azure_rm_adserviceprincipal:
@@ -47,7 +47,7 @@
 - name: Assert the third add password created
   ansible.builtin.assert:
     that:
-      - ad_fact03.changed
+      - ad_fact03 is changed
 
 - name: Can't update ad password
   azure_rm_adpassword:
@@ -82,7 +82,7 @@
 - name: Assert the ad password deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete all ad password
   azure_rm_adpassword:
@@ -94,4 +94,4 @@
 - name: Assert the ad password delete
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_adserviceprincipal/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adserviceprincipal/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Assert the ad service prinicipal created
   ansible.builtin.assert:
     that:
-      - ad_fact.changed
+      - ad_fact is changed
 
 - name: Create ad service principal (idempontent)
   azure_rm_adserviceprincipal:
@@ -27,7 +27,7 @@
 - name: Assert the ad service principal idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get ad service principal info by app_id
   azure_rm_adserviceprincipal_info:
@@ -67,4 +67,4 @@
 - name: Assert the ad service principals deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_aduser/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aduser/tasks/main.yml
@@ -52,7 +52,7 @@
 - name: Assert Nothing Changed
   ansible.builtin.assert:
     that:
-      - attempted_update_with_no_changes_should_pass["changed"] == False
+      - attempted_update_with_no_changes_should_pass is not changed
 
 - name: User_principal_name Should Pass
   azure_rm_aduser_info:

--- a/tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Assert the resource was created and returns expected variables
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
       - output.host_name
 
@@ -45,7 +45,7 @@
 - name: Assert the resource has not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Load Endpoint info
   azure_rm_afdendpoint_info:
@@ -64,7 +64,7 @@
       - output.afdendpoints[0].id
       - output.afdendpoints[0].profile_name == profile
       - output.afdendpoints[0].tags.test == 'tag value'
-      - not output.changed
+      - output is not changed
 
 - name: Update EndPoint (with different values)
   azure_rm_afdendpoint:
@@ -81,7 +81,7 @@
 - name: Assert the resource has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update EndPoint (idempotent test)
   azure_rm_afdendpoint:
@@ -98,7 +98,7 @@
 - name: Assert the resource has not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update EndPoint (replace tags)
   azure_rm_afdendpoint:
@@ -115,7 +115,7 @@
 - name: Assert the resource has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Load Endpoint info
   azure_rm_afdendpoint_info:
@@ -132,7 +132,7 @@
       - output.afdendpoints[0].enabled_state == 'Disabled'
       - output.afdendpoints[0].tags['test2'] == 'a tag value'
       - output.afdendpoints[0].tags['newtag'] is not defined
-      - not output.changed
+      - output is not changed
 
 - name: Delete EndPoint
   azure_rm_afdendpoint:
@@ -145,7 +145,7 @@
 - name: Assert the resource was deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete EndPoint (idempotent test)
   azure_rm_afdendpoint:
@@ -158,7 +158,7 @@
 - name: Assert the delete function is idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Frontdoor Profile
   azure_rm_cdnprofile:

--- a/tests/integration/targets/azure_rm_afdorigin/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdorigin/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update Origin (idempotent test)
@@ -69,7 +69,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Load Origin info
   azure_rm_afdorigin_info:
@@ -91,7 +91,7 @@
       - output.afdorigins[0].origin_host_header == '10.0.0.1'
       - output.afdorigins[0].priority == 1
       - output.afdorigins[0].weight == 123
-      - not output.changed
+      - output is not changed
 
 - name: Create Origin 2
   azure_rm_afdorigin:
@@ -111,7 +111,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Load Origin info for both
@@ -125,7 +125,7 @@
   ansible.builtin.assert:
     that:
       - output.afdorigins | length == 2
-      - not output.changed
+      - output is not changed
 
 - name: Update Origin (with different values)
   azure_rm_afdorigin:
@@ -144,7 +144,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update Origin Group (idempotent test)
   azure_rm_afdorigin:
@@ -163,7 +163,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Origin
   azure_rm_afdorigin:
@@ -177,7 +177,7 @@
 - name: Assert the resource was deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Origin 2
   azure_rm_afdorigin:
@@ -191,7 +191,7 @@
 - name: Assert the resource was delete
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Origin (idempotent test)
   azure_rm_afdorigin:
@@ -205,7 +205,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Origin Group
   azure_rm_afdorigingroup:

--- a/tests/integration/targets/azure_rm_afdorigingroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdorigingroup/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update Origin Group (idempotent test)
@@ -55,7 +55,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create Origin Group 2
   azure_rm_afdorigingroup:
@@ -77,7 +77,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Load info for all Origin Groups
@@ -90,7 +90,7 @@
   ansible.builtin.assert:
     that:
       - output.afdorigingroups | length == 2
-      - not output.changed
+      - output is not changed
 
 - name: Delete Origin Group 2
   azure_rm_afdorigingroup:
@@ -103,7 +103,7 @@
 - name: Assert the resource was deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Load Origin Group info
@@ -124,7 +124,7 @@
       - output.afdorigingroups[0].load_balancing_settings.additional_latency_in_milliseconds == 50
       - output.afdorigingroups[0].load_balancing_settings.sample_size == 4
       - output.afdorigingroups[0].load_balancing_settings.successful_samples_required == 3
-      - not output.changed
+      - output is not changed
 
 - name: Update Origin Group (with different values)
   azure_rm_afdorigingroup:
@@ -146,7 +146,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update Origin Group (idempotent test)
   azure_rm_afdorigingroup:
@@ -168,7 +168,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Origin Group
   azure_rm_afdorigingroup:
@@ -181,7 +181,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Origin Group (idempotent test)
   azure_rm_afdorigingroup:
@@ -194,7 +194,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Frontdoor Profile
   azure_rm_cdnprofile:

--- a/tests/integration/targets/azure_rm_afdroute/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdroute/tasks/main.yml
@@ -85,7 +85,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update Route (idempotent test)
@@ -111,7 +111,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.id
 
 - name: Load Route info
@@ -129,7 +129,7 @@
       - output.afdroutes[0].enabled_state == 'Enabled'
       - output.afdroutes[0].id
       - output.afdroutes[0].rule_sets | length == 1
-      - not output.changed
+      - output is not changed
 
 - name: Update Route (with different values)
   azure_rm_afdroute:
@@ -156,7 +156,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update Route (idempotent test)
@@ -184,7 +184,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.id
 
 - name: Delete Route
@@ -200,7 +200,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Delete Route (idempotent test)
@@ -216,7 +216,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Origin
   azure_rm_afdorigin:

--- a/tests/integration/targets/azure_rm_afdrules/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdrules/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update Rule 1 (idempotent test)
@@ -89,7 +89,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.id
 
 - name: Load Rule info
@@ -110,7 +110,7 @@
       - output.afdrules[0].match_processing_behavior == "Continue"
       - output.afdrules[0].order == 1
       - output.afdrules[0].rule_set_name == "{{ ruleset }}"
-      - not output.changed
+      - output is not changed
 
 - name: Delete Rule
   azure_rm_afdrules:
@@ -124,7 +124,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Delete Rule (idempotent test)
@@ -139,7 +139,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create Ruleset
   azure_rm_afdruleset:

--- a/tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update Ruleset (idempotent test)
@@ -37,7 +37,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create Ruleset 2
   azure_rm_afdruleset:
@@ -50,7 +50,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Load info for all Rulesets
@@ -63,7 +63,7 @@
   ansible.builtin.assert:
     that:
       - output.afdrulesets | length == 2
-      - not output.changed
+      - output is not changed
 
 - name: Delete Origin Group 2
   azure_rm_afdruleset:
@@ -76,7 +76,7 @@
 - name: Assert the resource was deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Load info for all Rulesets
@@ -90,7 +90,7 @@
     that:
       - output.afdrulesets | length == 1
       - output.afdrulesets[0].name == "{{ ruleset }}"
-      - not output.changed
+      - output is not changed
 
 - name: Delete Ruleset
   azure_rm_afdruleset:
@@ -103,7 +103,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Ruleset (idempotent test)
   azure_rm_afdruleset:
@@ -116,7 +116,7 @@
 - name: Assert the resource was not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete Frontdoor Profile
   azure_rm_cdnprofile:

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -110,7 +110,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
 
 - name: Get AKS fact
@@ -161,7 +161,7 @@
 - name: Assert the AKS instance is well update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get AKS fact
   azure_rm_aks_info:
@@ -219,7 +219,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get available version
   azure_rm_aksversion_info:
@@ -262,7 +262,7 @@
 - name: Assert the AKS instance is upgraded
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.kubernetes_version == version1.azure_aks_versions[0]
       - output.addon.httpApplicationRouting.enabled ==  False
       - output.agent_pool_profiles[0].count == 1
@@ -303,7 +303,7 @@
 - name: Assert the aks idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Upgrade the AKS instance with agent pool profiles
   azure_rm_aks:
@@ -341,7 +341,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
   ignore_errors: true
   register: ignore_errors_register
@@ -381,7 +381,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Upgrade the AKS instance with multiple agent pool profiles
   azure_rm_aks:
@@ -424,7 +424,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - "output.agent_pool_profiles | length == 2"
       - output.provisioning_state == 'Succeeded'
       - output.agent_pool_profiles[1].mode == 'User'
@@ -470,7 +470,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the default2 agent_pool mode from User to System
   azure_rm_aks:
@@ -513,7 +513,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - "output.agent_pool_profiles | length == 2"
       - output.provisioning_state == 'Succeeded'
       - output.agent_pool_profiles[1].mode == 'System'
@@ -579,7 +579,7 @@
 - name: Assert the AKS instance is well deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the AKS instance (idempotent)
   azure_rm_aks:
@@ -591,7 +591,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get AKS fact
   azure_rm_aks_info:

--- a/tests/integration/targets/azure_rm_aks/tasks/minimal-cluster.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/minimal-cluster.yml
@@ -44,7 +44,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
 
 - name: Get AKS fact
@@ -98,7 +98,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Use minimal parameters and user-assigned identity
   azure_rm_aks:
@@ -138,7 +138,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
 
 - name: Get AKS fact
@@ -194,7 +194,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Use minimal parameters and user-assigned 2 identity
   azure_rm_aks:
@@ -234,7 +234,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
 
 - name: Get AKS fact
@@ -284,7 +284,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the AKS instance
   azure_rm_aks:
@@ -296,7 +296,7 @@
 - name: Assert the AKS instance is well deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create Log Analytics Workspace
   azure_rm_loganalyticsworkspace:
@@ -348,7 +348,7 @@
 - name: Assert the AKS instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new kubernet service with security parameters (Idempotent test)
   azure_rm_aks:
@@ -390,7 +390,7 @@
 - name: Assert the AKS instance no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the kubernet service security parameters parameters
   azure_rm_aks:
@@ -432,7 +432,7 @@
 - name: Assert the AKS instance updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get AKS fact
   azure_rm_aks_info:

--- a/tests/integration/targets/azure_rm_aksagentpool/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aksagentpool/tasks/main.yml
@@ -127,7 +127,7 @@
 - name: Assert the node agent pool created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Add agent pool (Idempotent test)
   azure_rm_aksagentpool:
@@ -154,7 +154,7 @@
 - name: Assert the node agent pool not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get cluster's node agent pool info
   azure_rm_aksagentpool_info:
@@ -192,7 +192,7 @@
 - name: Assert the node agent pool udpated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get cluster's node agent pool info
   azure_rm_aksagentpool_info:
@@ -255,7 +255,7 @@
 - name: Assert the node agent pool create well
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new agent pool with multi parameters( Idempotent test)
   azure_rm_aksagentpool:
@@ -299,7 +299,7 @@
 - name: Assert the node agent pool no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete node agent pool
   azure_rm_aksagentpool:
@@ -319,4 +319,4 @@
 - name: Assert the node agent pool has deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_apimanagement/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_apimanagement/tasks/main.yml
@@ -35,8 +35,8 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - newapi.changed == True
-      - newapi.failed == False
+      - newapi is changed
+      - newapi is not failed
 
 - name: Create a new API instance Idempotent
   azure_rm_apimanagement:
@@ -54,8 +54,8 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - newapi_idempotent.changed == False
-      - newapi_idempotent.failed == False
+      - newapi_idempotent is not changed
+      - newapi_idempotent is not failed
 
 - name: Update protocols
   azure_rm_apimanagement:
@@ -74,7 +74,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - updateapi.changed == True
+      - updateapi is changed
 
 - name: Create different format api
   azure_rm_apimanagement:
@@ -91,8 +91,8 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - newopenapi.changed == True
-      - newopenapi.failed == False
+      - newopenapi is changed
+      - newopenapi is not failed
 
 - name: Get api information
   azure_rm_apimanagement_info:
@@ -117,7 +117,7 @@
 - name: Assert the changes
   ansible.builtin.assert:
     that:
-      - deleteapi.changed == True
+      - deleteapi is changed
 
 - name: Delete an api Idempotent
   azure_rm_apimanagement:
@@ -130,7 +130,7 @@
 - name: Assert the changes
   ansible.builtin.assert:
     that:
-      - deleteapi_idempotent.changed == False
+      - deleteapi_idempotent is not changed
 
 - name: Delete an api
   azure_rm_apimanagement:

--- a/tests/integration/targets/azure_rm_apimanagementservice/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_apimanagementservice/tasks/main.yml
@@ -15,8 +15,8 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed == True
-      - output.failed == False
+      - output is changed
+      - output is not failed
 
 - name: Recreate api management service idempotent test
   azure_rm_apimanagementservice:
@@ -31,8 +31,8 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed == False
-      - output.failed == False
+      - output is not changed
+      - output is not failed
 
 - name: Get api management service information
   azure_rm_apimanagementservice_info:
@@ -55,4 +55,4 @@
 - name: Assert the changes
   ansible.builtin.assert:
     that:
-      - output.changed == True
+      - output is changed

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -221,7 +221,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to create v2 instance of Application Gateway with rewrite rules - no update
   azure_rm_appgateway:
@@ -379,7 +379,7 @@
 - name: Assert the resource instance is not updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to create v2 instance of Application Gateway with rewrite rules - update rewrite rule
   azure_rm_appgateway:
@@ -540,7 +540,7 @@
 - name: Assert the resource instance is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to create v2 instance of Application Gateway with UserAssigned identity
   azure_rm_appgateway:
@@ -706,7 +706,7 @@
 - name: Assert the resource instance is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to create v2 instance of Application Gateway with no Update
   azure_rm_appgateway:
@@ -872,7 +872,7 @@
 - name: Assert the resource instance is updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to create v2 instance of Application Gateway with autoscale configuration and trusted root certificates
   azure_rm_appgateway:
@@ -1042,7 +1042,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 
 - name: Try to create v2 instance of Application Gateway with autoscale configuration and trusted root certificates - no update
@@ -1213,7 +1213,7 @@
 - name: Assert the resource instance is not updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Configure public IP for waf_v2 gateway
   azure_rm_publicipaddress:
@@ -1387,7 +1387,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to create waf_v2 instance of Application Gateway with waf configuration - no update
   azure_rm_appgateway:
@@ -1554,7 +1554,7 @@
 - name: Assert the resource instance is not updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Configure public IP for waf policy gateway
   azure_rm_publicipaddress:
@@ -1723,7 +1723,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to create waf policy instance of Application Gateway - no update
   azure_rm_appgateway:
@@ -1885,7 +1885,7 @@
 - name: Assert the resource instance is not updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete v2 instance of Application Gateway
   azure_rm_appgateway:
@@ -1896,7 +1896,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete waf_v2 instance of Application Gateway
   azure_rm_appgateway:
@@ -1907,7 +1907,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete waf policy instance of Application Gateway
   azure_rm_appgateway:
@@ -1918,7 +1918,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete public IP for v2 gateway
   azure_rm_publicipaddress:
@@ -1929,7 +1929,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete public IP for waf v2 gateway
   azure_rm_publicipaddress:
@@ -1940,7 +1940,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete virtual network
   azure_rm_virtualnetwork:

--- a/tests/integration/targets/azure_rm_applicationfirewallpolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_applicationfirewallpolicy/tasks/main.yml
@@ -64,7 +64,7 @@
 - name: Assert the there is no application firewall policy
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new application firewall policy
   azure_rm_applicationfirewallpolicy:
@@ -127,7 +127,7 @@
 - name: Assert the policy created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new application firewall policy (Idempotent Test)
   azure_rm_applicationfirewallpolicy:
@@ -190,7 +190,7 @@
 - name: Assert the policy no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the new application firewall policy
   azure_rm_applicationfirewallpolicy:
@@ -272,7 +272,7 @@
 - name: Assert the policy updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the application gateway facts
   azure_rm_applicationfirewallpolicy_info:
@@ -299,4 +299,4 @@
 - name: Assert the policy deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Assert app service was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create a linux plan
@@ -35,7 +35,7 @@
 - name: Assert app service was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Get app service plan by name
@@ -61,7 +61,7 @@
 
 - name: Assert app service is not updated
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update a windows plan sku
   azure_rm_appserviceplan:
@@ -73,7 +73,7 @@
 - name: Assert app service was updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update a linux plan number of workers
   azure_rm_appserviceplan:
@@ -87,7 +87,7 @@
 - name: Assert app service was updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create premium linux plan
   azure_rm_appserviceplan:
@@ -100,7 +100,7 @@
 - name: Assert app service was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create premium linux plan idempotent
@@ -113,4 +113,4 @@
 
 - name: Assert app service is not updated
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed

--- a/tests/integration/targets/azure_rm_automationaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_automationaccount/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Check the check mode return
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create automation account
   azure_rm_automationaccount:
@@ -25,7 +25,7 @@
 - name: Assert the account created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create automation account
@@ -37,7 +37,7 @@
 - name: Assert the account already created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get automation account
   azure_rm_automationaccount_info:
@@ -68,7 +68,7 @@
 - name: Assert the account deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete account
   azure_rm_automationaccount:
@@ -80,7 +80,7 @@
 - name: Assert the account deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete account
   azure_rm_automationaccount:
@@ -92,4 +92,4 @@
 - name: Assert the account delete
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed

--- a/tests/integration/targets/azure_rm_automationrunbook/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_automationrunbook/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Assert the automation runbook is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create automation runbook with default parameters (idempotent)
   azure_rm_automationrunbook:
@@ -43,7 +43,7 @@
 - name: Assert the automation runbook is well created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create automation runbook with more paramters
   azure_rm_automationrunbook:
@@ -62,7 +62,7 @@
 - name: Assert the automation runbook is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update automation runbook with more paramters
   azure_rm_automationrunbook:
@@ -81,7 +81,7 @@
 - name: Assert the automation runbook is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Publish automation runbook
   azure_rm_automationrunbook:
@@ -94,7 +94,7 @@
 - name: Assert the automation runbook is well published
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get automation runbook
   azure_rm_automationrunbook_info:

--- a/tests/integration/targets/azure_rm_autoscale/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_autoscale/tasks/main.yml
@@ -72,7 +72,7 @@
 - name: Assert check mode facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create auto scaling
   azure_rm_autoscale:
@@ -101,7 +101,7 @@
 - name: Assert the auto scale created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create auto scaling (idemponent)
@@ -128,7 +128,7 @@
 - name: Assert the auto scale idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.id
 
 - name: Update auto scaling
@@ -176,7 +176,7 @@
 - name: Assert the auto scale created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.profiles[0].rules[0].metric_resource_uri == vmss.ansible_facts.azure_vmss.id
 
 - name: Delete auto scaling (check mode)
@@ -190,7 +190,7 @@
 - name: Assert the auto scaling deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete auto scaling
   azure_rm_autoscale:
@@ -202,7 +202,7 @@
 - name: Assert the auto scaling deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete auto scaling (idemponetent)
   azure_rm_autoscale:
@@ -214,7 +214,7 @@
 - name: Assert the auto scaling deleted idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Clean VMSS
   azure_rm_virtualmachinescaleset:

--- a/tests/integration/targets/azure_rm_availabilityset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_availabilityset/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Assert the availability created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create an availability set with default options
   azure_rm_availabilityset:
@@ -21,7 +21,7 @@
 
 - name: Assert the availability created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create proximity placement group name
   ansible.builtin.set_fact:
@@ -47,7 +47,7 @@
 
 - name: Assert the availability set created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Modify availabilty set immutable options - no changes, fail for immutable options
   azure_rm_availabilityset:
@@ -63,7 +63,7 @@
 - name: Assert availabilty set modified
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.msg == 'You tried to change platform_update_domain_count but is was unsuccessful. An Availability Set is immutable, except tags'
 
 - name: Modify availabilty set immutable options and set tags - change tags and fail for immutable options
@@ -82,7 +82,7 @@
 - name: Assert the availabilty set idempotent
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.msg == 'You tried to change platform_update_domain_count but is was unsuccessful. An Availability Set is immutable, except tags'
 
 - name: Modify availabilty set options to update tags
@@ -133,7 +133,7 @@
 - name: Assert the check mode test
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.checktest1 == 'modified1'
 
 #
@@ -148,8 +148,8 @@
 - name: Assert the availabilty set facts
   ansible.builtin.assert:
     that:
-      - not results.changed
-      - not results.failed
+      - results is not changed
+      - results is not failed
       - results.ansible_info.azure_availabilitysets[0].platform_fault_domain_count == 2
       - results.ansible_info.azure_availabilitysets[0].platform_update_domain_count == 5
       - results.ansible_info.azure_availabilitysets[0].sku == 'Aligned'
@@ -165,7 +165,7 @@
 - name: Assert the availabilty set deleted
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Delete an availability set
   azure_rm_availabilityset:
@@ -183,7 +183,7 @@
 - name: Assert check mode return
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 - name: Delete an availability set
   azure_rm_availabilityset:

--- a/tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml
@@ -109,7 +109,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create Azure Firewall -- idempotent
   azure_rm_azurefirewall:
@@ -180,7 +180,7 @@
 - name: Assert that output has not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create Azure Firewall -- change something
   azure_rm_azurefirewall:
@@ -248,7 +248,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get info of the Azure Firewall
   azure_rm_azurefirewall_info:
@@ -259,7 +259,7 @@
 - name: Assert the azure firewall facts
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.firewalls['id'] != None
       - output.firewalls['name'] != None
       - output.firewalls['location'] != None
@@ -279,7 +279,7 @@
 - name: Assert the azure firewall deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the public IP address
   azure_rm_publicipaddress:

--- a/tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Trigger an on-demand backup for a protected Azure VM
   azure_rm_backupazurevm:
@@ -32,7 +32,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Stop protection but retain existing data
   azure_rm_backupazurevm:
@@ -46,7 +46,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get backup azure vm info
   azure_rm_backupazurevm_info:
@@ -73,4 +73,4 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Assert success on daily backup policy creation
   ansible.builtin.assert:
     that:
-      - daily_policy_output.changed
+      - daily_policy_output is changed
       - daily_policy_output.name == policy_name_daily
 
 - name: Assert Policy Success Retrieving Info
@@ -66,7 +66,7 @@
 - name: Assert that there is no change after second deletion of daily backup policy
   ansible.builtin.assert:
     that:
-      - not daily_policy_output_idempotent.changed
+      - daily_policy_output_idempotent is not changed
 
 - name: Create a daily enhanced VM backup policy
   azure.azcollection.azure_rm_backuppolicy:
@@ -93,7 +93,7 @@
 - name: Assert success on daily backup policy creation
   ansible.builtin.assert:
     that:
-      - daily_policy_output_enhanced.changed
+      - daily_policy_output_enhanced is changed
       - daily_policy_output_enhanced.name == policy_name_daily_enhanced
 
 - name: Assert Policy Success Retrieving Info
@@ -121,7 +121,7 @@
 - name: Assert success on update of daily policy
   ansible.builtin.assert:
     that:
-      - daily_policy_output_update.changed
+      - daily_policy_output_update is changed
       - daily_policy_output_update.name == policy_name_daily
 
 - name: Create a weekly VM backup policy
@@ -145,7 +145,7 @@
 - name: Assert success on weekly backup policy creation
   ansible.builtin.assert:
     that:
-      - weekly_policy_output.changed
+      - weekly_policy_output is changed
       - weekly_policy_output.name == policy_name_weekly
 
 - name: Update weekly VM backup policy
@@ -169,7 +169,7 @@
 - name: Assert success on update of weekly policy
   ansible.builtin.assert:
     that:
-      - weekly_policy_output_update.changed
+      - weekly_policy_output_update is changed
       - weekly_policy_output_update.name == policy_name_weekly
 
 - name: Delete a daily VM backup policy
@@ -183,7 +183,7 @@
 - name: Assert success on daily backup policy deletion
   ansible.builtin.assert:
     that:
-      - daily_policy_output_delete.changed
+      - daily_policy_output_delete is changed
 
 - name: Delete a daily VM enhanced backup policy
   azure.azcollection.azure_rm_backuppolicy:
@@ -196,7 +196,7 @@
 - name: Assert success on daily enhanced backup policy deletion
   ansible.builtin.assert:
     that:
-      - daily_policy_output_enhanced_delete.changed
+      - daily_policy_output_enhanced_delete is changed
 
 - name: Delete a weekly VM backup policy
   azure.azcollection.azure_rm_backuppolicy:
@@ -209,7 +209,7 @@
 - name: Assert success on weekly backup policy deletion
   ansible.builtin.assert:
     that:
-      - weekly_policy_output_delete.changed
+      - weekly_policy_output_delete is changed
 
 - name: Delete a daily VM backup policy (idempotent)
   azure.azcollection.azure_rm_backuppolicy:
@@ -222,7 +222,7 @@
 - name: Assert that there is no change after second deletion of daily backup policy
   ansible.builtin.assert:
     that:
-      - not daily_policy_output_delete_idempotent.changed
+      - daily_policy_output_delete_idempotent is not changed
 
 - name: Delete a daily VM enhanced backup policy (idempotent)
   azure.azcollection.azure_rm_backuppolicy:
@@ -235,7 +235,7 @@
 - name: Assert that there is no change after second deletion of daily enhanced backup policy
   ansible.builtin.assert:
     that:
-      - not daily_policy_output_enhanced_delete_idempotent.changed
+      - daily_policy_output_enhanced_delete_idempotent is not changed
 
 - name: Delete a weekly VM backup policy (idempotent)
   azure.azcollection.azure_rm_backuppolicy:
@@ -248,4 +248,4 @@
 - name: Assert that there is no change after second deletion of weekly backup policy
   ansible.builtin.assert:
     that:
-      - not weekly_policy_output_delete_idempotent.changed
+      - weekly_policy_output_delete_idempotent is not changed

--- a/tests/integration/targets/azure_rm_bastionhost/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_bastionhost/tasks/main.yml
@@ -88,7 +88,7 @@
 - name: Assert the bastion host created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create bastion host (Idempotent Test)
   azure_rm_bastionhost:
@@ -116,7 +116,7 @@
 - name: Assert the bastion host no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Pause for 15 mimutes to Bastion host updating
   ansible.builtin.command:
@@ -149,7 +149,7 @@
 - name: Assert the bastion host updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get bastion host info
   azure_rm_bastionhost_info:

--- a/tests/integration/targets/azure_rm_batchaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_batchaccount/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: Assert the resource was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.new.identity.type == "UserAssigned"
       - output.new.identity.user_assigned_identities | length == 1
       - output.new.identity.user_assigned_identities[managed_identity_ids[0]] is defined
@@ -91,7 +91,7 @@
 - name: Assert the resource wasn't changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.new.identity.type == "UserAssigned"
       - output.new.identity.user_assigned_identities | length == 1
       - output.new.identity.user_assigned_identities[managed_identity_ids[0]] is defined
@@ -115,7 +115,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.new.identity.type == "UserAssigned"
       - output.new.identity.user_assigned_identities | length == 1
       - output.new.identity.user_assigned_identities[managed_identity_ids[1]] is defined
@@ -153,7 +153,7 @@
 - name: Assert the resource was changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.new.identity.type == "SystemAssigned"
       - output.new.identity.user_assigned_identities is not defined
 
@@ -178,7 +178,7 @@
 - name: Assert the application was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new batchaccount application again(Idempotent test)
   azure_rm_batchaccountapplication:
@@ -192,7 +192,7 @@
 - name: Assert the application no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Upgrade the application
   azure_rm_batchaccountapplication:
@@ -206,7 +206,7 @@
 - name: Assert the application was updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the batchaccount application facts
   azure_rm_batchaccountapplication_info:
@@ -240,7 +240,7 @@
 - name: Assert the application package was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new batch account application package again(Idempotent test)
   azure_rm_batchaccountapplicationpackage:
@@ -253,7 +253,7 @@
 - name: Assert the application package no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the application package facts
   azure_rm_batchaccountapplicationpackage_info:
@@ -405,7 +405,7 @@
 - name: Assert the pool was created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new batch account pool again(Idempotent test)
   azure_rm_batchaccountpool:
@@ -468,7 +468,7 @@
 - name: Assert the pool no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Upgrade the batch account pool
   azure_rm_batchaccountpool:
@@ -531,7 +531,7 @@
 - name: Assert the pool was updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the batch account pool facts by name
   azure_rm_batchaccountpool_info:
@@ -562,7 +562,7 @@
 - name: Assert the pool stop resize
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Disable the batch account pool auto_scale
   azure_rm_batchaccountpool:
@@ -575,7 +575,7 @@
 - name: Assert the pool disable auto_scale
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the batch account pool
   azure_rm_batchaccountpool:
@@ -588,7 +588,7 @@
 - name: Assert the pool deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the application package
   azure_rm_batchaccountapplicationpackage:
@@ -602,7 +602,7 @@
 - name: Assert the application package deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the application
   azure_rm_batchaccountapplication:
@@ -614,7 +614,7 @@
 - name: Assert the application deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Batch Account
   azure_rm_batchaccount:
@@ -626,7 +626,7 @@
 - name: Assert that state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Clean up storage account
   azure_rm_storageaccount:

--- a/tests/integration/targets/azure_rm_capacityreservationgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_capacityreservationgroup/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Assert the capacity reservation group created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update the capacity reservation group's tag
   azure_rm_capacityreservationgroup:
@@ -43,7 +43,7 @@
 - name: Assert the capacity reservation group updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Recreate the capacity reservation group(idempotent test)
   azure_rm_capacityreservationgroup:
@@ -59,7 +59,7 @@
 - name: Assert the capacity reservation group no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get capacity reservation group by name
   azure_rm_capacityreservationgroup_info:
@@ -82,4 +82,4 @@
 - name: Assert the capacity reservation group deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_cdnprofile/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cdnprofile/tasks/main.yml
@@ -77,7 +77,7 @@
 - name: Assert the CDN profile is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id != ''
 
 - name: Gather CDN profile facts
@@ -116,7 +116,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the CDN profile - replace user identity
   azure_rm_cdnprofile:
@@ -140,7 +140,7 @@
 - name: Assert the CDN profile is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather CDN profile facts
   azure_rm_cdnprofile_info:
@@ -179,7 +179,7 @@
 - name: Assert the CDN profile is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather CDN profile facts
   azure_rm_cdnprofile_info:
@@ -216,7 +216,7 @@
 - name: Assert the CDN profile is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather CDN profile facts
   azure_rm_cdnprofile_info:
@@ -285,7 +285,7 @@
 - name: Assert the Azure CDN endpoint is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Get facts of a Azure CDN endpoint
@@ -324,7 +324,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Stop a Azure CDN endpoint
   azure_rm_cdnendpoint:
@@ -337,7 +337,7 @@
 - name: Assert stopped
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Stop a Azure CDN endpoint(idempotent)
   azure_rm_cdnendpoint:
@@ -350,7 +350,7 @@
 - name: Assert still stopped and not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Start a Azure CDN endpoint
   azure_rm_cdnendpoint:
@@ -363,7 +363,7 @@
 - name: Assert started
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update the Azure CDN endpoint
   azure_rm_cdnendpoint:
@@ -380,7 +380,7 @@
 - name: Assert the Azure CDN endpoint is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete a Azure CDN endpoint(check mode)
   azure_rm_cdnendpoint:
@@ -407,7 +407,7 @@
 - name: Assert the CDN profile is well deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get CDN profile fact
   azure_rm_cdnprofile_info:

--- a/tests/integration/targets/azure_rm_cognitivesearch/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cognitivesearch/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - invalid_hosting_name.failed == True
+      - invalid_hosting_name is failed
 
 - name: Create invalid Azure Search - Partition Count High Density
   azure_rm_cognitivesearch:
@@ -29,7 +29,7 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - invalid_partition_count.failed == True
+      - invalid_partition_count is failed
 
 - name: Create invalid Azure Search - Partition Count
   azure_rm_cognitivesearch:
@@ -42,7 +42,7 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - invalid_partition_count.failed == True
+      - invalid_partition_count is failed
 
 - name: Create invalid Azure Search - Replica Count
   azure_rm_cognitivesearch:
@@ -56,7 +56,7 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - invalid_replica_count.failed == True
+      - invalid_replica_count is failed
 
 - name: Create invalid Azure Search - Replica Count SKU basic
   azure_rm_cognitivesearch:
@@ -70,7 +70,7 @@
 - name: Assert task failed
   ansible.builtin.assert:
     that:
-      - invalid_replica_count.failed == True
+      - invalid_replica_count is failed
 
 - name: Create basic Azure Search
   azure_rm_cognitivesearch:
@@ -81,7 +81,7 @@
 - name: Assert status Succeeded and results
   ansible.builtin.assert:
     that:
-      - search_info.changed
+      - search_info is changed
       - search_info.state.id is defined
       - search_info.state.identity.type == "None"
       - search_info.state.identity.principal_id is not defined
@@ -124,7 +124,7 @@
 - name: Assert that idempotence is ok
   ansible.builtin.assert:
     that:
-      - not search_info.changed
+      - search_info is not changed
 
 - name: Delete Azure Search
   azure_rm_cognitivesearch:
@@ -152,7 +152,7 @@
 - name: Assert status Succeeded and results
   ansible.builtin.assert:
     that:
-      - search_info.changed
+      - search_info is changed
       - search_info.state.id is defined
       - search_info.state.identity.type == "SystemAssigned"
       - search_info.state.identity.principal_id is defined
@@ -184,7 +184,7 @@
 - name: Assert that idempotence is ok
   ansible.builtin.assert:
     that:
-      - not search_info.changed
+      - search_info is not changed
 
 - name: Delete Azure Search
   azure_rm_cognitivesearch:

--- a/tests/integration/targets/azure_rm_containerinstance/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_containerinstance/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Assert the container instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
 
 - name: Create sample container instance -- same parameters
@@ -72,7 +72,7 @@
 - name: Assert the container instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
 
 - name: Create sample container instance -- force update
   azure_rm_containerinstance:
@@ -102,7 +102,7 @@
 - name: Assert the container instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
 
 - name: Create second container instance for testing purposes
@@ -172,7 +172,7 @@
 - name: Assert the container instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts for single Container Instance
   azure_rm_containerinstance_info:
@@ -187,7 +187,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.containerinstances[0]['resource_group'] != None
       - output.containerinstances[0]['name'] != None
       - output.containerinstances[0]['os_type'] != None
@@ -206,7 +206,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.containerinstances[0]['resource_group'] != None
       - output.containerinstances[0]['name'] != None
       - output.containerinstances[0]['os_type'] != None
@@ -259,7 +259,7 @@
 - name: Assert that user identities are used
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - managed_identity_ids[0] in output.containerinstances[0].identity.user_assigned_identities
       - managed_identity_ids[1] in output.containerinstances[0].identity.user_assigned_identities
 
@@ -325,7 +325,7 @@
 - name: Assert the container instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.provisioning_state == 'Succeeded'
   register: ignore_errors_register
   ignore_errors: true
@@ -346,7 +346,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.containerinstances[0]['resource_group'] != None
       - output.containerinstances[0]['name'] != None
       - output.containerinstances[0]['os_type'] != None
@@ -412,7 +412,7 @@
 - name: Assert the container instance is deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Remove container instance
   azure_rm_containerinstance:
@@ -454,7 +454,7 @@
 - name: Assert the changed is false
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"

--- a/tests/integration/targets/azure_rm_containerregistry/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_containerregistry/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Assert the container registry instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.admin_user_enabled
       - output.location == location
       - output.sku == 'Premium'
@@ -71,7 +71,7 @@
 - name: Assert the ACR instance is well updated
   ansible.builtin.assert:
     that:
-      - output.changed == True
+      - output is changed
       - output.admin_user_enabled == False
       - output.sku == 'Standard'
       - output.tags['NewTag'] == 'newtag'
@@ -88,7 +88,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.registries[0]['name'] != None
       - output.registries[0]['location'] != None
       - output.registries[0]['admin_user_enabled'] != None
@@ -106,7 +106,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.registries[0]['name'] != None
       - output.registries[0]['location'] != None
       - output.registries[0]['admin_user_enabled'] != None
@@ -144,7 +144,7 @@
 - name: Assert the container registry instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - managed_identity_ids[0] in output.identity.user_assigned_identities
 
 - name: Update second container registry to test appending identity
@@ -167,7 +167,7 @@
 - name: Assert the container registry instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - managed_identity_ids[0] in output.identity.user_assigned_identities
       - managed_identity_ids[1] in output.identity.user_assigned_identities
 
@@ -188,7 +188,7 @@
 - name: Assert the container registry instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - '"user_assigned_identities" not in output.identity'
 
 - name: Delete first container registry

--- a/tests/integration/targets/azure_rm_containerregistrytag/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_containerregistrytag/tasks/main.yml
@@ -41,7 +41,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import tag (actually import)
   azure_rm_containerregistrytag:
@@ -55,7 +55,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import tag (test idempotency)
   azure_rm_containerregistrytag:
@@ -69,7 +69,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Import additional tag
   azure_rm_containerregistrytag:
@@ -83,7 +83,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import additional tag
   azure_rm_containerregistrytag:
@@ -97,7 +97,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import additional tag
   azure_rm_containerregistrytag:
@@ -111,7 +111,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Load all tags
   azure_rm_containerregistrytag_info:
@@ -185,7 +185,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete tag by name (actually delete)
   azure_rm_containerregistrytag:
@@ -196,7 +196,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete tag by name (test idempotency)
   azure_rm_containerregistrytag:
@@ -207,7 +207,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Load tags by repository
   azure_rm_containerregistrytag_info:
@@ -232,7 +232,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete repository (actually delete)
   azure_rm_containerregistrytag:
@@ -242,7 +242,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete repository (test idempotency)
   azure_rm_containerregistrytag:
@@ -252,7 +252,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Load all tags
   azure_rm_containerregistrytag_info:
@@ -276,7 +276,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import tag with same name (test idempotency)
   azure_rm_containerregistrytag:
@@ -288,7 +288,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Import tag with different repo, same name
   azure_rm_containerregistrytag:
@@ -301,7 +301,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import tag with different repo, same name (test idempotency)
   azure_rm_containerregistrytag:
@@ -314,7 +314,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Import tag with different name, same repo
   azure_rm_containerregistrytag:
@@ -327,7 +327,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Import tag with different name, same repo (test idempotency)
   azure_rm_containerregistrytag:
@@ -340,7 +340,7 @@
   register: output
 - name: Assert output
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Load all tags
   azure_rm_containerregistrytag_info:

--- a/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
@@ -76,7 +76,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -108,7 +108,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create again instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -140,7 +140,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Pause for 600 seconds
   ansible.builtin.command: sleep 600
@@ -177,7 +177,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create second instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -210,7 +210,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update second instance of Database Account - replace user-identity
   azure_rm_cosmosdbaccount:
@@ -244,7 +244,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get facts of single account
   azure_rm_cosmosdbaccount_info:
@@ -255,7 +255,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed == False
       - output.accounts | length == 1
       - output.accounts[0]['id'] != None
       - output.accounts[0]['resource_group'] == resource_group
@@ -311,7 +311,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed == False
       - output.accounts[0]['primary_master_key'] != None
       - output.accounts[0]['secondary_master_key'] != None
       - output.accounts[0]['primary_readonly_master_key'] != None
@@ -327,7 +327,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed == False
       - "'primary_master_key' not in output.accounts[0]"
       - "'secondary_master_key' not in output.accounts[0]"
       - output.accounts[0]['primary_readonly_master_key'] != None
@@ -341,7 +341,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed == False
       - output.accounts | length == 1
       - output.accounts[0]['id'] != None
       - output.accounts[0]['resource_group'] == resource_group
@@ -379,7 +379,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed == False
       - output.accounts | length >= 2
       - dbname in (output.accounts | map(attribute='name'))
       - db2name in (output.accounts | map(attribute='name'))
@@ -414,7 +414,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get facts for free tier account
   azure_rm_cosmosdbaccount_info:
@@ -442,7 +442,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -453,7 +453,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -464,7 +464,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Delete second instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -475,7 +475,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete free tier instance of Database Account
   azure_rm_cosmosdbaccount:
@@ -486,7 +486,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Clean up virtual network
   azure_rm_virtualnetwork:

--- a/tests/integration/targets/azure_rm_datafactory/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_datafactory/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Assert the data factory created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create data factory again (Idempotent test)
   azure_rm_datafactory:
@@ -37,7 +37,7 @@
 - name: Assert the idempotent success
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update data factory
   azure_rm_datafactory:
@@ -52,7 +52,7 @@
 - name: Assert the data factory updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get data factory info
   azure_rm_datafactory_info:
@@ -76,4 +76,4 @@
 - name: Assert the data factory deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_ddosprotectionplan/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_ddosprotectionplan/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Assert the ddos protection check mode return
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create DDoS protection plan
   azure_rm_ddosprotectionplan:
@@ -23,7 +23,7 @@
 
 - name: Assert the ddos protection created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Update DDoS protection plan
   azure_rm_ddosprotectionplan:
@@ -37,7 +37,7 @@
 - name: Assert the ddos protection updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve DDoS protection plan
@@ -61,7 +61,7 @@
 - name: Assert the ddos protection created
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 #
 # azure_rm_ddosprotectionplan cleanup
@@ -84,4 +84,4 @@
 
 - name: Assert the ddos protection plan deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_deployment/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_deployment/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: Assert that values are returned
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.deployments[0]['provisioning_state'] != None
       - output.deployments[0]['output_resources'] | length > 0
       - output.deployments[0]['outputs'] | length > 0

--- a/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Check the devtest lab changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a DevTest Lab (Idempotent test)
   azure_rm_devtestlab:
@@ -39,7 +39,7 @@
 
 - name: Check the devtest lab not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Get devtest lab facts
   azure_rm_devtestlab_info:
@@ -66,7 +66,7 @@
 - name: Assert the devtest lab virtual network create successfully
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the devtest lab virtual network
   azure_rm_devtestlabvirtualnetwork_info:
@@ -108,7 +108,7 @@
 - name: Assert the devtest lab virtual machine create successfully
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get devtest lab info
   azure_rm_devtestlabvirtualmachine_info:
@@ -136,7 +136,7 @@
 - name: Assert the devtest lab image create successufully
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get custom image
   azure_rm_devtestlabcustomimage_info:
@@ -177,7 +177,7 @@
 - name: Assert the devtest lab policy creatre successfully
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the devtest lab policy facts
   azure_rm_devtestlabpolicy_info:
@@ -203,7 +203,7 @@
 - name: Assert the devtest lab schedule create sussessfully
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get devtest lab schedule
   azure_rm_devtestlabschedule_info:

--- a/tests/integration/targets/azure_rm_diskaccess/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_diskaccess/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Assert the disk access created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new disk access(Idempotent Test)
   azure_rm_diskaccess:
@@ -37,7 +37,7 @@
 - name: Assert the disk access no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the disk access
   azure_rm_diskaccess:
@@ -51,7 +51,7 @@
 - name: Assert the disk access updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the disk access facts
   azure_rm_diskaccess_info:
@@ -74,4 +74,4 @@
 - name: Assert the disk access deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_diskencryptionset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_diskencryptionset/tasks/main.yml
@@ -102,7 +102,7 @@
 
 - name: Assert that disk encryption set is created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create disk encryption set (Idempotent test)
   azure_rm_diskencryptionset:
@@ -115,7 +115,7 @@
 
 - name: Assert that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update disk encryption set
   azure_rm_diskencryptionset:
@@ -130,7 +130,7 @@
 
 - name: Assert that disk encryption set is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get disk encryption set facts
   azure_rm_diskencryptionset_info:
@@ -141,7 +141,7 @@
 - name: Assert the disk encryption facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.diskencryptionsets[0].id != None
       - results.diskencryptionsets[0].name == "{{ set_name }}"
       - results.diskencryptionsets[0].active_key != None
@@ -165,7 +165,7 @@
 
 - name: Assert that disk encryption set with first UserAssigned Identity was updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create disk encryption set with first UserAssigned Identity (Idempotent test)
   azure_rm_diskencryptionset:
@@ -183,7 +183,7 @@
 
 - name: Assert that output is not changed (with first UserAssigned Identity)
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Get disk encryption set with first UserAssigned Identity facts
   azure_rm_diskencryptionset_info:
@@ -194,7 +194,7 @@
 - name: Assert the disk encryption set  with UserAssigned Identity facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.diskencryptionsets[0].id != None
       - results.diskencryptionsets[0].name == "{{ set_name }}"
       - results.diskencryptionsets[0].active_key != None
@@ -220,7 +220,7 @@
 
 - name: Assert that disk encryption set with second UserAssigned is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get disk encryption set with UserAssigned Identity facts
   azure_rm_diskencryptionset_info:
@@ -231,7 +231,7 @@
 - name: Assert the disk encryption set  with second UserAssigned Identity facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.diskencryptionsets[0].id != None
       - results.diskencryptionsets[0].name == "{{ set_name }}"
       - results.diskencryptionsets[0].active_key != None
@@ -257,7 +257,7 @@
 
 - name: Assert that disk encryption set with (SystemAssigned, UserAssigned) is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get disk encryption set with (SystemAssigned, UserAssigned) facts
   azure_rm_diskencryptionset_info:
@@ -268,7 +268,7 @@
 - name: Assert the disk encryption set with (SystemAssigned, UserAssigned) facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.diskencryptionsets[0].id != None
       - results.diskencryptionsets[0].name == "{{ set_name }}"
       - results.diskencryptionsets[0].active_key != None
@@ -287,7 +287,7 @@
 
 - name: Assert that disk encryption set is deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete disk encryption set (Idempotent test)
   azure_rm_diskencryptionset:
@@ -298,7 +298,7 @@
 
 - name: Asset that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Delete the Key Vault
   azure_rm_keyvault:

--- a/tests/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Assert that DNS zone was created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create public ip
   azure_rm_publicipaddress:
@@ -34,7 +34,7 @@
 
 - name: Assert that A record set was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create "A" record set with multiple records
   azure_rm_dnsrecordset:
@@ -50,7 +50,7 @@
 
 - name: Assert that A record set was created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Re-run "A" record with same values
   azure_rm_dnsrecordset:
@@ -66,7 +66,7 @@
 
 - name: Assert that A record set was not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update "A" record set with additional record
   azure_rm_dnsrecordset:
@@ -82,7 +82,7 @@
 - name: Assert that new record was appended
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Re-update "A" record set with additional record
   azure_rm_dnsrecordset:
@@ -98,7 +98,7 @@
 - name: Assert that A record set was not changed
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 - name: Remove 1 record from record set
   azure_rm_dnsrecordset:
@@ -115,7 +115,7 @@
 - name: Assert that record was deleted
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Check_mode test
   azure_rm_dnsrecordset:
@@ -131,7 +131,7 @@
 - name: Assert that check_mode returns new state
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 # FUTURE: add facts module calls to ensure that we really didn't touch anything
 
@@ -146,7 +146,7 @@
 
 - name: Assert that record set deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Re-run record set absent(idempotence test)
   azure_rm_dnsrecordset:
@@ -159,7 +159,7 @@
 
 - name: Assert the record set deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Create SRV records in a new record set
   azure_rm_dnsrecordset:
@@ -179,7 +179,7 @@
 - name: Assert that SRV record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Create TXT records in a new record set
   azure_rm_dnsrecordset:
@@ -199,7 +199,7 @@
 - name: Assert that TXT record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Update SOA record
   azure_rm_dnsrecordset:
@@ -221,7 +221,7 @@
 - name: Assert that SOA record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Delete DNS zone
   azure_rm_dnszone:

--- a/tests/integration/targets/azure_rm_dnszone/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_dnszone/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Assert the dns zone created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create a DNS zone
   azure_rm_dnszone:
@@ -21,7 +21,7 @@
 
 - name: Assert the dns zone created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Update DNS zone with tags
   azure_rm_dnszone:
@@ -34,7 +34,7 @@
 - name: Assert the dns zone updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve DNS Zone Facts
@@ -58,7 +58,7 @@
 - name: Assert idempotent test result
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 #
 # azure_rm_dnsrecordset test
@@ -79,7 +79,7 @@
 - name: Assert that A record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - 'results.state.a_records | length == 3'
 
 - name: Re-run "A" record with same values
@@ -96,7 +96,7 @@
 
 - name: Assert that A record set was not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update "A" record set with additional record
   azure_rm_dnsrecordset:
@@ -112,7 +112,7 @@
 - name: Assert that new record was appended
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - 'results.state.a_records | length == 4'
 
 - name: Re-update "A" record set with additional record
@@ -129,7 +129,7 @@
 - name: Assert that A record set was not changed
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 - name: Remove 1 record from record set
   azure_rm_dnsrecordset:
@@ -146,7 +146,7 @@
 - name: Assert that record was deleted
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - 'results.state.a_records | length == 3'
 
 - name: Check_mode test
@@ -163,7 +163,7 @@
 - name: Assert that check_mode returns new state
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 # FUTURE: add facts module calls to ensure that we really didn't touch anything
 
@@ -184,7 +184,7 @@
 - name: Assert that SRV record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Create TXT records in a new record set
   azure_rm_dnsrecordset:
@@ -203,7 +203,7 @@
 - name: Cssert that TXT record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 #
 # azure_rm_dnsrecordset_info
@@ -220,7 +220,7 @@
 - name: Assert that facts module returned result for single Record Set
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 #     - azure_dnsrecordset[0].name == 'www'
       - results.dnsrecordsets[0].relative_name == 'www'
       - 'results.dnsrecordsets[0].records | length == 3'
@@ -235,7 +235,7 @@
 - name: Assert that facts module returned result for all Record Sets
   ansible.builtin.assert:
     that:
-      - not facts.changed
+      - facts is not changed
 #     - facts.ansible_facts.azure_dnsrecordset[0].name == '@'
 #     - facts.ansible_facts.azure_dnsrecordset[1].name == '@'
 #     - facts.ansible_facts.azure_dnsrecordset[4].name == 'www'
@@ -257,7 +257,7 @@
 
 - name: Assert that record set deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Retrieve DNS Record Set Facts for all Record Sets
   azure_rm_dnsrecordset_info:
@@ -282,7 +282,7 @@
 
 - name: Assert the dns recored deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 #
 # azure_rm_dnszone cleanup
@@ -302,4 +302,4 @@
 
 - name: Assert the dns zone deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_eventhub/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_eventhub/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Assert the check mode result
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create Event Hub (check mode)
   azure_rm_eventhub:
@@ -49,7 +49,7 @@
 
 - name: Assert the check mode result
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create Event Hub Namespace
   azure_rm_eventhub:
@@ -61,7 +61,7 @@
 
 - name: Assert the event hub namespace created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create Event Hub
   azure_rm_eventhub:
@@ -73,7 +73,7 @@
 
 - name: Assert the event hub created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Update Namespace
   azure_rm_eventhub:
@@ -88,7 +88,7 @@
 - name: Assert the namespace updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Update Namespace - add SystemAssigned Identity
@@ -106,7 +106,7 @@
 - name: Assert the Namespace updated with the SystemAssigned Identity
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve Namespace with the SystemAssigned Identity
@@ -118,7 +118,7 @@
 - name: Assert the facts of the Namespace with the SystemAssigned Identity
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.namespace[0].name == "{{ namespace_name }}"
       - results.namespace[0].identity.type == 'SystemAssigned'
       - results.namespace[0].identity.user_assigned_identities is not defined
@@ -141,7 +141,7 @@
 - name: Assert the Namespace updated with the first UserAssigned Identity
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve Namespace with the first UserAssigned Identity
@@ -153,7 +153,7 @@
 - name: Assert the facts of the Namespace with the first UserAssigned Identity
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.namespace[0].name == "{{ namespace_name }}"
       - results.namespace[0].identity.type == 'UserAssigned'
       - results.namespace[0].identity.user_assigned_identities | length == 1
@@ -178,7 +178,7 @@
 - name: Assert the Namespace updated with the second UserAssigned Identity
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve Namespace with the second UserAssigned Identity
@@ -190,7 +190,7 @@
 - name: Assert the facts of the Namespace with the second UserAssigned Identity
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.namespace[0].name == "{{ namespace_name }}"
       - results.namespace[0].identity.type == 'UserAssigned'
       - results.namespace[0].identity.user_assigned_identities | length == 1
@@ -214,7 +214,7 @@
 - name: Assert the Namespace updated with multiple identities
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve Namespace with multiple identities
@@ -226,7 +226,7 @@
 - name: Assert the facts of the Namespace with multiple identities
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.namespace[0].name == "{{ namespace_name }}"
       - results.namespace[0].identity.type == 'SystemAssigned, UserAssigned'
       - results.namespace[0].identity.user_assigned_identities | length == 2
@@ -248,7 +248,7 @@
 - name: Assert the event hub updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Test idempotent
   azure_rm_eventhub:
@@ -263,7 +263,7 @@
 - name: Assert idempotent success
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 # cleanup
 - name: Delete Event Hub
@@ -285,7 +285,7 @@
 
 - name: Assert the event hub deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Delete Namespace
   azure_rm_eventhub:
@@ -309,7 +309,7 @@
 
 - name: Assert the namespace deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Create Namespace - with multiple UserAssigned Identities
   azure_rm_eventhub:
@@ -330,7 +330,7 @@
 - name: Assert the Namespace updated with multiple UserAssigned Identities
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve Namespace with multiple UserAssigned Identities
@@ -342,7 +342,7 @@
 - name: Assert the facts of the Namespace with multiple UserAssigned Identities
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.namespace[0].name == "{{ namespace_name }}"
       - results.namespace[0].identity.type == 'UserAssigned'
       - results.namespace[0].identity.user_assigned_identities | length == 2
@@ -363,7 +363,7 @@
 
 - name: Assert the namespace deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"

--- a/tests/integration/targets/azure_rm_expressroute/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_expressroute/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Assert the excpress route check mode result
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 
 - name: Create Express route
@@ -50,7 +50,7 @@
 
 - name: Assert the express route created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 
 - name: Update Express route
@@ -76,7 +76,7 @@
 - name: Assert the express route updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 
@@ -101,7 +101,7 @@
 - name: Assert the idempotent
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 #
 # azure_rm_expressroute cleanup
@@ -121,4 +121,4 @@
 
 - name: Assert the express route deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_firewallpolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_firewallpolicy/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Assert that firewall policy is created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create a firewall policy again (Idempotent test)
   azure_rm_firewallpolicy:
@@ -38,7 +38,7 @@
 
 - name: Assert that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update a firewall policy
   azure_rm_firewallpolicy:
@@ -59,7 +59,7 @@
 
 - name: Assert that firewall policy is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get firewall policy facts
   azure_rm_firewallpolicy_info:
@@ -70,7 +70,7 @@
 - name: Assert the firewall policy facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.firewallpolicies[0].id != None
       - results.firewallpolicies[0].name == "{{ policy_name }}"
       - results.firewallpolicies[0].threat_intel_mode == "Deny"
@@ -87,7 +87,7 @@
 
 - name: Assert that firewall policy is deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete firewall policy again (Idempotent test)
   azure_rm_firewallpolicy:
@@ -98,4 +98,4 @@
 
 - name: Asset that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_functionapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_functionapp/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Assert the function was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create basic function app (idempotent)
   azure_rm_functionapp:
@@ -63,7 +63,7 @@
 
 - name: Assert the function was not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: List facts for function
   azure_rm_functionapp_info:
@@ -174,7 +174,7 @@
 
 - name: Assert the function was deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a function with app settings
   azure_rm_functionapp:
@@ -192,7 +192,7 @@
 
 - name: Assert the function with app settings was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Change app settings
   azure_rm_functionapp:
@@ -214,7 +214,7 @@
 
 - name: Assert the function was changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Append identity app settings
   azure_rm_functionapp:
@@ -237,7 +237,7 @@
 
 - name: Assert the function was changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete the function app
   azure_rm_functionapp:
@@ -248,7 +248,7 @@
 
 - name: Assert the function was deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a linux app service plan
   azure_rm_appserviceplan:
@@ -298,7 +298,7 @@
 
 - name: Assert the function was changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete the function app
   azure_rm_functionapp:

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -287,7 +287,7 @@
 - name: Assert the gallery created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create or update a simple gallery - idempotent
   azure_rm_gallery:
@@ -300,7 +300,7 @@
 - name: Assert the gallery created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create or update a simple gallery - change description
   azure_rm_gallery:
@@ -313,7 +313,7 @@
 - name: Assert the gallery updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get a gallery info.
   azure_rm_gallery_info:
@@ -324,7 +324,7 @@
 - name: Assert the gallery facts
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.galleries['id'] != None
       - output.galleries['name'] != None
       - output.galleries['location'] != None
@@ -353,7 +353,7 @@
 - name: Assert the gallery image created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create or update gallery image - idempotent
   azure_rm_galleryimage:
@@ -377,7 +377,7 @@
 - name: Assert the gallery image idempotent result
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create or update gallery image - change description
   azure_rm_galleryimage:
@@ -401,7 +401,7 @@
 - name: Assert the gallery image updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get a gallery image info.
   azure_rm_galleryimage_info:
@@ -413,7 +413,7 @@
 - name: Assert the gallery image facts
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.images['id'] != None
       - output.images['name'] != None
       - output.images['location'] != None
@@ -458,7 +458,7 @@
 - name: Assert the gallery image version created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create or update a simple gallery Image Version.
   azure_rm_galleryimageversion:
@@ -497,7 +497,7 @@
 - name: Assert the gallery image version created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create or update a simple gallery Image Version - idempotent
   azure_rm_galleryimageversion:
@@ -536,7 +536,7 @@
 - name: Assert the gallery image version result
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create or update a simple gallery Image Version - change end of life
   azure_rm_galleryimageversion:
@@ -575,7 +575,7 @@
 - name: Assert the gallery image version updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get a simple gallery Image Version info.
   azure_rm_galleryimageversion_info:
@@ -588,7 +588,7 @@
 - name: Assert the gallery image version facts
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.versions['id'] != None
       - output.versions['name'] != None
       - output.versions['location'] != None
@@ -607,7 +607,7 @@
 - name: Assert the gallery image version from URI deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete gallery image Version.
   azure_rm_galleryimageversion:
@@ -621,7 +621,7 @@
 - name: Assert the gallery image version deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pasue 5 minutes, wait for deletion complete
   ansible.builtin.pause:
@@ -639,7 +639,7 @@
 - name: Assert the gallery image deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pasue 2 minutes, wait for deletion complete
   ansible.builtin.pause:
@@ -656,13 +656,13 @@
 - name: Assert the gallery deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Role Assignment by id
   azure_rm_roleassignment:
     id: "{{ az_role_assignment_create.id }}"
     state: absent
-  when: az_role_assignment_create.changed
+  when: az_role_assignment_create is changed
 
 - name: Delete the public IP address
   azure_rm_publicipaddress:

--- a/tests/integration/targets/azure_rm_hdinsightcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_hdinsightcluster/tasks/main.yml
@@ -99,7 +99,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Cluster
   azure_rm_hdinsightcluster:
@@ -148,7 +148,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Wait for instance of Cluster provisioning to complete
   azure_rm_hdinsightcluster_info:
@@ -205,7 +205,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Create again instance of Cluster -- resize and add tags
   azure_rm_hdinsightcluster:
@@ -258,7 +258,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get facts of Cluster
   azure_rm_hdinsightcluster_info:
@@ -269,7 +269,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.clusters[0]['id'] != None
       - output.clusters[0]['resource_group'] != None
       - output.clusters[0]['name'] != None
@@ -296,7 +296,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of Cluster
   azure_rm_hdinsightcluster:
@@ -307,7 +307,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: managedidentity.yml

--- a/tests/integration/targets/azure_rm_hostgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_hostgroup/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Assert that host group is created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create a host group again (Idempotent test)
   azure_rm_hostgroup:
@@ -30,7 +30,7 @@
 
 - name: Assert that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update a host group
   azure_rm_hostgroup:
@@ -47,7 +47,7 @@
 
 - name: Assert that host group is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get host group facts
   azure_rm_hostgroup_info:
@@ -58,7 +58,7 @@
 - name: Assert the host group facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.hostgroups[0].name == "{{ group_name }}"
       - results.hostgroups[0].location == "eastus"
       - results.hostgroups[0].platform_fault_domain_count == 1
@@ -74,7 +74,7 @@
 
 - name: Assert that host group is deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete host group again (Idempotent test)
   azure_rm_hostgroup:
@@ -85,4 +85,4 @@
 
 - name: Asset that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_image/tasks/azure_test_encrypted.yml
+++ b/tests/integration/targets/azure_rm_image/tasks/azure_test_encrypted.yml
@@ -17,7 +17,7 @@
 
 - name: Assert the image check mode
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create an image from VM
   azure_rm_image:
@@ -35,7 +35,7 @@
 - name: Assert the image created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create an image from VM (idempotent)
@@ -52,7 +52,7 @@
 - name: Assert the image created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.id
 
 - name: Gather information about image created
@@ -78,7 +78,7 @@
 - name: Assert the image check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete image
   azure_rm_image:
@@ -90,7 +90,7 @@
 - name: Assert the imaged deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete image (idempotent)
   azure_rm_image:
@@ -102,7 +102,7 @@
 - name: Assert the image has deleted
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Destroy disk encryption set
   azure_rm_diskencryptionset:

--- a/tests/integration/targets/azure_rm_image/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_image/tasks/main.yml
@@ -88,7 +88,7 @@
 
 - name: Assert the image check mode
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create an image from VM
   azure_rm_image:
@@ -104,7 +104,7 @@
 - name: Assert the image created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create an image from VM (idempotent)
@@ -119,7 +119,7 @@
 - name: Assert the image created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.id
 
 - name: Gather information about image created
@@ -145,7 +145,7 @@
 - name: Assert the image check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete image
   azure_rm_image:
@@ -157,7 +157,7 @@
 - name: Assert the imaged deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete image (idempotent)
   azure_rm_image:
@@ -169,7 +169,7 @@
 - name: Assert the image has deleted
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Test encrypted images
   ansible.builtin.include_tasks: azure_test_encrypted.yml

--- a/tests/integration/targets/azure_rm_iothub/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_iothub/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Assert the check mode result
   ansible.builtin.assert:
     that:
-      - iothub.changed
+      - iothub is changed
 
 - name: Query IoT Hub
   azure_rm_iothub_info:
@@ -56,7 +56,7 @@
 - name: Assert tht iot hub created
   ansible.builtin.assert:
     that:
-      - iothub.changed
+      - iothub is changed
 
 - name: Update IoT Hub (identity)
   azure_rm_iothub:
@@ -72,7 +72,7 @@
 - name: Assert tht iot hub created
   ansible.builtin.assert:
     that:
-      - iothub.changed
+      - iothub is changed
 
 - name: Get the IoT Hub facts
   azure_rm_iothub_info:
@@ -104,7 +104,7 @@
 - name: Assert the iot hub created
   ansible.builtin.assert:
     that:
-      - not iothub.changed
+      - iothub is not changed
 
 - name: Update IoT Hub (identity)
   azure_rm_iothub:
@@ -121,7 +121,7 @@
 - name: Assert tht iot hub created
   ansible.builtin.assert:
     that:
-      - iothub.changed
+      - iothub is changed
 
 - name: Get the IoT Hub facts
   azure_rm_iothub_info:
@@ -248,7 +248,7 @@
 - name: Assert iot hub check mode result
   ansible.builtin.assert:
     that:
-      - iothub.changed
+      - iothub is changed
 
 - name: Delete IoT Hub
   azure_rm_iothub:
@@ -260,7 +260,7 @@
 - name: Assert the iot hub deleted
   ansible.builtin.assert:
     that:
-      - iothub.changed
+      - iothub is changed
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"

--- a/tests/integration/targets/azure_rm_ipgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_ipgroup/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Assert that IP group is created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create same IP group again (Idempotent test)
   azure_rm_ipgroup:
@@ -50,7 +50,7 @@
 
 - name: Assert that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update IP group
   azure_rm_ipgroup:
@@ -65,7 +65,7 @@
 
 - name: Assert that IP group is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get IP group facts
   azure_rm_ipgroup_info:
@@ -76,7 +76,7 @@
 - name: Assert the ip group facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.ipgroups[0].id != None
       - results.ipgroups[0].name == "{{ group_name }}"
       - results.ipgroups[0].location == "eastus"
@@ -93,7 +93,7 @@
 
 - name: Assert that IP group is deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete IP group again (Idempotent test)
   azure_rm_ipgroup:
@@ -104,4 +104,4 @@
 
 - name: Asset that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -69,7 +69,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Key Vault
   azure_rm_keyvault:
@@ -97,7 +97,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Key Vault again
   azure_rm_keyvault:
@@ -124,7 +124,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Update existing Key Vault (add a rule and tags)
   azure_rm_keyvault:
@@ -163,7 +163,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get key vault facts
   azure_rm_keyvault_info:
@@ -247,7 +247,7 @@
 
 - name: Assert the keyvault created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Update instance of Key Vault
   azure_rm_keyvault:
@@ -285,7 +285,7 @@
 
 - name: Assert the keyvault Updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get key vault facts
   azure_rm_keyvault_info:
@@ -323,7 +323,7 @@
       register: output
     - name: Assert the keyvault key created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault key
       azure_rm_keyvaultkey:
@@ -355,7 +355,7 @@
 
 - name: Assert the keyvault deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 #
 # azure_rm_keyvaultsecret tests
@@ -373,7 +373,7 @@
       register: output
     - name: Assert the keyvault secret created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault secret
       azure_rm_keyvaultsecret:
@@ -390,7 +390,7 @@
 
 - name: Assert the keyvault secret deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 #
 # azure_rm_keyvault finalize & clean up
@@ -406,7 +406,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of Key Vault
   azure_rm_keyvault:
@@ -417,7 +417,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of Key Vault
   azure_rm_keyvault:
@@ -428,7 +428,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 #
 # azure_rm_keyvault hsm setup and test
@@ -457,7 +457,7 @@
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Create instance of HSM
       azure_rm_keyvault:
@@ -478,7 +478,7 @@
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Create instance of HSM again
       azure_rm_keyvault:
@@ -499,7 +499,7 @@
     - name: Assert the state has not changed
       ansible.builtin.assert:
         that:
-          - output.changed == false
+          - output is not changed
 
     - name: Update existing HSM (add tags)
       azure_rm_keyvault:
@@ -522,7 +522,7 @@
     - name: Assert the state has changed
       ansible.builtin.assert:
         that:
-          - output.changed == true
+          - output is changed
 
     - name: Get hsm facts
       azure_rm_keyvault_info:
@@ -571,7 +571,7 @@
     - name: Assert the state has changed
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Delete instance of HSM
       azure_rm_keyvault:
@@ -583,7 +583,7 @@
     - name: Assert the state has changed
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Delete unexisting instance of HSM
       azure_rm_keyvault:
@@ -595,7 +595,7 @@
     - name: Assert the state has changed
       ansible.builtin.assert:
         that:
-          - output.changed == false
+          - output is not changed
 
 - name: Purge the deleted vault
   azure_rm_keyvault:

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -75,7 +75,7 @@
 
 - name: Assert the keyvault certificate created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: For the keyvault certificate idempotent test
   azure_rm_keyvaultcertificate:
@@ -102,7 +102,7 @@
 
 - name: Assert the keyvault certificate no changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update thekeyvault certificate
   azure_rm_keyvaultcertificate:
@@ -129,7 +129,7 @@
 
 - name: Assert the keyvault certificate changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get the keyvault certificate facts
   azure_rm_keyvaultcertificate_info:
@@ -157,7 +157,7 @@
 
 - name: Assert the keyvault certificate imported
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete the keyvault certificate
   azure_rm_keyvaultcertificate:
@@ -189,7 +189,7 @@
 
 - name: Assert the keyvault certificate recovered
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Purge the keyvault certificate
   azure_rm_keyvaultcertificate:
@@ -200,7 +200,7 @@
 
 - name: Assert the keyvault certificate purged
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: List all delete keyvault certificate
   azure_rm_keyvaultcertificate_info:

--- a/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
@@ -62,7 +62,7 @@
       register: output
     - name: Assert the keyvault key created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault key
       azure_rm_keyvaultkey:
@@ -90,7 +90,7 @@
       register: output
     - name: Assert the keyvault key created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault key
       azure_rm_keyvaultkey:
@@ -118,7 +118,7 @@
       register: output
     - name: Assert the keyvault key created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault key
       azure_rm_keyvaultkey:
@@ -146,7 +146,7 @@
       register: output
     - name: Assert the keyvault key created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault key
       azure_rm_keyvaultkey:
@@ -176,7 +176,7 @@
       register: output
     - name: Assert the keyvault key created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault ke
       azure_rm_keyvaultkey:
@@ -193,7 +193,7 @@
 
 - name: Assert the keyvault key deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete instance of Key Vault
   azure_rm_keyvault:

--- a/tests/integration/targets/azure_rm_keyvaultsecret/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultsecret/tasks/main.yml
@@ -60,7 +60,7 @@
       register: output
     - name: Assert the keyvault secret created
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
   rescue:
     - name: Delete the keyvault secret
       azure_rm_keyvaultsecret:
@@ -97,4 +97,4 @@
 
 - name: Assert the keyvault secret deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed

--- a/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancer/tasks/main.yml
@@ -51,7 +51,7 @@
 
 - name: Assert load balancer created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create load balancer
   azure_rm_loadbalancer:
@@ -65,7 +65,7 @@
 
 - name: Assert load balancer created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create load balancer -- idempotent
   azure_rm_loadbalancer:
@@ -80,7 +80,7 @@
 - name: Assert no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete load balancer
   azure_rm_loadbalancer:
@@ -91,7 +91,7 @@
 
 - name: Assert load balancer deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete load balancer (idempotent)
   azure_rm_loadbalancer:
@@ -102,7 +102,7 @@
 
 - name: Assert load balancer deleted (idempotent)
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Create another load balancer with more options
   azure_rm_loadbalancer:
@@ -155,7 +155,7 @@
 - name: Assert complex load balancer created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.sku.name == 'Standard'
 
 - name: Create load balancer again to check idempotency
@@ -209,7 +209,7 @@
 - name: Assert that output has not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the load balancer facts
   azure_rm_loadbalancer_info:
@@ -276,7 +276,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: The second time to get the load balancer facts
   azure_rm_loadbalancer_info:
@@ -331,7 +331,7 @@
 - name: Assert complex load balancer created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete load balancer
   azure_rm_loadbalancer:
@@ -370,7 +370,7 @@
 
 - name: Assert complex load balancer created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete load balancer
   azure_rm_loadbalancer:
@@ -431,7 +431,7 @@
 - name: Assert complex load balancer created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.frontend_ip_configurations[0].zones | length == 3
 
 - name: Delete load balancer

--- a/tests/integration/targets/azure_rm_localnetworkgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_localnetworkgateway/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: Assert the local network gateway is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.provisioning_state == 'Succeeded'
 
 - name: Create a new local network gateway(Idempotent test)
@@ -62,7 +62,7 @@
 - name: Assert the local network gateway no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create a new local network gateway(Update test)
   azure_rm_localnetworkgateway:
@@ -84,7 +84,7 @@
 - name: Assert the local network gateway updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get a new local network gateway
   azure_rm_localnetworkgateway_info:
@@ -95,7 +95,7 @@
 - name: Assert the local network gateway facts
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.state[0].bgp_settings.asn == 10
       - output.state[0].bgp_settings.peer_weight == 5
       - "output.state[0].tags | length == 1"
@@ -111,4 +111,4 @@
 - name: Assert the local network gateway is deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: Assert there is no log analytics workspace
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get Log Analytics workspace information
   azure_rm_loganalyticsworkspace_info:
@@ -77,7 +77,7 @@
 - name: Assert the log analytics workspace created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.retention_in_days == 30
       - output.intelligence_packs | selectattr('name', 'equalto', 'Backup') | map(attribute='enabled') | first == true
       - output.intelligence_packs | selectattr('name', 'equalto', 'Containers') | map(attribute='enabled') | first == true
@@ -104,7 +104,7 @@
 - name: Assert the log analytics workspace updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.retention_in_days == retention_days
       - output.tags.key2 == 'value2'
       - output.identity.type == 'UserAssigned'
@@ -123,7 +123,7 @@
 - name: Assert the log analytics workspace facts
   ansible.builtin.assert:
     that:
-      - not facts.changed
+      - facts is not changed
       - facts.workspaces | length > 0
       - facts.workspaces[0].retention_in_days == retention_days
       - facts.workspaces[0].intelligence_packs | length > 0
@@ -147,7 +147,7 @@
 - name: Assert the log analytics workspace facts
   ansible.builtin.assert:
     that:
-      - not facts.changed
+      - facts is not changed
       - facts.workspaces | length > 0
       - facts.workspaces[0].retention_in_days == retention_days
       - facts.workspaces[0].intelligence_packs is not defined
@@ -166,7 +166,7 @@
 - name: Assert the log anaytics workspace already created
   ansible.builtin.assert:
     that:
-      - not log_analytics_workspace_output.changed
+      - log_analytics_workspace_output is not changed
 
 - name: Create data collection rule (check mode)
   azure.azcollection.azure_rm_monitordatacollectionrules:
@@ -199,7 +199,7 @@
 - name: Assert the data collection rule is created (check mode)
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create data collection rule (no tags)
   azure.azcollection.azure_rm_monitordatacollectionrules:
@@ -231,7 +231,7 @@
 - name: Assert the data collection rule is created (no tags)
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create data collection rule (no tags, idempotency check)
   azure.azcollection.azure_rm_monitordatacollectionrules:
@@ -263,7 +263,7 @@
 - name: Assert the data collection rule is already created (no tags)
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create data collection rule (creation tags)
   azure.azcollection.azure_rm_monitordatacollectionrules:
@@ -297,7 +297,7 @@
 - name: Assert the data collection rule is created (creation tags)
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.datacollectionrule.tags.CreationTag1 == 'CreationTagValue1'
 
 - name: Create data collection rule (creation tags, idempotency check)
@@ -332,7 +332,7 @@
 - name: Assert the data collection rule is already created (creation tags)
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.datacollectionrule.tags.CreationTag1 == 'CreationTagValue1'
 
 - name: Add tag to data collection rule
@@ -347,7 +347,7 @@
 - name: Assert the data collection rule tags are updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.datacollectionrule.tags.TestTag1 == 'TestValue1'
 
 - name: Add tag to data collection rule (Idempotency)
@@ -362,7 +362,7 @@
 - name: Assert the data collection rule tags are updated (Idempotency)
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.datacollectionrule.tags.TestTag1 == 'TestValue1'
 
 - name: Add tag to data collection rule (append)
@@ -377,7 +377,7 @@
 - name: Assert the data collection rule tags are updated (append)
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.datacollectionrule.tags.TestTag1 == 'TestValue1'
       - output.datacollectionrule.tags.TestTag2 == 'TestValue2'
 
@@ -393,7 +393,7 @@
 - name: Assert the data collection rule tags are updated (append, idempotency)
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.datacollectionrule.tags.TestTag1 == 'TestValue1'
       - output.datacollectionrule.tags.TestTag2 == 'TestValue2'
 
@@ -409,7 +409,7 @@
 - name: Assert the data collection rule tags are replaced
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.datacollectionrule.tags.TestTag1 is not defined
       - output.datacollectionrule.tags.TestTag2 is not defined
       - output.datacollectionrule.tags.TestTag3 == 'TestValue3'
@@ -426,7 +426,7 @@
 - name: Assert the data collection rule tags are replaced (idempotency)
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.datacollectionrule.tags.TestTag1 is not defined
       - output.datacollectionrule.tags.TestTag2 is not defined
       - output.datacollectionrule.tags.TestTag3 == 'TestValue3'
@@ -441,7 +441,7 @@
 - name: Assert the data collection rule tags are removed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.datacollectionrule.tags.TestTag1 is not defined
       - output.datacollectionrule.tags.TestTag2 is not defined
       - output.datacollectionrule.tags.TestTag3 is not defined
@@ -456,7 +456,7 @@
 - name: Assert the data collection rule tags are removed (idempotency)
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.datacollectionrule.tags.TestTag1 is not defined
       - output.datacollectionrule.tags.TestTag2 is not defined
       - output.datacollectionrule.tags.TestTag3 is not defined
@@ -502,7 +502,7 @@
 - name: Assert the data collection rule is changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Remove data collection rule
   azure.azcollection.azure_rm_monitordatacollectionrules:
@@ -514,7 +514,7 @@
 - name: Assert the data collection rule is changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Remove data collection rule (check if actually removed)
   azure.azcollection.azure_rm_monitordatacollectionrules:
@@ -526,7 +526,7 @@
 - name: Assert the data collection rule is already removed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Use info module to make sure data collection rule is gone (direct match)
   azure.azcollection.azure_rm_monitordatacollectionrules_info:
@@ -568,7 +568,7 @@
 - name: Assert the data collection rule is changed (creation tags)
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Remove Log Analytics workspace (Check Mode On)
   azure_rm_loganalyticsworkspace:
@@ -581,7 +581,7 @@
 - name: Assert there is no log anaytics workspace
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get Log Analytics workspace information(Check still exists after remove Check Mode On)
   azure_rm_loganalyticsworkspace_info:
@@ -626,7 +626,7 @@
 - name: Assert the log analytics workspace deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get Log Analytics workspace information
   azure_rm_loganalyticsworkspace_info:
@@ -650,7 +650,7 @@
 - name: Assert the log analytics workspace deleted
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Destroy User Managed Identities
   azure_rm_resource:

--- a/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: Assert status succeeded (Check Mode)
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state
 
 - name: Create new managed disk succesfully
@@ -63,7 +63,7 @@
 - name: Assert status succeeded and results include an Id value
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.disk_size_gb == 1
       - output.state.id is defined
       - output.state.os_type == None
@@ -81,7 +81,7 @@
 - name: Assert status succeeded and results include an Id value
   ansible.builtin.assert:
     that:
-      - disk2.changed
+      - disk2 is changed
       - disk2.state.id is defined
 
 - name: Create disk to a new managed disk with zone and os type
@@ -97,7 +97,7 @@
 - name: Assert status succeeded and results include an Id value
   ansible.builtin.assert:
     that:
-      - disk3.changed
+      - disk3 is changed
       - disk3.state.id is defined
       - disk3.state.zone == "1"
       - disk3.state.os_type == "windows"
@@ -134,7 +134,7 @@
 - name: Assert the disk updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.storage_account_type == "StandardSSD_LRS"
       - output.state.disk_size_gb == 2
       - "output.state.tags | length == 2"
@@ -180,7 +180,7 @@
 - name: Assert the disk created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create new managed disk with  I(account_type=StandardSSD_ZRS)
   azure_rm_manageddisk:
@@ -194,7 +194,7 @@
 - name: Assert the managed disk update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.storage_account_type == "StandardSSD_ZRS"
       - output.state.disk_size_gb == 2
 
@@ -223,7 +223,7 @@
 - name: Assert the managed disk created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.storage_account_type == "Premium_ZRS"
       - output.state.disk_size_gb == 2
 
@@ -255,7 +255,7 @@
 - name: Assert the managed disk Created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create new managed disk with throught parameters(Idempotent Test)
   azure_rm_manageddisk:
@@ -272,7 +272,7 @@
 - name: Assert the managed disk no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the managed disk
   azure_rm_manageddisk:
@@ -289,7 +289,7 @@
 - name: Assert the managed disk updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the managed disk facts
   azure_rm_manageddisk_info:
@@ -326,7 +326,7 @@
 - name: Assert status succeeded and results include an Id value
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete managed disk (Check Mode)
   azure_rm_manageddisk:
@@ -339,7 +339,7 @@
 - name: Assert status succeeded
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state
 
 - name: Gather Resource Group info
@@ -373,7 +373,7 @@
 - name: Assert Tags
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.tags.testtag1 == 'TestValue1'
 
 - name: Update tags (replace) on managed disk (fromimage)
@@ -388,7 +388,7 @@
 - name: Assert Tags
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state
       - output.state.tags.testtag1 is not defined
       - output.state.tags.testtag2 == 'TestValue2'
@@ -405,7 +405,7 @@
 - name: Assert Tags
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state
       - output.state.tags.testtag1 is not defined
       - output.state.tags.testtag2 == 'TestValue2'

--- a/tests/integration/targets/azure_rm_mariadbserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mariadbserver/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of MariaDB Server
   azure_rm_mariadbserver:
@@ -41,7 +41,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 
 - name: Create again instance of MariaDB Server
@@ -61,7 +61,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
       - output.state == 'Ready'
 
 - name: Update instance of MariaDB Server, change storage size
@@ -81,7 +81,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 - name: Print the state of the mariadb server
   ansible.builtin.debug:
@@ -138,7 +138,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers[0]['id'] != None
       - output.servers[0]['name'] != None
       - output.servers[0]['location'] != None
@@ -158,7 +158,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers[0]['id'] != None
       - output.servers[0]['name'] != None
       - output.servers[0]['location'] != None
@@ -191,7 +191,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of MariaDB Database
   azure_rm_mariadbdatabase:
@@ -204,7 +204,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.name == 'testdatabase'
 
 - name: Create again instance of MariaDB Database
@@ -218,7 +218,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
       - output.name == 'testdatabase'
 
 - name: Try to update database without force_update
@@ -233,7 +233,7 @@
 - name: Assert that nothing has changed
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
 
 - name: Update instance of database using force_update
   azure_rm_mariadbdatabase:
@@ -247,7 +247,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.name == 'testdatabase'
 
 - name: Create second instance of MariaDB Database
@@ -266,7 +266,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None
@@ -280,7 +280,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed 
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None
@@ -301,7 +301,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of MariaDB Database
   azure_rm_mariadbdatabase:
@@ -313,7 +313,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of MariaDB Database
   azure_rm_mariadbdatabase:
@@ -325,7 +325,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 #
 # azure_rm_firewallrule tests below
@@ -342,7 +342,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Firewall Rule
   azure_rm_mariadbfirewallrule:
@@ -355,7 +355,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create again instance of Firewall Rule
   azure_rm_mariadbfirewallrule:
@@ -368,7 +368,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 - name: Delete instance of Firewall Rule -- check mode
   azure_rm_mariadbfirewallrule:
@@ -381,7 +381,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Firewall Rule -- second
   azure_rm_mariadbfirewallrule:
@@ -394,7 +394,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts MariaDB Firewall Rule
   azure_rm_mariadbfirewallrule_info:
@@ -405,7 +405,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].server_name != None
       - output.rules[0].name != None
@@ -421,7 +421,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].server_name != None
       - output.rules[0].name != None
@@ -443,7 +443,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of Firewall Rule
   azure_rm_mariadbfirewallrule:
@@ -455,7 +455,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 - name: Delete instance of Firewall Rule - second
   azure_rm_mariadbfirewallrule:
@@ -473,7 +473,7 @@
 - name: Assert that empty list was returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules | length == 0
 
 #
@@ -490,7 +490,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to delete default configuraion
   azure_rm_mariadbconfiguration_info:
@@ -512,7 +512,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to change default configuraion
   azure_rm_mariadbconfiguration:
@@ -524,7 +524,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to change default configuration -- idempotent
   azure_rm_mariadbconfiguration:
@@ -536,7 +536,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to reset configuration
   azure_rm_mariadbconfiguration:
@@ -548,7 +548,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to reset configuration -- idempotent
   azure_rm_mariadbconfiguration:
@@ -560,7 +560,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Gather facts MariaDB Configuration
   azure_rm_mariadbconfiguration_info:
@@ -571,7 +571,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.settings[0].id != None
       - output.settings[0].name != None
       - output.settings[0].value != None
@@ -587,7 +587,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.settings[0].id != None
       - output.settings[0].name != None
       - output.settings[0].value != None
@@ -609,7 +609,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of MariaDB Server
   azure_rm_mariadbserver:
@@ -620,7 +620,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of MariaDB Server
   azure_rm_mariadbserver:
@@ -631,7 +631,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 - name: Delete second instance of MariaDB Server
   azure_rm_mariadbserver:

--- a/tests/integration/targets/azure_rm_monitordiagnosticsetting/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_monitordiagnosticsetting/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: Assert no settings
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.settings | length == 0
 
 - name: Create storage-based diagnostic setting for vnet (check mode)
@@ -84,7 +84,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create storage-based diagnostic setting for vnet (actually create)
   azure_rm_monitordiagnosticsetting:
@@ -99,7 +99,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.name == 'logs-storage'
       - output.state.storage_account.id == storage_output.state.id
       - output.state.logs | length == 1
@@ -125,7 +125,7 @@
 - name: Assert resource not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create storage-based diagnostic setting for vnet by resource dict (idempotent)
   azure_rm_monitordiagnosticsetting:
@@ -143,7 +143,7 @@
 - name: Assert resource not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update storage-based diagnostic setting for vnet
   azure_rm_monitordiagnosticsetting:
@@ -156,7 +156,7 @@
 - name: Assert resource updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.name == 'logs-storage'
       - output.state.storage_account.id == storage_output.state.id
       - output.state.logs | length == 1
@@ -181,7 +181,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.name == 'logs-storage2'
       - output.state.storage_account.id == storage2_output.state.id
       - output.state.logs | length == 1
@@ -208,7 +208,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.logs[0].retention_policy.days == 30
 
 - name: Update second storage-based diagnostic setting for vnet (idempotent)
@@ -226,7 +226,7 @@
 - name: Assert resource not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get diagnostic settings for virtual network
   azure_rm_monitordiagnosticsetting_info:
@@ -311,7 +311,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.name == 'logs'
       - output.state.storage_account.id == storage_output.state.id
       - output.state.event_hub.namespace == 'hub-{{ rpfx }}'
@@ -352,7 +352,7 @@
 - name: Assert resource created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update diagnostic setting to remove storage and log category
   azure_rm_monitordiagnosticsetting:
@@ -377,7 +377,7 @@
 - name: Assert resource updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - not output.state.storage_account
       - output.state.logs | length == 5
       - output.state.logs[0].category == 'AppServiceHTTPLogs'
@@ -398,7 +398,7 @@
 - name: Assert resource delete
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete diagnostic setting via resource dict (idempotent)
   azure_rm_monitordiagnosticsetting:
@@ -412,7 +412,7 @@
 - name: Assert resource delete
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete diagnostic setting (check mode)
   azure_rm_monitordiagnosticsetting:
@@ -424,7 +424,7 @@
 - name: Assert resource deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete diagnostic setting (actually delete)
   azure_rm_monitordiagnosticsetting:
@@ -435,7 +435,7 @@
 - name: Assert resource deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete diagnostic setting (idempotent)
   azure_rm_monitordiagnosticsetting:
@@ -446,7 +446,7 @@
 - name: Assert resource already deleted
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete second diagnostic setting
   azure_rm_monitordiagnosticsetting:
@@ -457,7 +457,7 @@
 - name: Assert resource deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 # ------ teardown ------
 

--- a/tests/integration/targets/azure_rm_monitorlogprofile/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_monitorlogprofile/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: Assert create check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create log profile
   azure_rm_monitorlogprofile:
@@ -55,7 +55,7 @@
 - name: Assert create
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Update log profile (idempotence)
@@ -78,7 +78,7 @@
 - name: Assert update idempotence
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update log profile
   azure_rm_monitorlogprofile:
@@ -99,7 +99,7 @@
 - name: Assert update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete log profile (check mode)
   azure_rm_monitorlogprofile:
@@ -110,7 +110,7 @@
 - name: Assert delete
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete log profile
   azure_rm_monitorlogprofile:
@@ -120,7 +120,7 @@
 - name: Assert delete
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete log profile (idempotence)
   azure_rm_monitorlogprofile:
@@ -130,4 +130,4 @@
 - name: Assert delete
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed

--- a/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
@@ -58,7 +58,7 @@
 - name: Assert the resource is created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create mysql flexible server again(Idempotent Test)
   azure_rm_mysqlflexibleserver:
@@ -89,7 +89,7 @@
 - name: Assert the resource is no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create mysql flexible server again(Idempotent Test)
   azure_rm_mysqlflexibleserver:
@@ -120,7 +120,7 @@
 - name: Assert the resource is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts mysql flexible Server -- by name
   azure_rm_mysqlflexibleserver_info:
@@ -148,7 +148,7 @@
 - name: Assert the database is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a MySQL flexible database again(Idempotent Test)
   azure_rm_mysqlflexibledatabase:
@@ -162,7 +162,7 @@
 - name: Assert the database no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the MySQL flexible database facts
   azure_rm_mysqlflexibledatabase_info:
@@ -189,7 +189,7 @@
 - name: Assert the firewall rule is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a MySQL flexible firewall rule again(Idempotent Test)
   azure_rm_mysqlflexiblefirewallrule:
@@ -203,7 +203,7 @@
 - name: Assert the firewall rule no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create a MySQL flexible firewall rule again(Update Test)
   azure_rm_mysqlflexiblefirewallrule:
@@ -217,7 +217,7 @@
 - name: Assert the firewall rule is well updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the MySQL flexible firewall rule facts
   azure_rm_mysqlflexiblefirewallrule_info:
@@ -257,7 +257,7 @@
 - name: Assert the MySQL configuration is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the MySQL flexible configuration by name
   azure_rm_mysqlflexibleconfiguration_info:
@@ -283,7 +283,7 @@
 - name: Assert the database deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the mysql flexible server
   azure_rm_mysqlflexibleserver:
@@ -295,4 +295,4 @@
 - name: Assert the flexible server deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_mysqlserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlserver/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of MySQL Server
   azure_rm_mysqlserver:
@@ -49,7 +49,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 
 - name: Create again instance of MySQL Server
@@ -73,7 +73,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
       - output.state == 'Ready'
 
 - name: Update instance of MySQL Server, change storage size
@@ -97,7 +97,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 - name: Print the state of the mysql server
   ansible.builtin.debug:
@@ -122,7 +122,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create second instance of MySQL Server
   azure_rm_mysqlserver:
@@ -173,7 +173,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers[0]['id'] != None
       - output.servers[0]['name'] != None
       - output.servers[0]['location'] != None
@@ -193,7 +193,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers[0]['id'] != None
       - output.servers[0]['name'] != None
       - output.servers[0]['location'] != None
@@ -226,7 +226,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of MySQL Database
   azure_rm_mysqldatabase:
@@ -239,7 +239,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.name == 'testdatabase'
 
 - name: Create again instance of MySQL Database
@@ -253,7 +253,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
       - output.name == 'testdatabase'
 
 - name: Try to update database without force_update
@@ -268,7 +268,7 @@
 - name: Assert that nothing has changed
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
 
 - name: Update instance of database using force_update
   azure_rm_mysqldatabase:
@@ -282,7 +282,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.name == 'testdatabase'
 
 - name: Create second instance of MySQL Database
@@ -301,7 +301,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None
@@ -315,7 +315,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None
@@ -336,7 +336,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of MySQL Database
   azure_rm_mysqldatabase:
@@ -348,7 +348,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of MySQL Database
   azure_rm_mysqldatabase:
@@ -360,7 +360,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 #
 # azure_rm_firewallrule tests below
@@ -377,7 +377,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Firewall Rule
   azure_rm_mysqlfirewallrule:
@@ -390,7 +390,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create again instance of Firewall Rule
   azure_rm_mysqlfirewallrule:
@@ -403,7 +403,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 - name: Delete instance of Firewall Rule -- check mode
   azure_rm_mysqlfirewallrule:
@@ -416,7 +416,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Firewall Rule -- second
   azure_rm_mysqlfirewallrule:
@@ -429,7 +429,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts MySQL Firewall Rule
   azure_rm_mysqlfirewallrule_info:
@@ -440,7 +440,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].server_name != None
       - output.rules[0].name != None
@@ -456,7 +456,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].server_name != None
       - output.rules[0].name != None
@@ -478,7 +478,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of Firewall Rule
   azure_rm_mysqlfirewallrule:
@@ -490,7 +490,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 - name: Delete instance of Firewall Rule - second
   azure_rm_mysqlfirewallrule:
@@ -508,7 +508,7 @@
 - name: Assert that empty list was returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - "output.rules | length == 0"
 
 #
@@ -525,7 +525,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to delete default configuraion
   azure_rm_mysqlconfiguration_info:
@@ -547,7 +547,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to change default configuraion
   azure_rm_mysqlconfiguration:
@@ -559,7 +559,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to change default configuration -- idempotent
   azure_rm_mysqlconfiguration:
@@ -571,7 +571,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to reset configuration
   azure_rm_mysqlconfiguration:
@@ -583,7 +583,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to reset configuration -- idempotent
   azure_rm_mysqlconfiguration:
@@ -595,7 +595,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Gather facts MySQL Configuration
   azure_rm_mysqlconfiguration_info:
@@ -606,7 +606,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.settings[0].id != None
       - output.settings[0].name != None
       - output.settings[0].value != None
@@ -622,7 +622,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.settings[0].id != None
       - output.settings[0].name != None
       - output.settings[0].value != None
@@ -644,7 +644,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of MySQL Server
   azure_rm_mysqlserver:
@@ -655,7 +655,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of MySQL Server
   azure_rm_mysqlserver:
@@ -666,7 +666,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed == false
 
 - name: Delete second instance of MySQL Server
   azure_rm_mysqlserver:

--- a/tests/integration/targets/azure_rm_natgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_natgateway/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get NAT gateways
   azure_rm_natgateway_info:
@@ -53,7 +53,7 @@
 - name: Assert that gateway is well created
   ansible.builtin.assert:
     that:
-      - natgw_output.changed
+      - natgw_output is changed
       - natgw_output.resource_group == "{{ resource_group }}"
       - natgw_output.name == "nat-gateway{{ rpfx }}1"
       - natgw_output.location == "{{ rg_location }}"
@@ -75,7 +75,7 @@
 - name: Assert the resource instance is not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to update instance of NAT Gateway - change timeout
   azure_rm_natgateway:
@@ -86,7 +86,7 @@
 - name: Assert the resource instance is changed
   ansible.builtin.assert:
     that:
-      - natgw_output.changed
+      - natgw_output is changed
       - natgw_output.location == "{{ rg_location }}"
 - name: Get NAT gateways
   azure_rm_natgateway_info:
@@ -109,7 +109,7 @@
 - name: Assert the resource instance is not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create public IP for NAT Gateway
   azure_rm_publicipaddress:
@@ -144,7 +144,7 @@
 - name: Assert the resource instance is changed
   ansible.builtin.assert:
     that:
-      - natgw_output.changed
+      - natgw_output is changed
 - name: Get NAT gateways
   azure_rm_natgateway_info:
     name: nat-gateway{{ rpfx }}1
@@ -168,7 +168,7 @@
 - name: Assert the resource instance is changed
   ansible.builtin.assert:
     that:
-      - natgw_output.changed
+      - natgw_output is changed
 - name: Get NAT gateways
   azure_rm_natgateway_info:
     name: nat-gateway{{ rpfx }}1
@@ -191,7 +191,7 @@
 - name: Assert the resource instance is changed
   ansible.builtin.assert:
     that:
-      - natgw_output.changed
+      - natgw_output is changed
 - name: Get NAT gateways
   azure_rm_natgateway_info:
     name: nat-gateway{{ rpfx }}1
@@ -289,7 +289,7 @@
 - name: Assert the resource instance is changed
   ansible.builtin.assert:
     that:
-      - natgw_output.changed
+      - natgw_output is changed
       - natgw_output.location == "eastus"
 - name: Get NAT gateways
   azure_rm_natgateway_info:

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -97,7 +97,7 @@
 - name: Assert the check mode facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create most simple NIC with virtual_network resource_group
   azure_rm_networkinterface:
@@ -115,7 +115,7 @@
 - name: Assert the NIC created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.id
       - output.state.ip_configuration.primary
 
@@ -156,7 +156,7 @@
 - name: Assert the NIC created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create most simple NIC (idempotent)
   azure_rm_networkinterface:
@@ -172,7 +172,7 @@
 - name: Assert NIC created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update security group (check mode)
   azure.azcollection.azure_rm_networkinterface:
@@ -189,7 +189,7 @@
 - name: Assert the security group check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update security group
   azure.azcollection.azure_rm_networkinterface:
@@ -205,7 +205,7 @@
 - name: Assert the security group check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.network_security_group.name == "tn{{ rpfx }}sg"
 
 - name: Update public ip address (check mode)
@@ -226,7 +226,7 @@
 - name: Assert the public ip check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update public ip address
   azure.azcollection.azure_rm_networkinterface:
@@ -245,7 +245,7 @@
 - name: Assert the public ip check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.network_security_group.name == "tn{{ rpfx }}sg"
       - output.state.ip_configurations[0].public_ip_address.name == "tn{{ rpfx }}"
 
@@ -265,7 +265,7 @@
 - name: Assert the network check mode facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update accelerated networking
   azure.azcollection.azure_rm_networkinterface:
@@ -282,7 +282,7 @@
 - name: Assert the network check mode facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.network_security_group.name == "tn{{ rpfx }}sg"
       - output.state.ip_configurations[0].public_ip_address.name == "tn{{ rpfx }}"
       - output.state.enable_accelerated_networking
@@ -303,7 +303,7 @@
 - name: Assert the NIC check mode facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update dns server (check mode)
   azure_rm_networkinterface:
@@ -323,7 +323,7 @@
 - name: Assert the NIC check mode facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update NIC
   azure_rm_networkinterface:
@@ -362,7 +362,7 @@
 - name: Assert NIC update facts
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.dns_settings.dns_servers == ['8.9.10.11', '7.8.9.10']
       - output.state.enable_ip_forwarding
       - output.state.network_security_group.name == "tn{{ rpfx }}sg"
@@ -407,7 +407,7 @@
 - name: Assert the NIC no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get fact of the new created NIC
   azure_rm_networkinterface_info:
@@ -465,7 +465,7 @@
 - name: Assert the NIC changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.dns_settings.dns_servers == ['8.9.10.11']
       - output.state.enable_ip_forwarding
       - output.state.network_security_group.name == "tn{{ rpfx }}sg"
@@ -483,7 +483,7 @@
 - name: Assert check mode creation
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create Application security group
   azure_rm_applicationsecuritygroup:
@@ -496,7 +496,7 @@
 - name: Assert application security group creation
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id != ''
 
 - name: Get Application security group
@@ -524,7 +524,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update application security group
   azure_rm_applicationsecuritygroup:
@@ -538,7 +538,7 @@
 - name: Assert update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create Application security group in secondary resource group
   azure_rm_applicationsecuritygroup:
@@ -566,7 +566,7 @@
 - name: Assert creation succeeded
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create Nic with application security groups (idempotent)
   azure_rm_networkinterface:
@@ -590,7 +590,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update Nic with application security groups
   azure_rm_networkinterface:
@@ -611,7 +611,7 @@
 - name: Assert update succeeded
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get fact of the new created NIC
   azure_rm_networkinterface_info:
@@ -705,7 +705,7 @@
 - name: Assert the NIC created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.ip_configurations | length == 1
       - output.state.ip_configurations[0].application_gateway_backend_address_pools | length == 1
       - output.state.ip_configurations[0].application_gateway_backend_address_pools[0] == appgw_output.id + '/backendAddressPools/test_backend_address_pool'
@@ -731,7 +731,7 @@
 - name: Assert the NIC idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get facts for appgw nic
   azure_rm_networkinterface_info:
@@ -756,7 +756,7 @@
 - name: Assert the NIC deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete application gateway
   azure_rm_appgateway:
@@ -767,7 +767,7 @@
 - name: Assert the application gateway deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the NIC (check mode)
   azure_rm_networkinterface:
@@ -780,7 +780,7 @@
 - name: Assert the NIC check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the NIC
   azure_rm_networkinterface:
@@ -792,7 +792,7 @@
 - name: Assert the NIC deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the NIC (idempotent)
   azure_rm_networkinterface:
@@ -804,7 +804,7 @@
 - name: Assert the NIC idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete load balancer
   azure_rm_loadbalancer:
@@ -827,7 +827,7 @@
 - name: Assert the NIC deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.results | length == 4
 
 - name: Delete the NIC
@@ -847,7 +847,7 @@
 - name: Assert delete check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the application security group
   azure_rm_applicationsecuritygroup:
@@ -859,7 +859,7 @@
 - name: Assert the deletion
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete second application security group
   azure_rm_applicationsecuritygroup:
@@ -881,7 +881,7 @@
 - name: Assert the security group deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.results | length == 2
 
 - name: Delete virtual network
@@ -894,4 +894,4 @@
 - name: Assert the virtual network deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_networkwatcher/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkwatcher/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Assert the network watcher is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a Network Watcher again(Idempotent test)
   azure_rm_networkwatcher:
@@ -40,7 +40,7 @@
 - name: Assert the network watcher is no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the network watcher facts
   azure_rm_networkwatcher_info:
@@ -75,4 +75,4 @@
 - name: Assert the network watcher is well delete
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_notificationhub/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_notificationhub/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Assert the notification hub check mode
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create Notification Hub  (check mode)
   azure_rm_notificationhub:
@@ -28,7 +28,7 @@
 
 - name: Assert the notfication hub check mode
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create Namespace Hub
   azure_rm_notificationhub:
@@ -40,7 +40,7 @@
 
 - name: Assert the notification hub created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create Notification Hub
   azure_rm_notificationhub:
@@ -53,7 +53,7 @@
 
 - name: Assert the notification hub created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Update Namespace
   azure_rm_notificationhub:
@@ -67,7 +67,7 @@
 - name: Assert the namespace updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Update Notification Hub
@@ -83,7 +83,7 @@
 - name: Assert the notification hub updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Retrieve Namespace
@@ -106,7 +106,7 @@
 - name: Assert the notification hub check mode
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 #
 # azure_rm_ddos_notification hub and namspace cleanup
@@ -134,7 +134,7 @@
 
 - name: Assert the namespace deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Delete Notification Hub
   azure_rm_notificationhub:
@@ -160,4 +160,4 @@
 
 - name: Assert the notificationhub deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -99,7 +99,7 @@
 
 - name: Assert the cluster created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 
 - name: Get available clusters for a specific resource_group
@@ -183,4 +183,4 @@
 
 - name: Assert the cluster deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -99,7 +99,7 @@
 - name: Assert the postgresql flexible server create success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Assert User identity assigned
   ansible.builtin.assert:
@@ -142,7 +142,7 @@
 - name: Assert the postgresql server create success
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update postgresql flexible server with multiple parameters
   azure_rm_postgresqlflexibleserver:
@@ -183,7 +183,7 @@
 - name: Assert the postgresql server update success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts postgresql flexible Server
   azure_rm_postgresqlflexibleserver_info:
@@ -237,7 +237,7 @@
 - name: Assert the postgresql flexible database created success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a postgresql flexible database(Idempotent test)
   azure_rm_postgresqlflexibledatabase:
@@ -251,7 +251,7 @@
 - name: Assert the postgresql flexible database no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the postgresql flexibe database facts
   azure_rm_postgresqlflexibledatabase_info:
@@ -277,7 +277,7 @@
 - name: Assert the postgresql flexible database deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a postgresql flexible firwall rule (Check mode)
   azure_rm_postgresqlflexiblefirewallrule:
@@ -300,7 +300,7 @@
 - name: Assert the postgrepsql flexible firewall rule created well
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create the postgresql flexible firwall rule (Idempotent test)
   azure_rm_postgresqlflexiblefirewallrule:
@@ -314,7 +314,7 @@
 - name: Assert the postgresql flexible firewall rule support idempotent test
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the postgresql flexible firwall rule
   azure_rm_postgresqlflexiblefirewallrule:
@@ -328,7 +328,7 @@
 - name: Assert the postgresql flexible server update well
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the postgresql flexible firwall rule facts
   azure_rm_postgresqlflexiblefirewallrule_info:
@@ -354,7 +354,7 @@
 - name: Assert the postgresql flexible server delete well
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: List the postgresql flexible config facts
   azure_rm_postgresqlflexibleconfiguration_info:
@@ -377,7 +377,7 @@
 - name: Assert the postgresql flexible server backup created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new backup for the postgresql flexible server(Idempotent test)
   azure_rm_postgresqlflexiblebackup:
@@ -389,7 +389,7 @@
 - name: Assert the postgresql flexible server backup no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the backup for the postgresql flexible server
   azure_rm_postgresqlflexiblebackup_info:
@@ -414,7 +414,7 @@
 - name: Assert the postgresql flexible server backup deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new virtual endpoint for the postgresql flexible server
   azure_rm_postgresqlflexiblevirtualendpoint:
@@ -429,7 +429,7 @@
 - name: Assert the postgresql flexible server virtual endpoint created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new virtual endpoint for the postgresql flexible server(Idempotent test)
   azure_rm_postgresqlflexiblevirtualendpoint:
@@ -444,7 +444,7 @@
 - name: Assert the postgresql flexible server virtual endpoint no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get the virtual endpoint for the postgresql flexible server
   azure_rm_postgresqlflexiblevirtualendpoint_info:
@@ -469,7 +469,7 @@
 - name: Assert the postgresql flexible server virtual endpoint deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Stop the postgresql flexible server
   azure_rm_postgresqlflexibleserver:
@@ -481,7 +481,7 @@
 - name: Assert the postgresql server stop success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pause for 10 mimutes
   ansible.builtin.pause:
@@ -498,7 +498,7 @@
 - name: Assert the postgresql server restart success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete postgresql flexible server
   azure_rm_postgresqlflexibleserver:
@@ -510,7 +510,7 @@
 - name: Assert the postgresql server is well deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
@@ -534,4 +534,4 @@
 - name: Assert the resource group is well deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of PostgreSQL Server
   azure_rm_postgresqlserver:
@@ -39,7 +39,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 
 - name: Create again instance of PostgreSQL Server
@@ -58,7 +58,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
       - output.state == 'Ready'
 
 - name: Update instance of PostgreSQL Server, change storage size
@@ -77,7 +77,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 - name: Print the postgresql server states
   ansible.builtin.debug:
@@ -136,7 +136,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers[0]['id'] != None
       - output.servers[0]['name'] != None
       - output.servers[0]['location'] != None
@@ -157,7 +157,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers[0]['id'] != None
       - output.servers[0]['name'] != None
       - output.servers[0]['location'] != None
@@ -192,7 +192,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of PostgreSQL Database
   azure_rm_postgresqldatabase:
@@ -205,7 +205,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.name == 'testdatabase'
 
 - name: Create again instance of PostgreSQL Database
@@ -219,7 +219,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
       - output.name == 'testdatabase'
 
 - name: Try to update PostgreSQL Database without force_update
@@ -234,7 +234,7 @@
 - name: Assert that nothing has changed
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
 
 - name: Try to update PostgreSQL Database with force_update
   azure_rm_postgresqldatabase:
@@ -248,7 +248,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.name == 'testdatabase'
 
 - name: Create second instance of PostgreSQL Database
@@ -267,7 +267,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None
@@ -281,7 +281,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None
@@ -302,7 +302,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of PostgreSQL Database
   azure_rm_postgresqldatabase:
@@ -314,7 +314,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of PostgreSQL Database
   azure_rm_postgresqldatabase:
@@ -326,7 +326,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 #
 # azure_rm_postgresqlfirewallrule
@@ -344,7 +344,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Firewall Rule
   azure_rm_postgresqlfirewallrule:
@@ -357,7 +357,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create again instance of Firewall Rule
   azure_rm_postgresqlfirewallrule:
@@ -370,7 +370,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Create Firewall Rule - second
   azure_rm_postgresqlfirewallrule:
@@ -389,7 +389,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].server_name != None
       - output.rules[0].name != None
@@ -405,7 +405,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].server_name != None
       - output.rules[0].name != None
@@ -428,7 +428,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of Firewall Rule
   azure_rm_postgresqlfirewallrule:
@@ -440,7 +440,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of Firewall Rule
   azure_rm_postgresqlfirewallrule:
@@ -452,7 +452,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Delete instance of Firewall Rule - second
   azure_rm_postgresqlfirewallrule:
@@ -470,7 +470,7 @@
 - name: Assert that empty list was returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - "output.rules | length == 0"
 
 #
@@ -487,7 +487,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to change default configuration
   azure_rm_postgresqlconfiguration:
@@ -499,7 +499,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to change default configuration -- idempotent
   azure_rm_postgresqlconfiguration:
@@ -511,7 +511,7 @@
 - name: Assert that change was not registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Try to reset configuration
   azure_rm_postgresqlconfiguration:
@@ -523,7 +523,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Try to reset configuration -- idempotent
   azure_rm_postgresqlconfiguration:
@@ -535,7 +535,7 @@
 - name: Assert that change was registered
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Gather facts PostgreSQL Configuration
   azure_rm_postgresqlconfiguration_info:
@@ -546,7 +546,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.settings[0].id != None
       - output.settings[0].name != None
       - output.settings[0].value != None
@@ -562,7 +562,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.settings[0].id != None
       - output.settings[0].name != None
       - output.settings[0].value != None
@@ -584,7 +584,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of PostgreSQL Server
   azure_rm_postgresqlserver:
@@ -595,7 +595,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of PostgreSQL Server
   azure_rm_postgresqlserver:
@@ -606,7 +606,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Delete second instance of PostgreSQL Server
   azure_rm_postgresqlserver:

--- a/tests/integration/targets/azure_rm_privatednsrecordset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privatednsrecordset/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Assert that Private DNS zone was created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create "A" record set with multiple records
   azure_rm_privatednsrecordset:
@@ -27,7 +27,7 @@
 
 - name: Assert that A record set was created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Re-run "A" record with same values
   azure_rm_privatednsrecordset:
@@ -43,7 +43,7 @@
 
 - name: Assert that A record set was not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update "A" record set with additional record
   azure_rm_privatednsrecordset:
@@ -59,7 +59,7 @@
 - name: Assert that new record was appended
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Re-update "A" record set with additional record
   azure_rm_privatednsrecordset:
@@ -75,7 +75,7 @@
 - name: Assert that A record set was not changed
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 - name: Remove 1 record from record set
   azure_rm_privatednsrecordset:
@@ -92,7 +92,7 @@
 - name: Assert that record was deleted
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Check_mode test
   azure_rm_privatednsrecordset:
@@ -108,7 +108,7 @@
 - name: Assert that check_mode returns new state
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Get information for A DNS recordset from Private DNS zone
   azure_rm_privatednsrecordset_info:
@@ -121,7 +121,7 @@
 - name: Assert the DNS recoredset facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.dnsrecordsets[0].id != None
       - results.dnsrecordsets[0].fqdn != None
       - results.dnsrecordsets[0].record_type == 'A'
@@ -140,7 +140,7 @@
 
 - name: Assert that record set deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Re-run record set absent (idempotence test)
   azure_rm_privatednsrecordset:
@@ -153,7 +153,7 @@
 
 - name: Assert recored set deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Create SRV records in a new record set
   azure_rm_privatednsrecordset:
@@ -173,7 +173,7 @@
 - name: Assert that SRV record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Get information for SRV DNS recordset from Private DNS zone
   azure_rm_privatednsrecordset_info:
@@ -186,7 +186,7 @@
 - name: Assert the DNS recordset facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.dnsrecordsets[0].id != None
       - results.dnsrecordsets[0].fqdn != None
       - results.dnsrecordsets[0].record_type == 'SRV'
@@ -212,7 +212,7 @@
 - name: Assert that TXT record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Get information for TXT DNS recordset from Private DNS zone
   azure_rm_privatednsrecordset_info:
@@ -225,7 +225,7 @@
 - name: Assert the DNS recordset facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.dnsrecordsets[0].id != None
       - results.dnsrecordsets[0].fqdn != None
       - results.dnsrecordsets[0].record_type == 'TXT'
@@ -253,7 +253,7 @@
 - name: Assert that SOA record set was created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Delete DNS zone
   azure_rm_privatednszone:

--- a/tests/integration/targets/azure_rm_privatednszone/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privatednszone/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Assert there is no private dns zone resource
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create a private DNS zone
   azure_rm_privatednszone:
@@ -21,7 +21,7 @@
 
 - name: Assert the private dns zone created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Update private DNS zone with tags
   azure_rm_privatednszone:
@@ -34,7 +34,7 @@
 - name: Assert the private dns zone updated
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.state.tags.test == 'modified'
 
 - name: Test idempotent
@@ -46,7 +46,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 - name: Retrieve DNS Zone Facts
   azure_rm_privatednszone_info:
@@ -79,4 +79,4 @@
 
 - name: Assert the private dns zone deleted
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_privatednszonelink/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privatednszonelink/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Assert that virtual network link is created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create a virtual network link (Idempotent test)
   azure_rm_privatednszonelink:
@@ -59,7 +59,7 @@
 
 - name: Assert that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update a virtual network link
   azure_rm_privatednszonelink:
@@ -73,7 +73,7 @@
 
 - name: Assert that virtual network link is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get virtual network link
   azure_rm_privatednszonelink_info:
@@ -85,7 +85,7 @@
 - name: Assert the virtual network link facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.virtualnetworklinks[0].name == "{{ link_name }}"
       - results.virtualnetworklinks[0].registration_enabled == true
       - results.virtualnetworklinks[0].provisioning_state == "Succeeded"
@@ -100,7 +100,7 @@
 
 - name: Assert that virtual network link is deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete virtual network link (Idempotent test)
   azure_rm_privatednszonelink:
@@ -112,7 +112,7 @@
 
 - name: Asset that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Delete virtual network
   azure_rm_virtualnetwork:

--- a/tests/integration/targets/azure_rm_privateendpoint/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpoint/tasks/main.yml
@@ -140,7 +140,7 @@
 - name: Assert status succeeded and results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.id is defined
       - output.state.provisioning_state == "Succeeded"
       - output.state.tags | length == 1
@@ -163,7 +163,7 @@
 - name: Assert status succeeded and results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
   ignore_errors: true
   register: ignore_errors_register
 
@@ -186,7 +186,7 @@
 - name: Assert status succeeded and results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.tags | length == 2
 
 - name: Get private endpoint info
@@ -217,7 +217,7 @@
 - name: Assert the secondary private endpoint created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create an application security group
   azure_rm_applicationsecuritygroup:
@@ -258,7 +258,7 @@
 - name: Assert the secondary private endpoint created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the third private endpoint
   azure_rm_privateendpoint:
@@ -284,7 +284,7 @@
 - name: Assert status succeeded and results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete private endpoint ( Idempotent Test)
   azure_rm_privateendpoint:
@@ -296,4 +296,4 @@
 - name: Assert status succeeded and results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed

--- a/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
@@ -92,7 +92,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.groups | length == 0
 
 - name: Create zone group for private endpoint - check mode
@@ -108,7 +108,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create zone group for private endpoint
   azure_rm_privateendpointdnszonegroup:
@@ -122,7 +122,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.id
       - output.state.name == 'zone-group-{{ rpfx }}'
       - output.state.provisioning_state == 'Succeeded'
@@ -150,7 +150,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get specific zone group for private endpoint
   azure_rm_privateendpointdnszonegroup_info:
@@ -161,7 +161,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.groups | length == 1
       - output.groups[0].id
       - output.groups[0].name == 'zone-group-{{ rpfx }}'
@@ -186,7 +186,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.groups | length == 1
       - output.groups[0].id
       - output.groups[0].name == 'zone-group-{{ rpfx }}'
@@ -215,7 +215,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.id
       - output.state.name == 'zone-group-{{ rpfx }}'
       - output.state.provisioning_state == 'Succeeded'
@@ -242,7 +242,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete zone group for private endpoint
   azure_rm_privateendpointdnszonegroup:
@@ -254,7 +254,7 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete non-existant zone group for private endpoint
   azure_rm_privateendpointdnszonegroup:
@@ -266,4 +266,4 @@
 - name: Assert results match expectations
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed

--- a/tests/integration/targets/azure_rm_privatelinkservice/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privatelinkservice/tasks/main.yml
@@ -92,7 +92,7 @@
 
 - name: Assert there is no private link service
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create private link service
   azure_rm_privatelinkservice:
@@ -124,7 +124,7 @@
 
 - name: Assert the private link service created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create private link service (Idempotent test)
   azure_rm_privatelinkservice:
@@ -156,7 +156,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update private link service
   azure_rm_privatelinkservice:
@@ -189,7 +189,7 @@
 
 - name: Assert the private link service update
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get private link service info by name
   azure_rm_privatelinkservice_info:
@@ -241,7 +241,7 @@
 
 - name: Assert the private endpoint connection updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get private endpoint connection info by name
   azure_rm_privateendpointconnection_info:
@@ -267,7 +267,7 @@
 
 - name: Assert the private endpoint connection deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Delete private endpoint
   azure_rm_privateendpoint:
@@ -277,7 +277,7 @@
 
 - name: Assert the private endpoint deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Pause for 5 mimutes to waiting
   ansible.builtin.command: sleep 300
@@ -292,7 +292,7 @@
 
 - name: Assert the private link service deleted
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Pause for 5 mimutes to waiting
   ansible.builtin.command: sleep 300

--- a/tests/integration/targets/azure_rm_proximityplacementgroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_proximityplacementgroup/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Assert that placement group is created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create a proximity placement group again (Idempotent test)
   azure_rm_proximityplacementgroup:
@@ -24,7 +24,7 @@
 
 - name: Assert that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Update a proximity placement group
   azure_rm_proximityplacementgroup:
@@ -38,7 +38,7 @@
 
 - name: Assert that placement group is updated
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get proximity placement group facts
   azure_rm_proximityplacementgroup_info:
@@ -49,7 +49,7 @@
 - name: Assert the proximity placement facts
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
       - results.proximityplacementgroups[0].name == "{{ group_name }}"
       - results.proximityplacementgroups[0].location == "eastus"
       - results.proximityplacementgroups[0].proximity_placement_group_type == "Standard"
@@ -63,7 +63,7 @@
 
 - name: Assert that placement group is deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete proximity placement group again (Idempotent test)
   azure_rm_proximityplacementgroup:
@@ -74,4 +74,4 @@
 
 - name: Asset that output is not changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed

--- a/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -68,7 +68,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update tags
   azure_rm_publicipaddress:

--- a/tests/integration/targets/azure_rm_publicipprefix/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_publicipprefix/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Assert the public IP prefix is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create public ip prefix (Idempotent test)
   azure_rm_publicipprefix:
@@ -55,7 +55,7 @@
 - name: Assert the public IP prefix no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update public ip prefix (Update tags)
   azure_rm_publicipprefix:
@@ -75,7 +75,7 @@
 - name: Assert the public IP prefix change
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts for a public ip prefix
   azure_rm_publicipprefix_info:
@@ -99,4 +99,4 @@
 - name: Assert the public IP prefix deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_recoveryservicesvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_recoveryservicesvault/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create Azure Recovery Service vault (idempotent)
   azure_rm_recoveryservicesvault:
@@ -51,7 +51,7 @@
 - name: Assert that output has no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update Azure Recovery Service vault with UserAssigned
   azure_rm_recoveryservicesvault:
@@ -69,7 +69,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update Azure Recovery Service vault with UserAssignd (idempotent)
   azure_rm_recoveryservicesvault:
@@ -87,7 +87,7 @@
 - name: Assert that output has no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update Azure Recovery Service vault with UserAssigned X2
   azure_rm_recoveryservicesvault:
@@ -106,7 +106,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update Azure Recovery Service vault with UserAssignd X2 (idempotent)
   azure_rm_recoveryservicesvault:
@@ -125,7 +125,7 @@
 - name: Assert that output has no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get Azure Recovery Service Vault Details
   azure_rm_recoveryservicesvault_info:
@@ -199,7 +199,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pause 3 minutes - wait for resource update to finish
   ansible.builtin.pause:
@@ -214,7 +214,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.response.tags.TestTag1 is defined
       - output.response.tags.TestTag1 == 'TestValue1'
 
@@ -232,7 +232,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pause 3 minutes - wait for resource update to finish
   ansible.builtin.pause:
@@ -247,7 +247,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.response.tags.TestTag1 is defined
       - output.response.tags.TestTag1 == 'TestValue1'
       - output.response.tags.TestTag2 is defined
@@ -267,7 +267,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pause 3 minutes - wait for resource update to finish
   ansible.builtin.pause:
@@ -282,7 +282,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - not output.response.tags.TestTag1 is defined
       - not output.response.tags.TestTag2 is defined
       - output.response.tags.TestTag3 is defined
@@ -299,7 +299,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete user managed identities
   ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"

--- a/tests/integration/targets/azure_rm_rediscache/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_rediscache/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: Assert creating redis cache check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a redis cache
   azure_rm_rediscache:
@@ -54,7 +54,7 @@
 - name: Assert creating redis cache
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Get facts
@@ -86,7 +86,7 @@
 - name: Assert output not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the redis cache ManagedIdentity UserAssigned
   azure_rm_rediscache:
@@ -106,7 +106,7 @@
 - name: Assert output changed
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Get redis-cache facts
   azure_rm_rediscache_info:
@@ -152,7 +152,7 @@
     - name: Assert output changed
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Update redis cache configuration
       azure_rm_rediscache:
@@ -170,7 +170,7 @@
     - name: Assert output changed
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Scale up the redis cache
       azure_rm_rediscache:
@@ -187,7 +187,7 @@
     - name: Assert the redis cache
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Force reboot redis cache
       azure_rm_rediscache:
@@ -203,7 +203,7 @@
     - name: Assert redis rebooted
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Delete the redis cache (Check Mode)
       azure_rm_rediscache:
@@ -218,7 +218,7 @@
 
     - name: Assert deleting redis cache check mode
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
 
     - name: Delete the redis cache
       azure_rm_rediscache:
@@ -233,7 +233,7 @@
     - name: Assert the redis cache deleted
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
       tags: [long_run, never]
 
 
@@ -252,7 +252,7 @@
 - name: Assert creating redis cache
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get facts for enhanced cache
   azure_rm_rediscache_info:
@@ -304,7 +304,7 @@
     - name: Assert output not changed
       ansible.builtin.assert:
         that:
-          - not output.changed
+          - output is not changed
 
     - name: Update redis cache public network access
       azure_rm_rediscache:
@@ -321,7 +321,7 @@
     - name: Assert output changed
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Get facts for enhanced cache
       azure_rm_rediscache_info:
@@ -346,7 +346,7 @@
     - name: Assert the redis cache deleted
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
       tags: [long_run, never]
 
 
@@ -379,7 +379,7 @@
 - name: Assert creating redis cache
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Get facts
@@ -409,7 +409,7 @@
 - name: Assert check mode creation
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Long-running key/firewallrule tests [run with `--tags long_run,untagged` to enable]
 # Creating firewall rule need Redis status is running, while creating redis Cache costs about 20 mins async operation,
@@ -440,7 +440,7 @@
     - name: Assert creation
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
           - output.id
 
     - name: Update firewall rule idempotence
@@ -455,7 +455,7 @@
     - name: Assert idempotence
       ansible.builtin.assert:
         that:
-          - output.changed == false
+          - output is not changed
 
     - name: Update firewall rule
       azure_rm_rediscachefirewallrule:
@@ -468,7 +468,7 @@
     - name: Assert updating
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Get key facts
       azure_rm_rediscache_info:
@@ -491,7 +491,7 @@
     - name: Assert output
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Get facts after key regeneration
       azure_rm_rediscache_info:
@@ -517,7 +517,7 @@
     - name: Assert deletion
       ansible.builtin.assert:
         that:
-          - output.changed
+          - output is changed
 
     - name: Delete the redis cache
       azure_rm_rediscache:

--- a/tests/integration/targets/azure_rm_registrationassignment/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_registrationassignment/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Assert the registration assignment check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a RegistrationAssignment
   azure_rm_registrationassignment:
@@ -40,7 +40,7 @@
 - name: Assert the registration assignment created
   ansible.builtin.assert:
     that:
-      - output2.changed
+      - output2 is changed
 
 - name: Create a RegistrationAssignment -- idempotent
   azure_rm_registrationassignment:
@@ -53,7 +53,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get a RegistrationAssignment
   azure_rm_registrationassignment_info:

--- a/tests/integration/targets/azure_rm_registrationdefinition/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_registrationdefinition/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Assert creating registration definition check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a RegistrationDefinition with scope
   azure_rm_registrationdefinition:
@@ -40,7 +40,7 @@
 - name: Assert creating registration definition
   ansible.builtin.assert:
     that:
-      - output2.changed
+      - output2 is changed
 
 - name: Create a RegistrationDefinition
   azure_rm_registrationdefinition:
@@ -56,7 +56,7 @@
 - name: Assert creating registration definition
   ansible.builtin.assert:
     that:
-      - output1.changed
+      - output1 is changed
 
 - name: Create a RegistrationDefinition (idempotent)
   azure_rm_registrationdefinition:
@@ -73,7 +73,7 @@
 - name: Assert creating registration definition
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the RegistrationDefinition properties description and name
   azure_rm_registrationdefinition:
@@ -90,7 +90,7 @@
 - name: Assert creating registration definition
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the Registration Definition info
   azure_rm_registrationdefinition_info:
@@ -126,7 +126,7 @@
 - name: Assert delete registration definition success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the registration definition
   azure_rm_registrationdefinition:

--- a/tests/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_resource/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Assert that something has changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Call REST API
   azure_rm_resource:
@@ -35,7 +35,7 @@
 
 - name: Assert that nothing has changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Call REST API
   azure_rm_resource:
@@ -54,7 +54,7 @@
 
 - name: Assert that something has changed
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Try to get information about account
   azure_rm_resource_info:
@@ -68,7 +68,7 @@
 - name: Assert value was returned
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.response[0]['name'] != None
       - output.response | length == 1
 
@@ -82,7 +82,7 @@
 - name: Assert value was returned
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.response[0]['name'] != None
       - output.response | length >= 1
 
@@ -95,7 +95,7 @@
 - name: Assert value was returned
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.response[0]['name'] != None
       - output.response | length >= 1
 
@@ -107,7 +107,7 @@
 - name: Assert value was returned
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.response | length >= 1
 
 - name: Create storage account that requires LRO polling

--- a/tests/integration/targets/azure_rm_resourcegroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_resourcegroup/tasks/main.yml
@@ -40,7 +40,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete resource group
   azure_rm_resourcegroup:
@@ -52,4 +52,4 @@
 - name: Assert the resource group deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_roleassignment/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_roleassignment/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: Check intended failures
   ansible.builtin.assert:
     that:
-      - item.failed
+      - item is failed
   loop: "{{ failures_info.results }}"
 
 - name: Intentional failures mutable
@@ -90,7 +90,7 @@
 - name: Check intended failures
   ansible.builtin.assert:
     that:
-      - item.failed
+      - item is failed
   loop: "{{ failures_mutable.results }} "
 
 - name: Get resource group info
@@ -123,8 +123,8 @@
 - name: Check idempotence
   ansible.builtin.assert:
     that:
-      - az_role_assignment_name_idempotent.changed == False
-      - az_role_assignment_scope_idempotent.changed == False
+      - az_role_assignment_name_idempotent is not changed
+      - az_role_assignment_scope_idempotent is not changed
 #
 # - name: List Role Assignments by Name
 #   azure_rm_roleassignment_info:
@@ -164,7 +164,7 @@
     id: "{{ az_role_assignment_create.id }}"
     state: absent
   register: az_role_assignment_delete
-  when: az_role_assignment_create.changed
+  when: az_role_assignment_create is changed
 
 - name: Create role assignment with name
   azure_rm_roleassignment:
@@ -198,7 +198,7 @@
     role_definition_id: "/subscriptions/{{ az_resource_group.resourcegroups[0].id.split('/')[2] }}/providers/Microsoft.Authorization/roleDefinitions/{{ az_role_definition_guid }}"
     state: absent
   register: az_role_assignment_delete
-  # when: az_role_assignment_create.changed
+  # when: az_role_assignment_create is changed
   ignore_errors: true
 
 - name: Absent assignment that doesn't exist - id
@@ -228,7 +228,7 @@
 # - name: Check intended failures info
 #   ansible.builtin.assert:
 #     that:
-#       - item.changed == false
+#       - item is not changed
 #   loop:
 #     - "{{ absent_nochange_properties }}"
 #     - "{{ absent_nochange_id }}"

--- a/tests/integration/targets/azure_rm_roledefinition/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_roledefinition/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Assert creating role definition check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a role definition
   azure_rm_roledefinition:
@@ -48,7 +48,7 @@
 - name: Assert creating role definition
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 
 ## because of the bug of azure service , the following tasks will cause failures randomly
@@ -101,7 +101,7 @@
 # - name: ansible.builtin.assert output not changed
 #  ansible.builtin.assert:
 #    that:
-#      - not output.changed
+#      - output is not changed
 #
 # - name: Update the role definition
 #  azure_rm_roledefinition:
@@ -125,7 +125,7 @@
 # - name: ansible.builtin.assert output changed
 #  ansible.builtin.assert:
 #    that:
-#      - output.changed
+#      - output is changed
 #
 # - name: Get role definition facts
 #  azure_rm_roledefinition_info:
@@ -154,7 +154,7 @@
 # - name: Assert creating role definition check mode
 #  ansible.builtin.assert:
 #    that:
-#      - output.changed
+#      - output is changed
 #
 # - name: Create a role assignment
 #  azure_rm_roleassignment:
@@ -166,7 +166,7 @@
 # - name: Assert creating role assignment
 #  ansible.builtin.assert:
 #    that:
-#      - output.changed
+#      - output is changed
 #
 # - name: Get facts
 #  azure_rm_roleassignment_info:
@@ -197,7 +197,7 @@
 #
 # - name: ansible.builtin.assert deleting role definition check mode
 #  ansible.builtin.assert:
-#    that: output.changed
+#    that: output is changed
 #
 # - name: Delete the role definition
 #  azure_rm_roledefinition:
@@ -208,4 +208,4 @@
 #
 # - ansible.builtin.assert:
 #    that:
-#      - output.changed
+#      - output is changed

--- a/tests/integration/targets/azure_rm_routetable/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_routetable/tasks/main.yml
@@ -17,7 +17,7 @@
   ansible.builtin.assert:
     that:
       - not output.id
-      - output.changed
+      - output is changed
 
 - name: Create a route table
   azure_rm_routetable:
@@ -30,7 +30,7 @@
 - name: Assert the route table created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create a route table (idemponent)
@@ -44,7 +44,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get facts of the table
   azure_rm_routetable_info:
@@ -71,7 +71,7 @@
 - name: Assert check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - not output.id
 
 - name: Create route
@@ -86,7 +86,7 @@
 - name: Assert the route created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
 
 - name: Create route (idemponent)
@@ -101,7 +101,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update route
   azure_rm_route:
@@ -115,7 +115,7 @@
 - name: Assert the route updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get facts of the route
   azure_rm_route_info:
@@ -162,7 +162,7 @@
 - name: Assert the route deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete route (idemponent)
   azure_rm_route:
@@ -175,7 +175,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete route table (check mode)
   azure_rm_routetable:
@@ -194,7 +194,7 @@
 - name: Assert the route table deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete route table (idemponent)
   azure_rm_routetable:
@@ -206,4 +206,4 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -120,7 +120,7 @@
   register: output
 - name: Assert resource not updated
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update tags
   azure_rm_securitygroup:
@@ -225,7 +225,7 @@
   register: output
 - name: Assert resource not updated
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Add a single one group
   azure_rm_securitygroup:
@@ -248,7 +248,7 @@
 - name: Assert resource updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.rules | length == 2
 
 # Use azure_rm_resource module to create with uppercase protocol name
@@ -289,7 +289,7 @@
 - name: Assert resource not updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create Application security group 1
   azure_rm_applicationsecuritygroup:
@@ -328,7 +328,7 @@
 - name: Assert resource retrieved
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create security group with application security group - Idempotent
   azure_rm_securitygroup:
@@ -351,7 +351,7 @@
 - name: Assert resource not updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete security group
   azure_rm_securitygroup:

--- a/tests/integration/targets/azure_rm_servicebus/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_servicebus/tasks/main.yml
@@ -38,7 +38,7 @@
   ansible.builtin.assert:
     that:
       - output.id
-      - output.changed
+      - output is changed
       - output.tags
 
 - name: Create a namespace (idempontent)
@@ -51,7 +51,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update namespace - ManagedIdentity SystemAssigned
   azure_rm_servicebus:
@@ -65,7 +65,7 @@
 - name: Assert SystemAssigned
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.identity.type == "SystemAssigned"
 
 - name: Gather facts
@@ -94,7 +94,7 @@
 - name: Assert UserAssigned
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.identity.type == "UserAssigned"
       - output.identity.user_assigned_identities | length == 1
       - output.identity.user_assigned_identities[managed_identity_ids[0]] is defined
@@ -114,7 +114,7 @@
 - name: Assert UserAssigned
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.identity.type == "UserAssigned"
       - output.identity.user_assigned_identities | length == 2
       - output.identity.user_assigned_identities[managed_identity_ids[0]] is defined
@@ -136,7 +136,7 @@
 - name: Assert UserAssigned
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.identity.type == "UserAssigned"
       - output.identity.user_assigned_identities | length == 1
       - output.identity.user_assigned_identities[managed_identity_ids[2]] is defined
@@ -158,7 +158,7 @@
 - name: Assert the service bus created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update the secondary namespace
   azure_rm_servicebus:
@@ -177,7 +177,7 @@
 - name: Assert the service bus udpated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather the namespace facts
   azure_rm_servicebus_info:
@@ -209,7 +209,7 @@
   ansible.builtin.assert:
     that:
       - queue.id
-      - queue.changed
+      - queue is changed
 
 - name: Create a topic (check mode)
   azure_rm_servicebustopic:
@@ -225,7 +225,7 @@
 - name: Assert the check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a topic
   azure_rm_servicebustopic:
@@ -240,7 +240,7 @@
 - name: Assert the topic created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.id
       - "'subscription_count' not in output"
 
@@ -257,7 +257,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create test policy
   azure_rm_servicebussaspolicy:
@@ -279,7 +279,7 @@
   ansible.builtin.assert:
     that:
       - subs.id
-      - subs.changed
+      - subs is changed
 
 - name: Retrive topic
   azure_rm_servicebus_info:

--- a/tests/integration/targets/azure_rm_snapshot/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_snapshot/tasks/main.yml
@@ -54,7 +54,7 @@
 - name: Assert the snapshot created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a managed disk
   azure_rm_manageddisk:
@@ -77,7 +77,7 @@
 - name: Assert the snapshot idempotent result
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: List the snapshot instance by resource group
   azure_rm_snapshot_info:

--- a/tests/integration/targets/azure_rm_sqlmanageddatabase/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_sqlmanageddatabase/tasks/main.yml
@@ -105,7 +105,7 @@
 - name: Assert the datebase is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new sql managed instance database (Idempotent test)
   azure_rm_sqlmidatabase:
@@ -121,7 +121,7 @@
 - name: Assert the datebase has no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the sql managed instance database tags
   azure_rm_sqlmidatabase:
@@ -137,7 +137,7 @@
 - name: Assert the datebase udpated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the sql managed instance database facts
   azure_rm_sqlmidatabase_info:
@@ -184,7 +184,7 @@
 - name: Assert the sql managed datebase long term retention policy updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get sql managed database long term retention policy by name
   azure_rm_sqlmidblongtermretentionpolicy_info:
@@ -229,7 +229,7 @@
 - name: Assert the sql managed datebase short term retention policy updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the sql managed instance database short term retention policy facts
   azure_rm_sqlmidbshorttermretentionpolicy_info:
@@ -256,7 +256,7 @@
 - name: Assert the sql managed datebase deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete sql managed instance
   azure_rm_sqlmanagedinstance:

--- a/tests/integration/targets/azure_rm_sqlmanagedinstance/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_sqlmanagedinstance/tasks/main.yml
@@ -118,7 +118,7 @@
 - name: Assert the resource instance is not exist
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create sql managed instance
   azure_rm_sqlmanagedinstance:
@@ -147,7 +147,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Wait for sql managed instance provisioning to complete
   azure_rm_sqlmanagedinstance_info:
@@ -184,7 +184,7 @@
 - name: Assert the resource instance no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Upgrade sql managed instance with tags
   azure_rm_sqlmanagedinstance:
@@ -214,7 +214,7 @@
 - name: Assert the resource instance is update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get SQL managed instance by name
   azure_rm_sqlmanagedinstance_info:

--- a/tests/integration/targets/azure_rm_sqlserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_sqlserver/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of SQL Server
   azure_rm_sqlserver:
@@ -55,7 +55,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 
 - name: Gather facts SQL Server
@@ -80,7 +80,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
       - output.state == 'Ready'
 
 - name: Create extended instance of SQL Server
@@ -105,7 +105,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
 
 - name: Gather facts SQL Server
@@ -141,7 +141,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - not output is not changed
       - output.state == 'Ready'
 
 - name: Update SQL admin password
@@ -155,7 +155,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of SQL Server with Azure AD admin
   azure_rm_sqlserver:
@@ -175,7 +175,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state == 'Ready'
   when: run_azuread_tests | bool
 
@@ -197,7 +197,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - not output is not changed
       - output.state == 'Ready'
   when: run_azuread_tests | bool
 
@@ -211,7 +211,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers['sqlsrv' ~ random_postfix ].id != None
       - output.servers['sqlsrv' ~ random_postfix ].name == 'sqlsrv' ~ random_postfix
       - output.servers['sqlsrv' ~ random_postfix ].type != None
@@ -232,7 +232,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers['sqlsrv-extended-' ~ random_postfix ].id != None
       - output.servers['sqlsrv-extended-' ~ random_postfix ].name == 'sqlsrv-extended-' ~ random_postfix
       - output.servers['sqlsrv-extended-' ~ random_postfix ].type != None
@@ -257,7 +257,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers['sqlsrv-azuread-' ~ random_postfix ].id != None
       - output.servers['sqlsrv-azuread-' ~ random_postfix ].name == 'sqlsrv-azuread-' ~ random_postfix
       - output.servers['sqlsrv-azuread-' ~ random_postfix ].type != None
@@ -284,7 +284,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers == {}
 
 - name: Gather facts SQL Server - list
@@ -294,7 +294,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.servers['sqlsrv' ~ random_postfix ].id != None
       - output.servers['sqlsrv' ~ random_postfix ].name == 'sqlsrv' ~ random_postfix
       - output.servers['sqlsrv' ~ random_postfix ].type != None
@@ -317,7 +317,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of SQL Database
   azure_rm_sqldatabase:
@@ -332,7 +332,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.status == 'Online'
 
 - name: Create again instance of SQL Database
@@ -348,7 +348,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
       - output.status == 'Online'
 
 # test database point in time restore
@@ -380,7 +380,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of SQL Database Point in time recovery
   azure_rm_sqldatabase:
@@ -392,7 +392,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 # test database facter:
 - name: Create second SQL Database
@@ -411,7 +411,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0].id != None
       - output.databases[0].name != None
       - output.databases[0].location != None
@@ -429,7 +429,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0].id != None
       - output.databases[0].name != None
       - output.databases[0].location != None
@@ -466,7 +466,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of SQL Database
   azure_rm_sqldatabase:
@@ -478,7 +478,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of SQL Database
   azure_rm_sqldatabase:
@@ -490,7 +490,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 # Test With SKU
 - name: Create SQL Database with sku -- check mode
@@ -507,7 +507,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create SQL Database with sku
   azure_rm_sqldatabase:
@@ -524,7 +524,7 @@
 - name: Assert the resource instance is well created with good SKU
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.status == 'Online'
 
 - name: Gather facts SQL Database with good SKU
@@ -536,7 +536,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0].id != None
       - output.databases[0].name != None
       - output.databases[0].location != None
@@ -561,7 +561,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
       - output.status == 'Online'
 
 - name: Create again instance of SQL Database with New SKU
@@ -579,7 +579,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.status == 'Online'
 
 - name: Gather facts SQL Database with good New SKU
@@ -591,7 +591,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases[0].id != None
       - output.databases[0].name != None
       - output.databases[0].location != None
@@ -611,7 +611,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 # test database facts without databases
 - name: Gather facts SQL Database
@@ -623,7 +623,7 @@
 - name: Assert that empty dictionary was returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases | length == 0
 
 - name: Gather facts SQL Database
@@ -634,7 +634,7 @@
 - name: Assert that empty dictionary was returned (one database is there by default)
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.databases | length == 1
 
 # azure_rm_sqlfirewallrule tests
@@ -651,7 +651,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of Firewall Rule
   azure_rm_sqlfirewallrule:
@@ -664,7 +664,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create again instance of Firewall Rule
   azure_rm_sqlfirewallrule:
@@ -677,7 +677,7 @@
 - name: Assert the state has not changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 #
 # azure_rm_sqlserverfirewallrule_facts
@@ -700,7 +700,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].resource_group != None
       - output.rules[0].server_name != None
@@ -716,7 +716,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules[0].id != None
       - output.rules[0].id != None
       - output.rules[0].resource_group != None
@@ -753,7 +753,7 @@
 - name: Assert that empty dictionary was returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.rules | length == 0
 
 # azure_rm_sqlelasticpool test
@@ -771,7 +771,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of SQL Elastic Pool
   azure_rm_sqlelasticpool:
@@ -786,7 +786,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create instance of SQL Elastic Pool -- Idempotent test
   azure_rm_sqlelasticpool:
@@ -801,7 +801,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - not output is not changed
 
 - name: Update instance of SQL Elastic Pool
   azure_rm_sqlelasticpool:
@@ -816,7 +816,7 @@
 - name: Assert the resource instance is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts SQL Database
   azure_rm_sqlelasticpool_info:
@@ -828,7 +828,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.elastic_pool[0].zone_redundant == false
       - output.elastic_pool[0].tags | length == 2
 
@@ -843,7 +843,7 @@
 - name: Assert the resource instance is deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 # finalise & clean up azure_rm_sqlserver test
 
@@ -857,7 +857,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete instance of SQL Server
   azure_rm_sqlserver:
@@ -868,7 +868,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete unexisting instance of SQL Server
   azure_rm_sqlserver:
@@ -879,7 +879,7 @@
 - name: Assert the state has changed
   ansible.builtin.assert:
     that:
-      - output.changed == false
+      - output is not changed
 
 - name: Delete extended instance of SQL Server
   azure_rm_sqlserver:

--- a/tests/integration/targets/azure_rm_sshpublickey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_sshpublickey/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Assert the SSH Public Key created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a new SSH Public Key (Idempotent test)
   azure_rm_sshpublickey:
@@ -30,7 +30,7 @@
 - name: Assert the SSH Public key no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update SSH Public Key with tags and public key
   azure_rm_sshpublickey:
@@ -44,7 +44,7 @@
 - name: Assert the SSH Public key Updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get ssh public keys by name
   azure_rm_sshpublickey_info:
@@ -67,4 +67,4 @@
 - name: Assert the SSH Public Key deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Check intentional name failure.
   ansible.builtin.assert:
     that:
-      - output.failed
+      - output is failed
       - output.msg is regex('AccountNameInvalid')
 
 - name: Delete storage accounts to prepare fresh deployment
@@ -63,7 +63,7 @@
 - name: Assert status succeeded and results match expectations
   ansible.builtin.assert:
     that:
-      - defaults_output.changed
+      - defaults_output is changed
       - defaults_output.state.name == storage_account_name_default
       - defaults_output.state.id is defined
       - defaults_output.state.https_only
@@ -83,7 +83,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.static_website is defined
       - not output.state.static_website.enabled
       - output.state.static_website.index_document == None
@@ -101,7 +101,7 @@
 - name: Assert not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Enable storage account static website
   azure_rm_storageaccount:
@@ -115,7 +115,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.static_website is defined
       - output.state.static_website.enabled
       - output.state.static_website.index_document == None
@@ -135,7 +135,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.static_website is defined
       - output.state.static_website.enabled
       - output.state.static_website.index_document == 'index.html'
@@ -155,7 +155,7 @@
 - name: Assert not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create new storage account with Hierarchical Namespace enabled
   azure_rm_storageaccount:
@@ -169,7 +169,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.large_file_shares_state == 'Enabled'
 
 - name: Gather facts of storage account
@@ -201,7 +201,7 @@
 - name: Assert the storage account well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create new storage account with immutable_storage_with_versioning(Idempotent test)
   azure_rm_storageaccount:
@@ -220,7 +220,7 @@
 - name: Assert the storage account no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the storage account with immutable_storage_with_versioning
   azure_rm_storageaccount:
@@ -239,7 +239,7 @@
 - name: Assert the storage account well updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather facts of storage account
   azure_rm_storageaccount_info:
@@ -270,7 +270,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.static_website is defined
       - output.state.static_website.enabled
       - output.state.static_website.index_document == "abc.htm"
@@ -295,7 +295,7 @@
 - name: Assert not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update storage account with different identity
   azure_rm_storageaccount:
@@ -341,7 +341,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.identity.type == "SystemAssigned"
 
 - name: Disable storage account static website
@@ -356,7 +356,7 @@
 - name: Assert output
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.static_website is defined
       - not output.state.static_website.enabled
       - output.state.static_website.index_document == None
@@ -372,7 +372,7 @@
 - name: Assert status succeeded and results match I(kind=FileStorage)
   ansible.builtin.assert:
     that:
-      - filestorage_output.changed
+      - filestorage_output is changed
       - filestorage_output.state.sku_name == "Premium_ZRS"
 
 - name: Create new storage account with explicit parameters
@@ -413,7 +413,7 @@
 - name: Assert status succeeded and correct parameter results
   ansible.builtin.assert:
     that:
-      - explicit_output.changed
+      - explicit_output is changed
       - explicit_output.state.id is defined
       - explicit_output.state.blob_cors | length == 1
       - not explicit_output.state.https_only
@@ -461,7 +461,7 @@
 - name: Assert that properties have not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.state.access_tier == explicit_output.state.access_tier
       - output.state.allow_blob_public_access == explicit_output.state.allow_blob_public_access
       - output.state.blob_cors == explicit_output.state.blob_cors
@@ -488,7 +488,7 @@
 - name: Assert that properties have not changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.state.access_tier == explicit_output.state.access_tier
       - output.state.allow_blob_public_access == explicit_output.state.allow_blob_public_access
       - output.state.blob_cors == explicit_output.state.blob_cors
@@ -542,7 +542,7 @@
 - name: Assert account change success
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.allow_blob_public_access == False
       - output.state.allow_blob_public_access != None
       - output.state.https_only == False
@@ -564,7 +564,7 @@
 - name: Assert account type change failed
   ansible.builtin.assert:
     that:
-      - output.failed
+      - output is failed
       - output.msg is regex('Storage account of type .* cannot be changed')
 
 - name: Unverified custom domain failure
@@ -579,7 +579,7 @@
 - name: Assert CNAME failure
   ansible.builtin.assert:
     that:
-      - output.failed
+      - output is failed
       - output.msg is regex('custom domain name could not be verified')
 
 - name: Create storage account with no public access
@@ -595,7 +595,7 @@
 - name: Assert desired account config
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.https_only
       - output.state.minimum_tls_version == 'TLS1_2'
       - not output.state.allow_blob_public_access
@@ -614,7 +614,7 @@
 - name: Assert no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Gather facts by tags
   azure_rm_storageaccount_info:
@@ -711,7 +711,7 @@
 - name: Assert storage account with (require_infrastructure_encryption=false) created
   ansible.builtin.assert:
     that:
-      - encryption_output.changed
+      - encryption_output is changed
 
 - name: Get account with (require_infrastructure_encryption=false)
   azure_rm_storageaccount_info:
@@ -741,7 +741,7 @@
 - name: Assert storage account is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a storage account with allow_shared_key_access(Idempotent test)
   azure_rm_storageaccount:
@@ -757,7 +757,7 @@
 - name: Assert storage account no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the storage account
   azure_rm_storageaccount:
@@ -773,7 +773,7 @@
 - name: Assert storage account is well updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the storage accounts facts
   azure_rm_storageaccount_info:

--- a/tests/integration/targets/azure_rm_storageaccountmanagementpolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccountmanagementpolicy/tasks/main.yml
@@ -108,7 +108,7 @@
 - name: Assert the Managed policy created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create storage account management policy rule(Idempotent test)
   azure_rm_storageaccountmanagementpolicy:
@@ -160,7 +160,7 @@
 - name: Assert the Managed policy no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create storage account management policy rule(Updating test)
   azure_rm_storageaccountmanagementpolicy:
@@ -212,7 +212,7 @@
 - name: Assert the Managed policy updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get storage account management policy
   azure_rm_storageaccountmanagementpolicy_info:
@@ -239,4 +239,4 @@
 - name: Assert the Managed policy deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_storageblob/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageblob/tasks/main.yml
@@ -63,7 +63,7 @@
   register: upload_facts
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: "not upload_facts.changed"
+    that: upload_facts is not changed
 
 - name: Download file idempotence
   azure_rm_storageblob:
@@ -75,7 +75,7 @@
   register: download_results
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not download_results.changed
+    that: download_results is not changed
 
 - name: Delete file
   ansible.builtin.file:
@@ -92,7 +92,7 @@
   register: download_results
 - name: Assert download file
   ansible.builtin.assert:
-    that: "download_results.changed"
+    that: download_results is not changed
 
 - name: Find file
   ansible.builtin.find:
@@ -131,7 +131,7 @@
 
 - name: Assert the blob created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Update the blob with I(standard_blob_tier=Cool)
   azure_rm_storageblob:
@@ -146,7 +146,7 @@
 
 - name: Assert the blob updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get the blob facts
   azure_rm_storageblob_info:
@@ -171,7 +171,7 @@
   register: output
 - name: Assert no blobs
   ansible.builtin.assert:
-    that: "not output.changed"
+    that: output is not changed
 
 - name: Delete blob object
   azure_rm_storageblob:
@@ -183,7 +183,7 @@
   register: output
 - name: Assert the blob deleted
   ansible.builtin.assert:
-    that: "output.changed"
+    that: output is changed
 
 - name: Delete container
   azure_rm_storageblob:
@@ -194,7 +194,7 @@
   register: output
 - name: Assert delete the container
   ansible.builtin.assert:
-    that: "output.changed"
+    that: output is changed
 
 - name: Delete storage account
   azure_rm_storageaccount:
@@ -213,7 +213,7 @@
 
 - name: Assert the blob deleted
   ansible.builtin.assert:
-    that: "output.changed"
+    that: output is changed
 
 - name: Delete container
   azure_rm_storageblob:
@@ -225,7 +225,7 @@
 
 - name: Assert delete the container
   ansible.builtin.assert:
-    that: "output.changed"
+    that: output is changed
 
 - name: Delete storage account
   azure_rm_storageaccount:

--- a/tests/integration/targets/azure_rm_storageshare/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageshare/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Assert create success
   ansible.builtin.assert:
     that:
-      - create_result.changed
+      - create_result is changed
       - create_result.state.name == share_name
       - create_result.state.share_quota == quota
       - create_result.state.metadata.source == metadata.source
@@ -49,7 +49,7 @@
 
 - name: Assert idempotence
   ansible.builtin.assert:
-    that: not create_result.changed
+    that: create_result is not changed
 
 - name: Get share details
   azure_rm_storageshare_info:
@@ -61,7 +61,7 @@
 - name: Assert storage share details
   ansible.builtin.assert:
     that:
-      - not share_facts.changed
+      - share_facts is not changed
       - share_facts.storageshares.name == share_name
       - share_facts.storageshares.share_quota == quota
       - share_facts.storageshares.metadata.source == metadata.source
@@ -86,7 +86,7 @@
 
 - name: Assert share update success
   ansible.builtin.assert:
-    that: update_result.changed
+    that: update_result is changed
 
 - name: Get updated details
   azure_rm_storageshare_info:

--- a/tests/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Assert created fail
   ansible.builtin.assert:
-    that: output.failed
+    that: output is failed
 
 - name: Add the subnet back
   azure_rm_subnet:
@@ -50,7 +50,7 @@
 - name: Assert the subnet created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.address_prefix == "10.1.0.0/24"
 
 - name: Add the subnet back (idempontent)
@@ -62,7 +62,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Create network security group
   azure_rm_securitygroup:
@@ -99,7 +99,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Able to completely remove service endpoints
   azure_rm_subnet:
@@ -135,7 +135,7 @@
 - name: Assert the subnet update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.network_security_group.id == nsg.state.id
 
 - name: Update the subnet (idempotent)
@@ -150,7 +150,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Create subnet with IPv4 and IPv6
   azure_rm_subnet:
@@ -165,7 +165,7 @@
 - name: Assert the subnet created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - not output.state.address_prefix
       - output.state.address_prefixes | length > 0
 
@@ -181,7 +181,7 @@
 
 - name: Assert the subnet updated
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update the subnet's IPv4 and IPv6 address
   azure_rm_subnet:
@@ -197,7 +197,7 @@
 - name: Assert the subnet update
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update the subnet with network policies
   azure_rm_subnet:
@@ -210,7 +210,7 @@
 
 - name: Assert the subnet updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: The subnet with network policies should be idempotent
   azure_rm_subnet:
@@ -223,7 +223,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update the subnet with delegations
   azure_rm_subnet:
@@ -237,7 +237,7 @@
 
 - name: Assert the subnet updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: The subnet with delegations should be idempotent
   azure_rm_subnet:
@@ -251,7 +251,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Get subnet facts
   azure_rm_subnet_info:
@@ -263,7 +263,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.subnets[0]['id'] != None
       - output.subnets[0]['resource_group'] != None
       - output.subnets[0]['virtual_network_name'] != None
@@ -286,7 +286,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
       - output.subnets[0]['id'] != None
       - output.subnets[0]['resource_group'] != None
       - output.subnets[0]['virtual_network_name'] != None
@@ -313,7 +313,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Remove subnet
   azure_rm_subnet:

--- a/tests/integration/targets/azure_rm_tags/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_tags/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Assert the tags created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create new tags with scope(Idempotent test)
   azure_rm_tags:
@@ -30,7 +30,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the tags with scope
   azure_rm_tags:
@@ -43,7 +43,7 @@
 - name: Assert the tags updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the tag info at thespecified resource
   azure_rm_tags_info:
@@ -65,4 +65,4 @@
 - name: Assert the tag deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_trafficmanagerprofile/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_trafficmanagerprofile/tasks/main.yml
@@ -60,7 +60,7 @@
 - name: Assert the Traffic Manager profile is well created
   ansible.builtin.assert:
     that:
-      - tm.changed
+      - tm is changed
 
 - name: Gather Traffic Manager profile facts
   azure_rm_trafficmanagerprofile_info:
@@ -98,7 +98,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the Traffic Manager profile
   azure_rm_trafficmanagerprofile:
@@ -123,7 +123,7 @@
 - name: Assert the Traffic Manager profile is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create the Seconday Traffic Manager profile
   azure_rm_trafficmanagerprofile:
@@ -151,7 +151,7 @@
 - name: Assert the Traffic Manager profile is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update the Seconday Traffic Manager profile
   azure_rm_trafficmanagerprofile:
@@ -183,7 +183,7 @@
 - name: Assert the Traffic Manager profile is well updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Gather Seconday Traffic Manager profile facts
   azure_rm_trafficmanagerprofile_info:
@@ -215,7 +215,7 @@
 - name: Assert check mode changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get endpoint
   azure_rm_trafficmanagerendpoint_info:
@@ -243,7 +243,7 @@
 - name: Assert endpoint create changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get endpoint
   azure_rm_trafficmanagerendpoint_info:
@@ -294,7 +294,7 @@
 - name: Assert endpoint creation idempotent
   ansible.builtin.assert:
     that:
-      - output.changed == False
+      - output is not changed
 
 - name: Delete second endpoint
   azure_rm_trafficmanagerendpoint:
@@ -308,7 +308,7 @@
 - name: Assert endpoint deletion changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get endpoint
   azure_rm_trafficmanagerendpoint_info:
@@ -351,7 +351,7 @@
 - name: Assert the Traffic Manager profile is well deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get Traffic Manager profile fact
   azure_rm_trafficmanagerprofile_info:

--- a/tests/integration/targets/azure_rm_virtualhub/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualhub/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Assert the virtual hub is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.provisioning_state == 'Succeeded'
 
 - name: Create a VirtualHub (idempotent)
@@ -32,7 +32,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get Virtual Hub Info
   azure_rm_virtualhub_info:
@@ -73,7 +73,7 @@
 - name: Assert the virtual hub is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.state.provisioning_state == 'Succeeded'
 
 - name: Delete Second VirtualHub
@@ -92,4 +92,4 @@
 - name: Assert the AKS instance is upgraded
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_virtualhubconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualhubconnection/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: Assert the virtual hub connection is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create virtual hub connection (idempotent test)
   azure_rm_virtualhubconnection:
@@ -102,7 +102,7 @@
 - name: Assert the virtual hub connection no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update virtual hub connection
   azure_rm_virtualhubconnection:
@@ -138,7 +138,7 @@
 - name: Assert the virtual hub connection no changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get virtual hub connection info
   azure_rm_virtualhubconnection_info:

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_ephemeral_os.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_ephemeral_os.yml
@@ -51,7 +51,7 @@
 - name: Assert the VM created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create virtual machine ephmeral OS disk
   azure_rm_virtualmachine:
@@ -73,7 +73,7 @@
 - name: Assert the vm created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ansible_facts.azure_vm.properties.storageProfile.osDisk.diffDiskSettings.option == 'Local'
 
 - name: Check virtual machine ephmeral OS disk idempotent
@@ -96,7 +96,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Check virtual machine ephmeral OS disk can't update
   azure_rm_virtualmachine:
@@ -117,7 +117,7 @@
 - name: Assert the vm updated
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Delete VM
   azure_rm_virtualmachine:

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_minimal_manageddisk.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_minimal_manageddisk.yml
@@ -51,7 +51,7 @@
 - name: Assert status succeeded
   ansible.builtin.assert:
     that:
-      - vm_output.changed
+      - vm_output is changed
 
 - name: Delete VM
   azure_rm_virtualmachine:

--- a/tests/integration/targets/azure_rm_virtualmachineextension/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachineextension/tasks/main.yml
@@ -93,7 +93,7 @@
   register: results
 - name: Assert that VM Extension ran
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Query extension
   azure_rm_virtualmachineextension_info:
@@ -104,7 +104,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - results.changed == False
+      - results is not changed
       - results.extensions[0]['id'] != None
       - results.extensions[0]['resource_group'] != None
       - results.extensions[0]['virtual_machine_name'] != None
@@ -129,7 +129,7 @@
   register: results
 - name: Assert no updates
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Create VM Extension (force update)
   azure_rm_virtualmachineextension:
@@ -145,7 +145,7 @@
   register: results
 - name: Assert updates
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: List extensions
   azure_rm_virtualmachineextension_info:
@@ -155,7 +155,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - results.changed == False
+      - results is not changed
       - results.extensions[0]['id'] != None
       - results.extensions[0]['resource_group'] != None
       - results.extensions[0]['virtual_machine_name'] != None
@@ -176,7 +176,7 @@
   register: results
 - name: Assert that VM Extension deleted
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete VM Extension (idempotent)
   azure_rm_virtualmachineextension:
@@ -187,7 +187,7 @@
   register: results
 - name: Assert no changes
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Create VM Extension to configure python required for VM diagnostic extension
   azure_rm_virtualmachineextension:
@@ -202,7 +202,7 @@
   register: results
 - name: Assert that VM Extension ran
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Install VM Extension for diagnostics
   azure_rm_virtualmachineextension:
@@ -218,7 +218,7 @@
   register: results
 - name: Assert extension installed
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Install VM Extension for diagnostics (idempotent)
   azure_rm_virtualmachineextension:
@@ -234,7 +234,7 @@
   register: results
 - name: Assert no updates
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: List extensions
   azure_rm_virtualmachineextension_info:
@@ -244,7 +244,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - results.changed == False
+      - results is not changed
       - results.extensions | length >= 2
       - "'python-install' in results.extensions | map(attribute='name')"
       - "'linux-diagnostics' in results.extensions | map(attribute='name')"

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -190,7 +190,7 @@
 
 - name: Assert that VMSS can be created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create VMSS with I(orchestration_mode=Flexible) again --- Idempotent
   azure_rm_virtualmachinescaleset:
@@ -233,7 +233,7 @@
 
 - name: Assert that VMSS can be created
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Retrieve scaleset VMSS fact
   azure_rm_virtualmachinescaleset_info:
@@ -388,7 +388,7 @@
 
 - name: Assert that VMSS can be created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Get VMSS to ansible.builtin.assert no VMSS is created in check mode
   azure_rm_virtualmachinescaleset_info:
@@ -438,7 +438,7 @@
 
 - name: Assert that VMSS was created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create VMSS -- test upgrade_policy idempotence and load balancer
   azure_rm_virtualmachinescaleset:
@@ -475,7 +475,7 @@
 
 - name: Assert that VMSS was created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Retrieve scaleset facts
   azure_rm_virtualmachinescaleset_info:
@@ -538,7 +538,7 @@
 
 - name: Assert that nothing was changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Install VMSS Extension
   azure_rm_virtualmachinescalesetextension:
@@ -554,7 +554,7 @@
 
 - name: Assert that something was changed
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Install Again VMSS Extension - again
   azure_rm_virtualmachinescalesetextension:
@@ -570,7 +570,7 @@
 
 - name: Assert that nothing was changed
   ansible.builtin.assert:
-    that: not results.changed
+    that: results is not changed
 
 - name: Query extension
   azure_rm_virtualmachinescalesetextension_info:
@@ -582,7 +582,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - results.changed == False
+      - results is not changed
       - results.extensions[0]['id'] != None
       - results.extensions[0]['resource_group'] != None
       - results.extensions[0]['vmss_name'] != None
@@ -602,7 +602,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - results.changed == False
+      - results is not changed
       - results.extensions[0]['id'] != None
       - results.extensions[0]['resource_group'] != None
       - results.extensions[0]['vmss_name'] != None
@@ -623,7 +623,7 @@
 
 - name: Assert that change was reported
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Upgrade instance to the latest image
   azure_rm_virtualmachinescalesetinstance:
@@ -635,7 +635,7 @@
 
 - name: Assert that something has changed
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Stop virtual machine
   azure_rm_virtualmachinescalesetinstance:
@@ -647,7 +647,7 @@
 
 - name: Assert that something has changed
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete instance
   azure_rm_virtualmachinescalesetinstance:
@@ -659,7 +659,7 @@
 
 - name: Assert that something has changed
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete VMSS
   azure_rm_virtualmachinescaleset:
@@ -693,7 +693,7 @@
 
 - name: Assert that VMSS can be created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Create VMSS with security group in same resource group, with accelerated networking.
   azure_rm_virtualmachinescaleset:
@@ -721,7 +721,7 @@
 - name: Assert that VMSS ran
   ansible.builtin.assert:
     that:
-      - 'results.changed'
+      - 'results is changed'
       - 'results.ansible_facts.azure_vmss.virtual_machine_profile.network_profile.network_interface_configurations[0].enable_accelerated_networking == true'
       - 'results.ansible_facts.azure_vmss.virtual_machine_profile.network_profile.network_interface_configurations[0].network_security_group != {}'
 
@@ -751,7 +751,7 @@
 - name: Assert that nothing has changed
   ansible.builtin.assert:
     that:
-      - not results.changed
+      - results is not changed
 
 - name: Create VMSS with security group in same resource group, with accelerated networking.
   azure_rm_virtualmachinescaleset:
@@ -779,7 +779,7 @@
 - name: Assert that something has changed
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
 
 - name: Update VMSS with security group in different resource group.
   azure_rm_virtualmachinescaleset:
@@ -809,7 +809,7 @@
 # - name: Assert that security group is correct
 #  ansible.builtin.assert:
 #    that:
-#      - 'results.changed'
+#      - 'results is changed'
 #      - '"testNetworkSecurityGroup2" in results.ansible_facts.azure_vmss.properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations.0.properties.networkSecurityGroup.id'
 
 - name: Delete VMSS
@@ -846,7 +846,7 @@
 - name: Assert vmss created
   ansible.builtin.assert:
     that:
-      - results.changed
+      - results is changed
       - results.ansible_facts.azure_vmss.virtual_machine_profile.storage_profile.os_disk.diff_disk_settings.option == 'Local'
 
 - name: Check VMSS ephmeral OS disk can't udpate
@@ -948,7 +948,7 @@
 
 - name: Assert that VMSS can be created
   ansible.builtin.assert:
-    that: results.changed
+    that: results is changed
 
 - name: Delete VMSS
   azure_rm_virtualmachinescaleset:

--- a/tests/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
@@ -111,7 +111,7 @@
 
 - name: Assert the virtual network idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update tags
   azure_rm_virtualnetwork:
@@ -152,7 +152,7 @@
 
 - name: Assert the virtual network updated
   ansible.builtin.assert:
-    that: output.failed
+    that: output is failed
 
 - name: Purge address prefixes
   azure_rm_virtualnetwork:

--- a/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Assert the virtual network gateway check mode
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create virtual network gateway Generation2 (check mode)
   check_mode: true
@@ -41,7 +41,7 @@
 
 - name: Assert the virtual network gateway check mode
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Long-running virtualnetworkgateway tests
   block:
@@ -137,7 +137,7 @@
 
     - name: Assert the idempotent
       ansible.builtin.assert:
-        that: not output.changed
+        that: output is not changed
 
     - name: Update virtual network gateway
       azure_rm_virtualnetworkgateway:
@@ -154,7 +154,7 @@
 
     - name: Assert the virtual network gateway updated
       ansible.builtin.assert:
-        that: output.changed
+        that: output is changed
 
     - name: List the virtual network gateway and filter by tags
       azure_rm_virtualnetworkgateway_info:
@@ -198,7 +198,7 @@
 
 - name: Assert the virtual network gateway deleted
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 # Clean up networking components after test
 - name: Delete subnet

--- a/tests/integration/targets/azure_rm_virtualnetworkgatewayconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgatewayconnection/tasks/main.yml
@@ -121,7 +121,7 @@
 - name: Assert the first resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a 'IPsec' type virtual network connection
   azure_rm_virtualnetworkgatewayconnection:
@@ -143,7 +143,7 @@
 - name: Assert the secondary resource created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Re-create the virtual network connection(Idempotent test)
   azure_rm_virtualnetworkgatewayconnection:
@@ -165,7 +165,7 @@
 - name: Assert the resource no change
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the virtual network connection(Update test)
   azure_rm_virtualnetworkgatewayconnection:
@@ -189,7 +189,7 @@
 - name: Assert the resource updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the virtual network connection
   azure_rm_virtualnetworkgatewayconnection_info:
@@ -220,7 +220,7 @@
 - name: Assert the resource deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the virtual network gateway
   azure_rm_virtualnetworkgateway:

--- a/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/tasks/main.yml
@@ -66,7 +66,7 @@
 - name: Assert the virtual network nat rule is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a virtual netowrk nat rule(Idempotent test)
   azure_rm_virtualnetworkgatewaynatrule:
@@ -84,7 +84,7 @@
 - name: Assert the virtual network nat rule no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Create a new virtual netowrk nat rule (Update test)
   azure_rm_virtualnetworkgatewaynatrule:
@@ -102,7 +102,7 @@
 - name: Assert the virtual network nat rule is well Updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the virtual netowrk nat rule facts
   azure_rm_virtualnetworkgatewaynatrule_info:
@@ -129,7 +129,7 @@
 - name: Assert the virtual network nat rule deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Pause for 5 mimutes to delete the virtual network gateway
   ansible.builtin.command: sleep 300

--- a/tests/integration/targets/azure_rm_virtualnetworkpeering/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkpeering/tasks/main.yml
@@ -26,8 +26,8 @@
 - name: Assert the second virtual network created
   ansible.builtin.assert:
     that:
-      - vnet1.changed
-      - vnet2.changed
+      - vnet1 is changed
+      - vnet2 is changed
 
 - name: Create virtual network peering (check mode)
   azure_rm_virtualnetworkpeering:
@@ -44,7 +44,7 @@
 
 - name: Assert the virtual network peering check mode
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create virtual network peering
   azure_rm_virtualnetworkpeering:
@@ -60,7 +60,7 @@
 
 - name: Assert the virtual network peering created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Update virtual network peering (idempotent)
   azure_rm_virtualnetworkpeering:
@@ -76,7 +76,7 @@
 
 - name: Assert the virtual network peering idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update virtual network peering
   azure_rm_virtualnetworkpeering:
@@ -92,7 +92,7 @@
 
 - name: Assert the virtual network peering updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get facts
   azure_rm_virtualnetworkpeering_info:

--- a/tests/integration/targets/azure_rm_virtualwan/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualwan/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Assert the virtual wan created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a VirtualWan again (Idempotent test)
   azure_rm_virtualwan:
@@ -28,7 +28,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the VirtualWan
   azure_rm_virtualwan:
@@ -44,7 +44,7 @@
 - name: Assert the virtual wan updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get VirtualWan info
   azure_rm_virtualwan_info:

--- a/tests/integration/targets/azure_rm_vmbackuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_vmbackuppolicy/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create VM Backup Policy (idempotent)
   azure_rm_vmbackuppolicy:
@@ -36,7 +36,7 @@
 - name: Assert that output has no changed
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get VM Backup Policy Details
   azure_rm_vmbackuppolicy_info:
@@ -62,7 +62,7 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete Azure Recovery Service vault
   azure_rm_recoveryservicesvault:
@@ -75,4 +75,4 @@
 - name: Assert that output has changed
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed

--- a/tests/integration/targets/azure_rm_vpnsite/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_vpnsite/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Assert the vpn site created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create the VpnSite without change (Idempotent test)
   azure_rm_vpnsite:
@@ -56,7 +56,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update the VpnSite's device properties
   azure_rm_vpnsite:
@@ -84,7 +84,7 @@
 - name: Assert the vpn site updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get the VpnSite info
   azure_rm_vpnsite_info:

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: Assert output changed
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Get the web app
   azure_rm_webapp_info:
@@ -114,7 +114,7 @@
 
 - name: Assert web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get web app with name
   azure_rm_webapp_info:
@@ -147,7 +147,7 @@
 - name: Assert the web app was updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get web app with name
   azure_rm_webapp_info:
@@ -186,7 +186,7 @@
 
 - name: Assert the web app was updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a win web app with python run time and php run time
   azure_rm_webapp:
@@ -204,7 +204,7 @@
 
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a docker web app with some app settings
   azure_rm_webapp:
@@ -223,7 +223,7 @@
 
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a docker web app with private acr registry
   azure_rm_webapp:
@@ -242,7 +242,7 @@
 
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a linux web app with nodejs framework
   azure_rm_webapp:
@@ -272,7 +272,7 @@
 
 - name: Assert idempotent
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Update nodejs framework
   azure_rm_webapp:
@@ -289,7 +289,7 @@
 
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a linux web app with deployment source github
   azure_rm_webapp:
@@ -307,7 +307,7 @@
 
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Assert error that java is mutually exclusive with frameworks
   azure_rm_webapp:
@@ -356,7 +356,7 @@
 
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get facts with publish profile
   azure_rm_webapp_info:
@@ -394,7 +394,7 @@
   register: output
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a web app with various site config params - idempotent
   azure_rm_webapp:
@@ -420,7 +420,7 @@
   register: output
 - name: Assert the web app not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Get facts for site config params
   azure_rm_webapp_info:
@@ -459,7 +459,7 @@
   register: output
 - name: Assert the web app was updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get facts for site config params
   azure_rm_webapp_info:
@@ -499,7 +499,7 @@
   register: output
 - name: Assert the web app was created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Create a web app with HTTP 2.0 - idempotent
   azure_rm_webapp:
@@ -526,7 +526,7 @@
   register: output
 - name: Assert the web app not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Get facts for HTTP 2.0 appp
   azure_rm_webapp_info:
@@ -566,7 +566,7 @@
   register: output
 - name: Assert the web app was updated
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: Get facts for HTTP 2.0 appp
   azure_rm_webapp_info:
@@ -605,7 +605,7 @@
 - name: Assert the web app is well created
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Update the web app with site_auth_settings
   azure_rm_webapp:
@@ -631,7 +631,7 @@
 - name: Assert the web app is well updated
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Get the web app facts
   azure_rm_webapp_info:
@@ -668,7 +668,7 @@
 - name: Assert the web app is well updated
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Get the web app facts
   azure_rm_webapp_info:
@@ -701,7 +701,7 @@
 - name: Assert the web app is well updated
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Get the web app facts
   azure_rm_webapp_info:
@@ -735,7 +735,7 @@
 - name: Assert the web app is not updated
   ansible.builtin.assert:
     that:
-      not output.changed
+      output is not changed
 
 - name: Get the web app facts
   azure_rm_webapp_info:
@@ -766,7 +766,7 @@
 - name: Assert the web app is well updated
   ansible.builtin.assert:
     that:
-      output.changed
+      output is changed
 
 - name: Get the web app facts
   azure_rm_webapp_info:
@@ -795,7 +795,7 @@
 - name: Assert slot check mode creation
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Create a webapp slot
   azure_rm_webappslot:
@@ -811,7 +811,7 @@
 - name: Assert slot creation
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Update webapp slot (idempotence)
   azure_rm_webappslot:
@@ -826,7 +826,7 @@
 - name: Assert idempotence
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Update webapp slot
   azure_rm_webappslot:
@@ -844,7 +844,7 @@
 - name: Assert updating
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Swap webapp slot
   azure_rm_webappslot:
@@ -859,7 +859,7 @@
 - name: Assert swap
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Stop webapp slot
   azure_rm_webappslot:
@@ -873,7 +873,7 @@
 - name: Assert stopped
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Delete the webapp resource
   azure_rm_webapp:

--- a/tests/integration/targets/azure_rm_webappaccessrestriction/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webappaccessrestriction/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Assert the resource is well created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: "Create webapp access restriction"
   azure_rm_webappaccessrestriction:
@@ -78,7 +78,7 @@
 - name: Assert the resource is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 3
       - output.ip_security_restrictions[0].action == 'Allow'
       - output.ip_security_restrictions[0].ip_address == '1.1.1.1/24'
@@ -97,7 +97,7 @@
 - name: Assert restrictions
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.ip_security_restrictions | length == 3
       - output.ip_security_restrictions[0].action == 'Allow'
       - output.ip_security_restrictions[0].ip_address == '1.1.1.1/24'
@@ -132,7 +132,7 @@
 
 - name: Assert the resource is not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: "Delete specific webapp access restriction"
   azure_rm_webappaccessrestriction:
@@ -148,7 +148,7 @@
 - name: Assert the resource is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 1
       - output.ip_security_restrictions[0].action == 'Allow'
       - output.ip_security_restrictions[0].ip_address == '1.1.1.1/24'
@@ -168,7 +168,7 @@
 - name: Assert the resource is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 1
       - output.ip_security_restrictions[0].action == 'Deny'
       - output.ip_security_restrictions[0].ip_address == '1.2.3.4/24'
@@ -188,7 +188,7 @@
 - name: Assert the resource is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 1
       - output.ip_security_restrictions[0].action == 'Deny'
       - output.ip_security_restrictions[0].ip_address == '1.2.3.4/24'
@@ -213,7 +213,7 @@
 - name: Assert the resource is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 1
       - output.ip_security_restrictions[0].action == 'Deny'
       - output.ip_security_restrictions[0].ip_address == '1.2.3.4/24'
@@ -245,7 +245,7 @@
 - name: Assert the resource is updated
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 1
       - output.ip_security_restrictions[0].action == 'Deny'
       - output.ip_security_restrictions[0].ip_address == '1.2.3.4/24'
@@ -278,7 +278,7 @@
   register: output
 - name: Assert the resource is not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: "Delete webapp access restrictions"
   azure_rm_webappaccessrestriction:
@@ -289,7 +289,7 @@
 - name: Assert the resource is deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.ip_security_restrictions | length == 0
       - output.scm_ip_security_restrictions | length == 0
       - output.scm_ip_security_restrictions_use_main == false
@@ -302,7 +302,7 @@
 - name: Assert no restrictions
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.ip_security_restrictions | length <= 1
       - output.scm_ip_security_restrictions | length <= 1
       - output.scm_ip_security_restrictions_use_main == false

--- a/tests/integration/targets/azure_rm_webappvnetconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webappvnetconnection/tasks/main.yml
@@ -43,7 +43,7 @@
   register: output
 - name: Assert the resource is well created
   ansible.builtin.assert:
-    that: output.changed
+    that: output is changed
 
 - name: "Check webapp vnetconnection facts 1"
   azure_rm_webappvnetconnection_info:
@@ -53,7 +53,7 @@
 - name: Assert the resource has no connections
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.connection | length == 0
 
 - name: "Create webapp vnetconnection"
@@ -66,7 +66,7 @@
 - name: Assert the resource is well created
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.connection.vnet_name == 'vnet{{ rpfx }}'
       - output.connection.subnet_name == 'subnet{{ rpfx }}'
       - output.connection.vnet_resource_group == '{{ resource_group_datalake }}'
@@ -79,7 +79,7 @@
 - name: Assert the connection exists
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.connection.vnet_name == 'vnet{{ rpfx }}'
       - output.connection.subnet_name == 'subnet{{ rpfx }}'
       - output.connection.vnet_resource_group == '{{ resource_group_datalake }}'
@@ -93,7 +93,7 @@
   register: output
 - name: Assert the resource is not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: "Delete webapp vnetconnection"
   azure_rm_webappvnetconnection:
@@ -104,7 +104,7 @@
 - name: Assert the connection is deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
       - output.connection | length == 0
 
 - name: "Check webapp vnetconnection facts 3"
@@ -115,7 +115,7 @@
 - name: Assert the resource has no connections
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
       - output.connection | length == 0
 
 - name: "Delete webapp vnetconnection - idempotent"
@@ -126,7 +126,7 @@
   register: output
 - name: Assert the resource is not changed
   ansible.builtin.assert:
-    that: not output.changed
+    that: output is not changed
 
 - name: Delete the web app
   azure_rm_webapp:

--- a/tests/integration/targets/azure_rm_workspace/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_workspace/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Assert the workspace check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get workspace
   azure_rm_loganalyticsworkspace_info:
@@ -37,7 +37,7 @@
   ansible.builtin.assert:
     that:
       - output.retention_in_days == 40
-      - output.changed
+      - output is changed
       - output.intelligence_packs
 
 - name: Create workspace (idempontent)
@@ -50,7 +50,7 @@
 - name: Assert idempotent
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed
 
 - name: Get workspace
   azure_rm_loganalyticsworkspace_info:
@@ -91,7 +91,7 @@
 - name: Assert the loganalytics workspace check mode
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get workspace
   azure_rm_loganalyticsworkspace_info:
@@ -114,7 +114,7 @@
 - name: Assert the loganalytics workspace deleted
   ansible.builtin.assert:
     that:
-      - output.changed
+      - output is changed
 
 - name: Get workspace
   azure_rm_loganalyticsworkspace_info:
@@ -137,4 +137,4 @@
 - name: Assert the loganalystics workspace deleted
   ansible.builtin.assert:
     that:
-      - not output.changed
+      - output is not changed


### PR DESCRIPTION
##### SUMMARY
Fix tests for ansible-2.19 checks.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

    Ansible 2.19 is more strict about checks.  Let's standardize on
    the ansible.builtin.changed and ansible.builtin.failed modules for
    checking each condition.
    
    https://docs.ansible.com/ansible/latest/collections/ansible/builtin/changed_test.html
    https://docs.ansible.com/ansible/latest/collections/ansible/builtin/failed_test.html