### PR TITLE
Fix exception handling in azure_rm_arcssh

### DIFF
--- a/plugins/action/azure_rm_arcssh.py
+++ b/plugins/action/azure_rm_arcssh.py
@@ -10,6 +10,7 @@ import os
 from ansible.errors import AnsibleActionFail
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
+from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError
 from ansible_collections.azure.azcollection.plugins.plugin_utils import (file_utils, ssh_info, connectivity_utils)
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
@@ -101,6 +102,12 @@ class ActionModule(ActionBase):
                                         azure_auth.subscription_id,
                                         azure_auth._cloud_environment.endpoints.resource_manager,
                                         credential_scopes=[azure_auth._cloud_environment.endpoints.resource_manager + ".default"])
+        # Define error_map with common http error codes
+        rest_client.error_map = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+        }
 
         config_session = ssh_info.ConfigSession(ssh_config_file,
                                                 ssh_relay_file,

--- a/plugins/action/azure_rm_arcssh.py
+++ b/plugins/action/azure_rm_arcssh.py
@@ -10,11 +10,14 @@ import os
 from ansible.errors import AnsibleActionFail
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
-from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError
 from ansible_collections.azure.azcollection.plugins.plugin_utils import (file_utils, ssh_info, connectivity_utils)
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AZURE_COMMON_ARGS
+try:
+    from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError
+except ImportError:
+    pass
 
 
 display = Display()

--- a/plugins/module_utils/azure_rm_common_rest.py
+++ b/plugins/module_utils/azure_rm_common_rest.py
@@ -54,6 +54,9 @@ class GenericRestClient(object):
         self._client = PipelineClient(base_url, config=self._config)
         self.models = None
 
+        # Support http errors by status code
+        self.error_map = {}
+
     def query(self, url, method, query_parameters, header_parameters, body, expected_status_codes, polling_timeout, polling_interval):
         # Construct and send request
         operation_config = {}
@@ -83,8 +86,8 @@ class GenericRestClient(object):
         response = self._client.send_request(request, **operation_config)
 
         if response.status_code not in expected_status_codes:
-            exp = SendRequestException(response.text(), response.status_code)
-            raise exp
+            return self.on_error(response)
+
         elif response.status_code == 202 and polling_timeout > 0:
             def get_long_running_output(response):
                 return response
@@ -102,6 +105,15 @@ class GenericRestClient(object):
             return poller.result()
         except Exception as exc:
             raise
+
+    def on_error(self, response):
+        """ handle errors in response
+        """
+        # raise common http errors
+        error_type = self.error_map.get(response.status_code)
+        if error_type:
+            raise error_type(response=response)
+        raise SendRequestException(response.text(), response.status_code)
 
 
 class SendRequestException(Exception):


### PR DESCRIPTION
When setting up the ARC proxy on Azure we need to check if the relay endpoint exists.  If it doesn't exist we rely on ResourceNotFoundError exception to know that we need to create one.

This adds an error_map where you can optionally raise specific exceptions based on http status codes while still supporting the exisiting code.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
