### PR TITLE
Add a filtering mechanism to obtain loganalystics under the resource group

### DIFF
--- a/tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml
@@ -597,6 +597,8 @@
 - name: List the Log Analytics workspace under specific resource group
   azure_rm_loganalyticsworkspace_info:
     resource_group: "{{ resource_group }}"
+    tags:
+      - key2
   register: facts
 
 - name: Assert only one log analytics workspace


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When obtaining loganalystics under the resource group, tag filtering is used to avoid failures caused by creation at other locations.

test/integration/targets/azure_rm_aks/tasks/minimal-cluster.yml

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml


