### PR TITLE
Azure servicebus - add async functionality

### DIFF
--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -1,55 +1,83 @@
 import asyncio
-from typing import Any
-from unittest.mock import MagicMock, patch
+from typing import Any, Dict, Optional, Type
+from unittest.mock import patch
 
 import pytest
 
-from extensions.eda.plugins.event_source.azure_service_bus import main as azure_main
+from extensions.eda.plugins.event_source.azure_service_bus import receive_events
 
 
-class MockQueue(asyncio.Queue[Any]):
-    def __init__(self) -> None:
-        self.queue: list[Any] = []
+class MockMsg:
+    def __init__(self, message_id: int, body: str) -> None:
+        self.message_id = message_id
+        self._body = body
 
-    def put_nowait(self, item: Any) -> None:
-        self.queue.append(item)
-
-
-@pytest.fixture
-def myqueue() -> MockQueue:
-    return MockQueue()
+    def __str__(self) -> str:
+        return self._body
 
 
-def test_receive_from_azure_service_bus(myqueue: MockQueue) -> None:
-    client = MagicMock()
+@pytest.mark.asyncio
+async def test_receive_events() -> None:
+    msg1 = MockMsg(1, "Hello World")
+    msg2 = MockMsg(2, '{"Say": "Hello World"}')
+
+    class AsyncMsgIter:
+        def __init__(self, msgs: list[MockMsg]) -> None:
+            self._msgs = msgs
+            self._idx = 0
+
+        def __aiter__(self) -> "AsyncMsgIter":
+            return self
+
+        async def __anext__(self) -> MockMsg:
+            if self._idx < len(self._msgs):
+                msg = self._msgs[self._idx]
+                self._idx += 1
+                return msg
+            raise StopAsyncIteration
+
+    class MockReceiver:
+        async def __aenter__(self) -> "MockReceiver":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Any,
+        ) -> None:
+            pass
+
+        def __aiter__(self) -> AsyncMsgIter:
+            return AsyncMsgIter([msg1, msg2])
+
+        async def complete_message(self, msg: MockMsg) -> None:
+            pass
+
+    class MockServiceBusClient:
+        async def __aenter__(self) -> "MockServiceBusClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Any,
+        ) -> None:
+            pass
+
+        def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
+            return MockReceiver()
+
     with patch(
-        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient."
-        "from_connection_string",
-        return_value=client,
+        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient.from_connection_string",
+        return_value=MockServiceBusClient(),
     ):
-        payload1 = MagicMock()
-        payload1.message_id = 1
-        payload1.__str__.return_value = "Hello World"  # type: ignore[attr-defined]
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        args: Dict[str, Any] = {"conn_str": "fake", "queue_name": "queue"}
+        await receive_events(queue, args)
 
-        payload2 = MagicMock()
-        payload2.message_id = 2
-        payload2.__str__.return_value = '{"Say":"Hello World"}'  # type: ignore[attr-defined]
-
-        receiver = MagicMock()
-        receiver.__iter__.return_value = [payload1, payload2]
-        client.get_queue_receiver.return_value = receiver
-        asyncio.run(
-            azure_main(
-                myqueue,
-                {
-                    "conn_str": "Endpoint=sb://foo.servicebus.windows.net/",
-                    "queue_name": "eda-queue",
-                },
-            )
-        )
-        assert myqueue.queue[0] == {"body": "Hello World", "meta": {"message_id": 1}}
-        assert myqueue.queue[1] == {
-            "body": {"Say": "Hello World"},
-            "meta": {"message_id": 2},
-        }
-        assert len(myqueue.queue) == 2
+        result1 = await queue.get()
+        result2 = await queue.get()
+        assert result1 == {"body": "Hello World", "meta": {"message_id": 1}}
+        assert result2 == {"body": {"Say": "Hello World"}, "meta": {"message_id": 2}}


### PR DESCRIPTION
Forwarding https://github.com/ansible/event-driven-ansible/pull/451 to the version of the `azure_service_bus.py` EDA source in this collection; quoting from that PR:
> This PR is to fix the issue https://github.com/ansible/event-driven-ansible/issues/401 , in which the async functionality was not working as expected. I've rewritten this module to leverage the Azure Service Bus async functionality.
> 
> In my testing, this resolves the QueueFull message that was being received when a large number of events needed to be processed.