### PR TITLE
Add support for public_ip_prefix in azure_rm_publicipaddress

### DIFF
--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -57,6 +57,16 @@ options:
             - Name of the Public IP.
         type: str
         required: true
+    public_ip_prefix:
+        description:
+            - The Public IP Prefix this Public IP Address should be allocated from.
+            - Once set, it cannot be updated.
+        type: dict
+        suboptions:
+            id:
+                description:
+                    - The Public IP Prefix ID.
+                type: str
     state:
         description:
             - Assert the state of the Public IP. Use C(present) to create or update a and C(absent) to delete.
@@ -214,6 +224,12 @@ state:
              returned: always
              type: str
              sample: ipv4
+        public_ip_prefix:
+            description:
+                - The Public IP Prefix this Public IP Address should be allocated from.
+            type: dict
+            returned: when-used
+            sample: {id: "/subscriptions/xxx-xxx/resourceGroups/testRG/providers/Microsoft.Network/publicIPPrefixes/prefix01}
         sku:
             description:
                 - The public IP address SKU.
@@ -268,7 +284,8 @@ def pip_to_dict(pip):
         provisioning_state=pip.provisioning_state,
         etag=pip.etag,
         sku=pip.sku.name,
-        zones=pip.zones
+        zones=pip.zones,
+        public_ip_prefix=None
     )
     if pip.dns_settings:
         result['dns_settings']['domain_name_label'] = pip.dns_settings.domain_name_label
@@ -276,6 +293,9 @@ def pip_to_dict(pip):
         result['dns_settings']['reverse_fqdn'] = pip.dns_settings.reverse_fqdn
     if pip.ip_tags:
         result['ip_tags'] = [dict(type=to_native(x.ip_tag_type), value=to_native(x.tag)) for x in pip.ip_tags]
+    if pip.public_ip_prefix:
+        result['public_ip_prefix'] = dict(id=pip.public_ip_prefix.id)
+
     return result
 
 
@@ -301,6 +321,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
             sku=dict(type='str', choices=['Standard', 'standard']),
             ip_tags=dict(type='list', elements='dict', options=ip_tag_spec),
             idle_timeout=dict(type='int'),
+            public_ip_prefix=dict(type='dict',options=dict(id=dict(type='str'))),
             zones=dict(type='list', elements='str', choices=['1', '2', '3'])
         )
 
@@ -317,6 +338,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
         self.version = None
         self.ip_tags = None
         self.idle_timeout = None
+        self.public_ip_prefix = None
 
         self.results = dict(
             changed=False,
@@ -420,6 +442,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
                     pip = self.network_models.PublicIPAddress(
                         location=self.location,
                         public_ip_address_version=self.version,
+                        public_ip_prefix=self.public_ip_prefix,
                         public_ip_allocation_method=self.allocation_method,
                         sku=self.network_models.PublicIPAddressSku(name=self.sku) if self.sku else None,
                         idle_timeout_in_minutes=self.idle_timeout if self.idle_timeout and self.idle_timeout > 0 else None,
@@ -441,6 +464,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
                         public_ip_allocation_method=results['public_ip_allocation_method'],
                         sku=self.network_models.PublicIPAddressSku(name=self.sku) if self.sku else None,
                         tags=results['tags'],
+                        public_ip_prefix=self.public_ip_prefix,
                         zones=results['zones']
                     )
                     if self.domain_name or self.reverse_fqdn:

--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -229,7 +229,7 @@ state:
                 - The Public IP Prefix this Public IP Address should be allocated from.
             type: dict
             returned: when-used
-            sample: {id: "/subscriptions/xxx-xxx/resourceGroups/testRG/providers/Microsoft.Network/publicIPPrefixes/prefix01}
+            sample: {"id": "/subscriptions/xxx-xxx/resourceGroups/testRG/providers/Microsoft.Network/publicIPPrefixes/prefix01"}
         sku:
             description:
                 - The public IP address SKU.
@@ -321,7 +321,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
             sku=dict(type='str', choices=['Standard', 'standard']),
             ip_tags=dict(type='list', elements='dict', options=ip_tag_spec),
             idle_timeout=dict(type='int'),
-            public_ip_prefix=dict(type='dict',options=dict(id=dict(type='str'))),
+            public_ip_prefix=dict(type='dict', options=dict(id=dict(type='str'))),
             zones=dict(type='list', elements='str', choices=['1', '2', '3'])
         )
 

--- a/plugins/modules/azure_rm_publicipaddress_info.py
+++ b/plugins/modules/azure_rm_publicipaddress_info.py
@@ -176,7 +176,7 @@ publicipaddresses:
                 - The Public IP Prefix this Public IP Address should be allocated from.
             type: dict
             returned: when-used
-            sample: {id: "/subscriptions/xxx-xxx/resourceGroups/testRG/providers/Microsoft.Network/publicIPPrefixes/prefix01}
+            sample: {"id": "/subscriptions/xxx-xxx/resourceGroups/testRG/providers/Microsoft.Network/publicIPPrefixes/prefix01"}
         etag:
             description:
                 - A unique read-only string that changes whenever the resource is updated.

--- a/plugins/modules/azure_rm_publicipaddress_info.py
+++ b/plugins/modules/azure_rm_publicipaddress_info.py
@@ -171,6 +171,12 @@ publicipaddresses:
             returned: always
             type: str
             sample: Succeeded
+        public_ip_prefix:
+            description:
+                - The Public IP Prefix this Public IP Address should be allocated from.
+            type: dict
+            returned: when-used
+            sample: {id: "/subscriptions/xxx-xxx/resourceGroups/testRG/providers/Microsoft.Network/publicIPPrefixes/prefix01}
         etag:
             description:
                 - A unique read-only string that changes whenever the resource is updated.
@@ -278,7 +284,8 @@ class AzureRMPublicIPInfo(AzureRMModuleBase):
             provisioning_state=pip.provisioning_state,
             etag=pip.etag,
             sku=pip.sku.name,
-            zones=pip.zones
+            zones=pip.zones,
+            public_ip_prefix=None
         )
         if pip.dns_settings:
             result['dns_settings']['domain_name_label'] = pip.dns_settings.domain_name_label
@@ -286,6 +293,8 @@ class AzureRMPublicIPInfo(AzureRMModuleBase):
             result['dns_settings']['reverse_fqdn'] = pip.dns_settings.reverse_fqdn
         if pip.ip_tags:
             result['ip_tags'] = [dict(type=x.ip_tag_type, value=x.tag) for x in pip.ip_tags]
+        if pip.public_ip_prefix:
+            result['public_ip_prefix'] = dict(id=pip.public_ip_prefix.id)
         return result
 
     def get_item(self):

--- a/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -44,12 +44,12 @@
       azure.azcollection.azure_rm_publicipaddress_info:
         resource_group: "{{ resource_group }}-publicip"
         name: "pip{{ rpfx }}-first"
-      register: output
+      register: pip_output
 
     - name: Assert the public ip facts
       ansible.builtin.assert:
         that:
-          - output.publicipaddresses[0].public_ip_prefix.id is defined
+          - pip_output.publicipaddresses[0].public_ip_prefix.id is defined
 
     - name: Create public ip
       azure.azcollection.azure_rm_publicipaddress:

--- a/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -16,14 +16,40 @@
         name: "pip{{ rpfx }}"
         state: absent
 
-    - name: Create the first public ip
+    - name: Create public ip prefix
+      azure_rm_publicipprefix:
+        resource_group: "{{ resource_group }}-publicip"
+        name: "prefix{{ rpfx }}"
+        zones:
+          - 1
+        public_ip_address_version: IPV4
+        prefix_length: 29
+        sku:
+          name: Standard
+          tier: Regional
+       register: output
+
+    - name: Create the first public ip with public_ip_prefix
       azure.azcollection.azure_rm_publicipaddress:
         resource_group: "{{ resource_group }}-publicip"
         name: "pip{{ rpfx }}-first"
         allocation_method: Static
+        public_ip_prefix:
+          id: "{{ output.state.id }}"
         sku: Standard
         domain_name: "{{ domain_name }}-first"
       register: output
+
+    - name: Get the first public ip
+      azure_rm_publicipaddress_info:
+        resource_group: "{{ resource_group }}-publicip"
+        name: "pip{{ rpfx }}-first"
+      register: output
+
+    - name: Assert the public ip facts
+      ansible.builtin.assert:
+        that:
+          - output.publicipaddresses[0].public_ip_prefix.id is defined
 
     - name: Create public ip
       azure.azcollection.azure_rm_publicipaddress:
@@ -156,6 +182,12 @@
       azure.azcollection.azure_rm_publicipaddress:
         resource_group: "{{ resource_group }}-publicip"
         name: "pip{{ rpfx }}-first"
+        state: absent
+
+    - name: Remove the public ip prefix
+      azure_rm_publicipprefix:
+        resource_group: "{{ resource_group }}-publicip"
+        name: "prefix{{ rpfx }}"
         state: absent
 
     - name: Remove public ip

--- a/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -17,7 +17,7 @@
         state: absent
 
     - name: Create public ip prefix
-      azure_rm_publicipprefix:
+      azure.azcollection.azure_rm_publicipprefix:
         resource_group: "{{ resource_group }}-publicip"
         name: "prefix{{ rpfx }}"
         zones:
@@ -27,7 +27,7 @@
         sku:
           name: Standard
           tier: Regional
-       register: output
+      register: output
 
     - name: Create the first public ip with public_ip_prefix
       azure.azcollection.azure_rm_publicipaddress:
@@ -41,7 +41,7 @@
       register: output
 
     - name: Get the first public ip
-      azure_rm_publicipaddress_info:
+      azure.azcollection.azure_rm_publicipaddress_info:
         resource_group: "{{ resource_group }}-publicip"
         name: "pip{{ rpfx }}-first"
       register: output
@@ -185,7 +185,7 @@
         state: absent
 
     - name: Remove the public ip prefix
-      azure_rm_publicipprefix:
+      azure.azcollection.azure_rm_publicipprefix:
         resource_group: "{{ resource_group }}-publicip"
         name: "prefix{{ rpfx }}"
         state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for public_ip_prefix in azure_rm_publicipaddress.py, try to fixes #2057 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_publicipaddress.py
azure_rm_publicipaddress_info.py
