### PR TITLE
Add SKU type for azure_rm_virtualnetworkgateway

### DIFF
--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -104,7 +104,7 @@ options:
     sku:
         description:
             - The reference of the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
-        default: VpnGw1AZ
+        default: VpnGw1
         type: str
         choices:
             - VpnGw1

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -278,7 +278,11 @@ class AzureRMVirtualNetworkGateway(AzureRMModuleBase):
             vpn_type=dict(type='str', default='route_based', choices=['route_based', 'policy_based']),
             vpn_gateway_generation=dict(type='str', default='Generation1', choices=['None', 'Generation1', 'Generation2']),
             enable_bgp=dict(type='bool', default=False),
-            sku=dict(type='str', default='VpnGw1AZ', choices=['VpnGw1', 'VpnGw2', 'VpnGw3', 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ', 'VpnGw4AZ', 'VpnGw5AZ', 'Standard', 'Basic', 'HighPerformance']),
+            sku=dict(type='str', default='VpnGw1', choices=[
+                'VpnGw1', 'VpnGw2', 'VpnGw3', 'Standard', 'Basic', 'HighPerformance',
+                'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ', 'VpnGw4AZ', 'VpnGw5AZ',
+                'ErGw1AZ', 'ErGw2AZ', 'ErGw3AZ', 'ErGwScale'
+            ]),
             bgp_settings=dict(type='dict', options=bgp_spec),
             virtual_network=dict(type='raw', aliases=['virtual_network_name'])
         )

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -104,12 +104,17 @@ options:
     sku:
         description:
             - The reference of the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
-        default: VpnGw1
+        default: VpnGw1AZ
         type: str
         choices:
             - VpnGw1
             - VpnGw2
             - VpnGw3
+            - VpnGw1AZ
+            - VpnGw2AZ
+            - VpnGw3AZ
+            - VpnGw4AZ
+            - VpnGw5AZ
             - Standard
             - Basic
             - HighPerformance
@@ -273,7 +278,7 @@ class AzureRMVirtualNetworkGateway(AzureRMModuleBase):
             vpn_type=dict(type='str', default='route_based', choices=['route_based', 'policy_based']),
             vpn_gateway_generation=dict(type='str', default='Generation1', choices=['None', 'Generation1', 'Generation2']),
             enable_bgp=dict(type='bool', default=False),
-            sku=dict(type='str', default='VpnGw1', choices=['VpnGw1', 'VpnGw2', 'VpnGw3', 'Standard', 'Basic', 'HighPerformance']),
+            sku=dict(type='str', default='VpnGw1AZ', choices=['VpnGw1', 'VpnGw2', 'VpnGw3', 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ', 'VpnGw4AZ', 'VpnGw5AZ', 'Standard', 'Basic', 'HighPerformance']),
             bgp_settings=dict(type='dict', options=bgp_spec),
             virtual_network=dict(type='raw', aliases=['virtual_network_name'])
         )

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -110,14 +110,18 @@ options:
             - VpnGw1
             - VpnGw2
             - VpnGw3
+            - Standard
+            - Basic
+            - HighPerformance
             - VpnGw1AZ
             - VpnGw2AZ
             - VpnGw3AZ
             - VpnGw4AZ
             - VpnGw5AZ
-            - Standard
-            - Basic
-            - HighPerformance
+            - ErGw1AZ
+            - ErGw2AZ
+            - ErGw3AZ
+            - ErGwScale
     vpn_gateway_generation:
         description:
             - The generation for this VirtualNetworkGateway. Must be C(None) if C(gateway_type) is not VPN.


### PR DESCRIPTION
##### SUMMARY
Add support for more gateway SKUs.

I couldn’t find an existing issue related to this.  
I did find an older PR with a similar fix: https://github.com/ansible-collections/azure/pull/67  

I’m not sure whether the default value should be updated, since the old SKUs are still working at the moment, even though Microsoft’s documentation suggests otherwise. 

Tested locally with a copy of the collection and confirmed it works.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure.azcollection.azure_rm_virtualnetworkgateway

##### ADDITIONAL INFORMATION
https://learn.microsoft.com/en-us/azure/vpn-gateway/gateway-sku-consolidation


```paste below

```
