### PR TITLE
Disable CDN profile test

### DIFF
--- a/tests/integration/targets/azure_rm_cdnprofile/aliases
+++ b/tests/integration/targets/azure_rm_cdnprofile/aliases
@@ -4,3 +4,4 @@ destructive
 azure_rm_cdnprofile_info
 azure_rm_cdnendpoint
 needs/file/tests/integration_common_tasks/managed_identity.yml
+disabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Disable CDN profile test. Starting 15 August 2025, no new domain onboarding or profile creation will be allowed for Azure Front Door classic,
The CDN of Azure Front Door type is included in the following test：
- tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
- tests/integration/targets/azure_rm_afdorigin/tasks/main.yml
- tests/integration/targets/azure_rm_afdorigngroup/tasks/main.yml
- tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
- tests/integration/targets/azure_rm_afdruels/tasks/main.yml
- tests/integration/targets/azure_rm_afdroute/tasks/main.yml
