### PR TITLE
Handle the azure_rm_virtualwan.py deletion of LROPollery results

### DIFF
--- a/plugins/modules/azure_rm_virtualwan.py
+++ b/plugins/modules/azure_rm_virtualwan.py
@@ -388,6 +388,8 @@ class AzureRMVirtualWan(AzureRMModuleBaseExt):
         try:
             response = self.network_client.virtual_wans.begin_delete(resource_group_name=self.resource_group,
                                                                      virtual_wan_name=self.name)
+            if isinstance(response, LROPoller):
+                self.get_poller_result(response)
         except Exception as e:
             self.log('Error attempting to delete the VirtualWan instance.')
             self.fail('Error deleting the VirtualWan instance: {0}'.format(str(e)))


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After executing the deletion of virtual hub, wait for the result proccessing of LROPoller to complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualwan.py
