### PR TITLE
Update the web app service plan SKU

### DIFF
--- a/tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appserviceplan/tasks/main.yml
@@ -27,7 +27,7 @@
   azure_rm_appserviceplan:
     resource_group: "{{ linux_plan_resource_group }}"
     name: "{{ linux_plan_name }}1"
-    sku: S1
+    sku: B1
     is_linux: true
     number_of_workers: 1
   register: output
@@ -54,7 +54,7 @@
   azure_rm_appserviceplan:
     resource_group: "{{ linux_plan_resource_group }}"
     name: "{{ linux_plan_name }}1"
-    sku: S1
+    sku: B1
     is_linux: true
     number_of_workers: 1
   register: output
@@ -79,7 +79,7 @@
   azure_rm_appserviceplan:
     resource_group: "{{ linux_plan_resource_group }}"
     name: "{{ linux_plan_name }}1"
-    sku: S1
+    sku: B1
     is_linux: true
     number_of_workers: 2
   register: output

--- a/tests/integration/targets/azure_rm_functionapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_functionapp/tasks/main.yml
@@ -255,7 +255,7 @@
     resource_group: "{{ resource_group_third }}"
     name: "{{ plan_name }}"
     location: "{{ location }}"
-    sku: S1
+    sku: B1
     is_linux: true
     number_of_workers: 1
 

--- a/tests/integration/targets/azure_rm_monitordiagnosticsetting/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_monitordiagnosticsetting/tasks/main.yml
@@ -20,7 +20,7 @@
       name: "webapp-{{ rpfx }}-plan"
       resource_group: "{{ resource_group }}"
       is_linux: false
-      sku: S1
+      sku: B1
   register: webapp_output
 
 - name: Create storage account

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -41,7 +41,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}"
       is_linux: false
-      sku: S1
+      sku: B1
 
 - name: Create a windows web app with existing app service plan
   azure_rm_webapp:
@@ -215,7 +215,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_plan_name }}"
       is_linux: true
-      sku: S1
+      sku: B1
       number_of_workers: 1
     container_settings:
       name: "ansible/ansible:ubuntu1404"
@@ -379,7 +379,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_app_name }}-siteconfig-plan"
       is_linux: true
-      sku: S1
+      sku: B1
     frameworks:
       - name: java
         version: "8"
@@ -405,7 +405,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_app_name }}-siteconfig-plan"
       is_linux: true
-      sku: S1
+      sku: B1
     frameworks:
       - name: java
         version: "8"
@@ -444,7 +444,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_app_name }}-siteconfig-plan"
       is_linux: true
-      sku: S1
+      sku: B1
     frameworks:
       - name: java
         version: "8"
@@ -483,7 +483,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_app_name }}-http20-plan"
       is_linux: true
-      sku: S1
+      sku: B1
     frameworks:
       - name: java
         version: "8"
@@ -510,7 +510,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_app_name }}-http20-plan"
       is_linux: true
-      sku: S1
+      sku: B1
     frameworks:
       - name: java
         version: "8"
@@ -550,7 +550,7 @@
       resource_group: "{{ linux_app_plan_resource_group }}"
       name: "{{ linux_app_name }}-http20-plan"
       is_linux: true
-      sku: S1
+      sku: B1
     frameworks:
       - name: java
         version: "8"
@@ -589,7 +589,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}-auth"
       is_linux: false
-      sku: S1
+      sku: B1
     site_auth_settings:
       client_id: "{{ azure_client_id }}"
       default_provider: 'MicrosoftAccount'
@@ -615,7 +615,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}-auth"
       is_linux: false
-      sku: S1
+      sku: B1
     site_auth_settings:
       client_id: "{{ azure_client_id }}"
       default_provider: 'MicrosoftAccount'
@@ -657,7 +657,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}-identity"
       is_linux: false
-      sku: S1
+      sku: B1
     identity:
       type: UserAssigned
       user_assigned_identities:
@@ -690,7 +690,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}-identity"
       is_linux: false
-      sku: S1
+      sku: B1
     identity:
       type: "SystemAssigned, UserAssigned"
       user_assigned_identities:
@@ -724,7 +724,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}-identity"
       is_linux: false
-      sku: S1
+      sku: B1
     identity:
       type: "SystemAssigned, UserAssigned"
       user_assigned_identities:
@@ -758,7 +758,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: "{{ win_plan_name }}-identity"
       is_linux: false
-      sku: S1
+      sku: B1
     identity:
       type: "SystemAssigned"
   register: output
@@ -779,6 +779,14 @@
     that:
       - output.webapps[0].identity.type == 'SystemAssigned'
       - '"user_assigned_identities" not in output.webapps[0].identity'
+
+- name: Update app service plan I(sku=P0v3)
+  azure_rm_appserviceplan:
+    resource_group: "{{ linux_app_plan_resource_group }}"
+    name: "{{ linux_plan_name }}"
+    sku: P0v3
+    is_linux: false
+    number_of_workers: 1
 
 - name: Create a webapp slot (Check mode)
   azure_rm_webappslot:

--- a/tests/integration/targets/azure_rm_webappaccessrestriction/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webappaccessrestriction/tasks/main.yml
@@ -25,7 +25,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: webappplan{{ rpfx }}
       is_linux: false
-      sku: S1
+      sku: B1
 
 - name: "Create webapp access restriction - check mode"
   azure_rm_webappaccessrestriction:

--- a/tests/integration/targets/azure_rm_webappvnetconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webappvnetconnection/tasks/main.yml
@@ -31,7 +31,7 @@
       resource_group: "{{ resource_group_datalake }}"
       name: webappplan{{ rpfx }}
       is_linux: false
-      sku: S1
+      sku: B1
 
 - name: "Create webapp vnetconnection - check mode"
   azure_rm_webappvnetconnection:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the web app service plan SKU， S1 is an old version and does not support creation now. Therefore, B1 is used instead.
When creating a webapp slot, the app service plan needs to be higher than B3. Add and upgrade the app service plan sku to P0v3
<img width="652" height="332" alt="image" src="https://github.com/user-attachments/assets/c52da14e-7144-4ddd-871b-7cbcb4d8f7e8" />


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 azure_rm_appserviceplan/tasks/main.yml
 azure_rm_functionapp/tasks/main.yml
 azure_rm_monitordiagnosticsetting/tasks/main.yml
 azure_rm_webapp/tasks/main.yml
 azure_rm_webappaccessrestriction/tasks/main.yml
 azure_rm_webappvnetconnection/tasks/main.yml


```
