### PR TITLE
Fix compare error where the returned ID is in uppercase

### DIFF
--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -593,7 +593,7 @@ def compare_rules_change(old_list, new_list, purge_list):
 
 def compare_rules(old_rule, rule):
     def compare_list_rule(old_rule, rule, key):
-        return set(map(str, rule.get(key) or [])) != set(map(str, old_rule.get(key) or []))
+        return set(map(lambda x: str(x).lower(), rule.get(key) or [])) != set(map(lambda x: str(x).lower(), old_rule.get(key) or []))
     changed = False
     if old_rule['name'].lower() != rule['name'].lower():
         changed = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix compare error where the returned ID is in uppercase.
pipeline erorr: https://dev.azure.com/azclitools/internal/_build/results?buildId=268620&view=logs&j=74643a41-85da-5afc-0d1e-5e3c1770b297&t=469d1757-8389-5c48-bd4e-7213ae177b56
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_securitygroup.py
