### PR TITLE
Fix ansible-lint check error

### DIFF
--- a/tests/integration/targets/azure_rm_mariadbserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mariadbserver/tasks/main.yml
@@ -280,7 +280,7 @@
 - name: Assert that facts are returned
   ansible.builtin.assert:
     that:
-      - output is not changed 
+      - output is not changed
       - output.databases[0]['server_name'] != None
       - output.databases[0]['name'] != None
       - output.databases[0]['charset'] != None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix ansible-lint check error, Remove the space key in the azure_rm_mariadbserver.py test case
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration/targets/azure_rm_mariadbserver/tasks/main.yml

