### PR TITLE
Update meta/extensions.yml to include eda path

### DIFF
--- a/meta/extensions.yml
+++ b/meta/extensions.yml
@@ -1,0 +1,3 @@
+extensions:
+  - args:
+      ext_dir: eda/plugins/event_source


### PR DESCRIPTION
##### SUMMARY
In order for automation hub to show the eda plugins from this repository the meta/extenasions.yml path needs to be updated.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meta/extensions.yml

##### ADDITIONAL INFORMATION
Currently https://console.redhat.com/ansible/automation-hub/repo/published/azure/azcollection/docs/ does not show the eda plugin.  This minor update will allow it to know about the eda plugin.