### PR TITLE
Add modules for arc machine extensions

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -34,6 +34,8 @@ action_groups:
     - azure.azcollection.azure_rm_applicationsecuritygroup_info
     - azure.azcollection.azure_rm_appserviceplan
     - azure.azcollection.azure_rm_appserviceplan_info
+    - azure.azcollection.azure_rm_arcmachineextensions
+    - azure.azcollection.azure_rm_arcmachineextensions_info
     - azure.azcollection.azure_rm_automationaccount
     - azure.azcollection.azure_rm_automationaccount_info
     - azure.azcollection.azure_rm_automationrunbook

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -140,6 +140,7 @@ AZURE_API_PROFILES = {
         'BatchManagementClient': 'latest',
         'EventGridManagementClient': '2025-02-15',
         'AppConfigurationManagementClient': '2024-05-01'
+        'HybridComputeManagementClient': 'latest',
     },
     '2019-03-01-hybrid': {
         'StorageManagementClient': '2017-10-01',
@@ -284,6 +285,8 @@ try:
     from azure.mgmt.batch import models as BatchManagementModel
     from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
     from azure.mgmt.cdn import CdnManagementClient
+    from azure.mgmt.hybridcompute import HybridComputeManagementClient
+
 except ImportError as exc:
     AZURE_IMPORT_ERROR = traceback.format_exc()
 
@@ -443,6 +446,7 @@ class AzureRMModuleBase(object):
         self._batch_account_client = None
         self._resourcehealth_client = None
         self._cdn_client = None
+        self._hybrid_compute_management_client = None
 
         self.check_mode = self.module.check_mode
         self.api_profile = self.module.params.get('api_profile')
@@ -1533,6 +1537,14 @@ class AzureRMModuleBase(object):
                                                         base_url=self._cloud_environment.endpoints.resource_manager,
                                                         api_version='2024-02-01')
         return self._cdn_client
+
+    @property
+    def hybrid_compute_management_client(self):
+        self.log('Getting hybrid compute management client...')
+        if not self._hybrid_compute_management_client:
+            self._hybrid_compute_management_client = self.get_mgmt_svc_client(HybridComputeManagementClient,
+                                                                              base_url=self._cloud_environment.endpoints.resource_manager)
+        return self._hybrid_compute_management_client
 
 
 class AzureRMAuthException(Exception):

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -139,8 +139,8 @@ AZURE_API_PROFILES = {
         'CdnManagementClient': '2017-04-02',
         'BatchManagementClient': 'latest',
         'EventGridManagementClient': '2025-02-15',
-        'AppConfigurationManagementClient': '2024-05-01'
-        'HybridComputeManagementClient': 'latest',
+        'AppConfigurationManagementClient': '2024-05-01',
+        'HybridComputeManagementClient': 'latest'
     },
     '2019-03-01-hybrid': {
         'StorageManagementClient': '2017-10-01',

--- a/plugins/modules/azure_rm_arcmachineextensions.py
+++ b/plugins/modules/azure_rm_arcmachineextensions.py
@@ -99,7 +99,7 @@ author:
 
 EXAMPLES = '''
 - name: Add a arc machine extension
-  azure.azcollection.azure_rm_arcmachineextensionsextensions:
+  azure.azcollection.azure_rm_arcmachineextensions:
     state: present
     resource_group: resource_group_name
     machine_name: vm_name
@@ -113,7 +113,7 @@ EXAMPLES = '''
       type_handler_version: 1.37.0
 
 - name: Delete a arc machine extension
-  azure.azcollection.azure_rm_arcmachineextensionsextensions:
+  azure.azcollection.azure_rm_arcmachineextensions:
     state: absent
     name: arc_machine_extension_name
     machine_name: vm_name

--- a/plugins/modules/azure_rm_arcmachineextensions.py
+++ b/plugins/modules/azure_rm_arcmachineextensions.py
@@ -1,0 +1,390 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2025 Klaas Demter (@Klaas-)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: azure_rm_arcmachineextensions
+version_added: "3.9.0"
+short_description: Create, update and delete arc machine extensions.
+description:
+    - Create, update and delete arc machine extensions.
+    - >-
+      U(https://learn.microsoft.com/en-us/python/api/azure-mgmt-hybridcompute/azure.mgmt.hybridcompute.operations.machineextensionsoperations?view=azure-python#azure-mgmt-hybridcompute-operations-machineextensionsoperations-begin-create-or-update)
+options:
+    name:
+        description:
+            - The name of the arc machine extension you're creating, updateing or deleting.
+        required: true
+        type: str
+    machine_name:
+        description:
+            - The name of the arc machine.
+        required: true
+        type: str
+    resource_group:
+        description:
+            - The name of the resource group.
+        required: true
+        type: str
+    location:
+        description:
+            - Location of the arc machine extension.
+        required: false
+        type: str
+    properties:
+        description:
+            - Describes Machine Extension Properties.
+            - Required for creation.
+            - >-
+              U(https://learn.microsoft.com/en-us/python/api/azure-mgmt-hybridcompute/azure.mgmt.hybridcompute.models.machineextensionproperties?view=azure-python)
+        type: dict
+        suboptions:
+            force_update_tag:
+                description:
+                    - How the extension handler should be forced to update even if the extension configuration has not changed.
+                type: str
+            publisher:
+                description:
+                    - The name of the extension handler publisher.
+                type: str
+            type:
+                description:
+                    - Specifies the type of the extension.
+                type: str
+            type_handler_version:
+                description:
+                    - Specifies the version of the script handler.
+                type: str
+            enable_automatic_upgrade:
+                description:
+                    - Indicates whether the extension should be automatically upgraded by the platform if there is a newer version available.
+                type: bool
+            auto_upgrade_minor_version:
+                description:
+                    - Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the
+                      extension will not upgrade minor versions unless redeployed, even with this property set to true.
+                    - Does not work U(https://github.com/Azure/azure-rest-api-specs/issues/37591)
+                type: bool
+            settings:
+                description:
+                    - Public settings for the extension.
+                type: dict
+            protected_settings:
+                description:
+                    - Protected settings for the extension.
+                type: dict
+    state:
+        description:
+            - State of the arc machine extension
+            - Use C(present) for creating/updating a arc machine extension.
+            - Use C(absent) for deleting a arc machine extension.
+        default: present
+        type: str
+        choices:
+            - present
+            - absent
+extends_documentation_fragment:
+    - azure.azcollection.azure
+    - azure.azcollection.azure_tags
+
+author:
+    - Klaas Demter (@Klaas-)
+'''
+
+EXAMPLES = '''
+- name: Add a arc machine extension
+  azure.azcollection.azure_rm_arcmachineextensionsextensions:
+    state: present
+    resource_group: resource_group_name
+    machine_name: vm_name
+    name: AzureMonitorLinuxAgent
+    location: germanywestcentral
+    properties:
+      auto_upgrade_minor_version: false
+      enable_automatic_upgrade: true
+      publisher: Microsoft.Azure.Monitor
+      type: AzureMonitorLinuxAgent
+      type_handler_version: 1.37.0
+
+- name: Delete a arc machine extension
+  azure.azcollection.azure_rm_arcmachineextensionsextensions:
+    state: absent
+    name: arc_machine_extension_name
+    machine_name: vm_name
+    resource_group: resource_group_name
+'''
+
+RETURN = '''
+arcmachineextension:
+    description:
+        - Details of the arc machine extension
+        - Is null on state==absent (arc machine extension does not exist or will be deleted)
+        - Assumes you make legal changes in check mode
+    type: dict
+    returned: always
+    sample: {
+        "id": \
+"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/ResourceGroup/providers/Microsoft.HybridCompute/machines/VMName/extensions/AzureMonitorLinuxAgent",
+        "location": "germanywestcentral",
+        "name": "AzureMonitorLinuxAgent",
+        "properties":
+        {
+            "auto_upgrade_minor_version": false,
+            "enable_automatic_upgrade": true,
+            "force_update_tag": null,
+            "instance_view":
+            {
+                "name": "AzureMonitorLinuxAgent",
+                "status":
+                {
+                    "code": "0",
+                    "level": "Information",
+                    "message": "Extension Message: Enable succeeded",
+                },
+                "type": "AzureMonitorLinuxAgent",
+                "type_handler_version": "1.37.0",
+            },
+            "protected_settings": null,
+            "publisher": "Microsoft.Azure.Monitor",
+            "settings": null,
+            "type": "AzureMonitorLinuxAgent",
+            "type_handler_version": "1.37.0",
+        },
+        "system_data":
+        {
+            "created_at": "2025-09-24T13:12:35.754905Z",
+            "created_by": "your_sp",
+            "created_by_type": "Application",
+            "last_modified_at": "2025-09-24T13:12:35.754905Z",
+            "last_modified_by": "your_sp",
+            "last_modified_by_type": "Application",
+        },
+        "tags":
+        {
+            "Tag1": "Value1",
+        },
+        "type": "Microsoft.HybridCompute/machines/extensions",
+    }
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+AZURE_OBJECT_CLASS = 'hybridcomputemachineextensions'
+
+properties_spec = dict(
+    force_update_tag=dict(type='str'),
+    publisher=dict(type='str'),
+    type=dict(type='str'),
+    type_handler_version=dict(type='str'),
+    enable_automatic_upgrade=dict(type='bool'),
+    auto_upgrade_minor_version=dict(type='bool'),
+    settings=dict(type='dict'),
+    protected_settings=dict(type='dict'),
+)
+
+
+class AzureRMarcmachineextensions(AzureRMModuleBaseExt):
+    """Information class for an Azure RM arc machine extensions"""
+
+    def __init__(self):
+        # https://learn.microsoft.com/en-us/python/api/azure-mgmt-hybridcompute/azure.mgmt.hybridcompute.models.machineextension?view=azure-python
+        self.module_arg_spec = dict(
+            name=dict(type='str', required=True),
+            resource_group=dict(type='str', required=True),
+            machine_name=dict(type='str', required=True),
+            location=dict(type='str'),
+            properties=dict(type='dict', options=properties_spec),
+            state=dict(type='str', choices=['present', 'absent'], default='present')
+        )
+
+        self.name = None
+        self.resource_group = None
+        self.machine_name = None
+        self.location = None
+        self.tags = None
+        self.properties = None
+        self.state = None
+        self.log_path = None
+        self.log_mode = None
+
+        self.results = dict(
+            changed=False,
+            arcmachineextension=dict(),
+            diff=dict(
+                before=None,
+                after=None
+            )
+        )
+
+        super(AzureRMarcmachineextensions, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                          supports_check_mode=True,
+                                                          supports_tags=True)
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            if hasattr(self, key):
+                setattr(self, key, kwargs[key])
+
+        # Defaults for variables
+        result = None
+        result_compare = dict(compare=[])
+        before_dict = None
+
+        # Get current arc machine extension if it exists
+        before_dict = self.get_arc_machine_extension()
+
+        # Create dict from input, without None values
+        # https://learn.microsoft.com/en-us/python/api/azure-mgmt-monitor/azure.mgmt.monitor.v2018_03_01.models.arcmachineextensionresource?view=azure-python
+        # tags seperately because of update_tags behavior
+        arc_machine_extension_template = {
+            "location": self.location,
+            "name": self.name,
+            "properties": self.properties
+        }
+        # Filter out all None values
+        arc_machine_extension_input = {key: value for key, value in arc_machine_extension_template.items() if value is not None}
+
+        # Create/Update if state==present
+        if self.state == 'present':
+            if before_dict is None:
+                # arc machine extension does not exist, create
+                # On creation input == what we send to api
+                arc_machine_extension_update = arc_machine_extension_input
+                # Needs to be extended by tags if set
+                if self.tags:
+                    arc_machine_extension_update['tags'] = self.tags
+                # If no location is set default to the location of the resource group
+                if not self.location:
+                    resource_group = self.get_resource_group(self.resource_group)
+                    arc_machine_extension_update['location'] = resource_group.location
+                self.results['changed'] = True
+                if self.check_mode:
+                    # Check mode, skipping actual creation
+                    pass
+                else:
+                    create_response = self.create_or_update(arc_machine_extension_update)
+            else:
+                # arc machine extension already exists, updating it
+                # Dict for update is the union of existing object overwritten by input data
+                arc_machine_extension_update = before_dict | arc_machine_extension_input
+
+                # Enhanced with tags (special behaviour because of append_tags possibility)
+                update_tags, update_tags_content = self.update_tags(before_dict.get('tags'))
+                # Check if we need to update the arc machine extension
+                if update_tags or not self.default_compare({}, arc_machine_extension_update, before_dict, '', result_compare):
+                    arc_machine_extension_update['tags'] = update_tags_content
+                    # Need to create/update the arc machine extension; changed -> True
+                    self.results['changed'] = True
+                    if self.check_mode:
+                        # Check mode, skipping actual creation
+                        pass
+                    else:
+                        create_response = self.create_or_update(arc_machine_extension_update)
+
+            if self.check_mode or not self.results['changed']:
+                # When object was not updated or when running in check mode
+                # assume arc_machine_extension_update is resulting object
+                result = arc_machine_extension_update
+            else:
+                # otherwise take resulting new object from response of create call
+                result = create_response
+
+        # Delete arc machine extension if state is absent and it exists
+        # if it doesn't exist, it's already absent
+        elif self.state == 'absent' and before_dict is not None:
+            self.results['changed'] = True
+            if self.check_mode:
+                # do not delete in check mode
+                pass
+            else:
+                self.delete()
+
+        self.results['diff']['before'] = before_dict
+        self.results['diff']['after'] = result
+        self.results['arcmachineextension'] = result
+
+        return self.results
+
+    def get_arc_machine_extension(self):
+        '''
+        Gets the properties of the specified arc machine extension.
+
+        :return: List of arc machine extensions
+        '''
+        self.log("Checking if arc machine extension {0} on machien {1} in resource group {2} is present".format(self.name,
+                                                                                                                self.machine_name,
+                                                                                                                self.resource_group))
+
+        result = None
+        response = None
+
+        try:
+            response = self.hybrid_compute_management_client.machine_extensions.get(extension_name=self.name,
+                                                                                    machine_name=self.machine_name,
+                                                                                    resource_group_name=self.resource_group)
+        except ResourceNotFoundError as ex:
+            self.log("Could not find arc machine extension {0} on machine {1} in resource group {2}".format(self.name, self.machine_name, self.resource_group))
+        if response:
+            result = self.serialize_obj(response, AZURE_OBJECT_CLASS)
+
+        return result
+
+    def create_or_update(self, arc_machine_extension_update):
+        result = None
+        response = None
+        arc_machine_extensions = self.hybrid_compute_management_client.machine_extensions
+
+        try:
+            response = arc_machine_extensions.begin_create_or_update(resource_group_name=self.resource_group,
+                                                                     machine_name=self.machine_name,
+                                                                     extension_name=self.name,
+                                                                     extension_parameters=arc_machine_extension_update,
+                                                                     logging_enable=False)
+        except Exception as ex:
+            self.fail("Error creating or update arc machine extension {0} on machine {1} in resource group {2}: {3}".format(self.name,
+                                                                                                                            self.machine_name,
+                                                                                                                            self.resource_group,
+                                                                                                                            str(ex)))
+
+        if response:
+            result = self.serialize_obj(self.get_poller_result(response), AZURE_OBJECT_CLASS)
+
+        return result
+
+    def delete(self):
+        response = None
+        try:
+            response = self.hybrid_compute_management_client.machine_extensions.begin_delete(resource_group_name=self.resource_group,
+                                                                                             machine_name=self.machine_name,
+                                                                                             extension_name=self.name)
+        except Exception as ex:
+            self.fail("Error deleting arc machine {0} in resource group {1}: {2}".format(self.name, self.resource_group, str(ex)))
+
+        if response:
+            return self.get_poller_result(response)
+        else:
+            return None
+
+
+def main():
+    """Main execution"""
+    AzureRMarcmachineextensions()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_arcmachineextensions.py
+++ b/plugins/modules/azure_rm_arcmachineextensions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2025 Klaas Demter (@Klaas-)
+# Copyright (c) 2026 Klaas Weyermann (@Klaas-)
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: azure_rm_arcmachineextensions
-version_added: "3.9.0"
+version_added: "3.17.0"
 short_description: Create, update and delete arc machine extensions.
 description:
     - Create, update and delete arc machine extensions.
@@ -94,7 +94,7 @@ extends_documentation_fragment:
     - azure.azcollection.azure_tags
 
 author:
-    - Klaas Demter (@Klaas-)
+    - Klaas Weyermann (@Klaas-)
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/azure_rm_arcmachineextensions_info.py
+++ b/plugins/modules/azure_rm_arcmachineextensions_info.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2025 Klaas Demter (@Klaas-)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: azure_rm_arcmachineextensions_info
+version_added: "3.9.0"
+short_description: Get arc machine extensions
+description:
+    - Get arc machine extensions
+
+options:
+    name:
+        description:
+            - The name of the arc machine extension you're trying to get details about.
+        type: str
+    machine_name:
+        description:
+            - The name of the arc machine
+        required: true
+        type: str
+    resource_group:
+        description:
+            - The name of the resource group in which the arc machine is
+        required: true
+        type: str
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Klaas Demter (@Klaas-)
+'''
+
+EXAMPLES = '''
+- name: Get arc machine extension details
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: extension_name
+    machine_name: arc_machine_name
+    resource_group: resource_group_name
+
+- name: Get all arc machine extensions of specific arc machine
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    machine_name: arc_machine_name
+    resource_group: resource_group_name
+'''
+
+RETURN = '''
+arcmachineextensions:
+    description:
+        - List of arc machine extensions
+        - Can be empty if listing arc machine extensions or arc machine extension does not exist
+    type: list
+    returned: always
+    sample: [
+        {
+            "id": \
+"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/Resource_Group/providers/Microsoft.HybridCompute/machines/VMName/extensions/AzureMonitorLinuxAgent",
+            "location": "germanywestcentral",
+            "name": "AzureMonitorLinuxAgent",
+            "properties": {
+                "auto_upgrade_minor_version": false,
+                "enable_automatic_upgrade": true,
+                "instance_view": {
+                    "name": "AzureMonitorLinuxAgent",
+                    "status": {
+                        "code": "0",
+                        "level": "Information",
+                        "message": "Extension Message: Enable succeeded"
+                    },
+                    "type": "AzureMonitorLinuxAgent",
+                    "type_handler_version": "1.37.0"
+                },
+                "provisioning_state": "Succeeded",
+                "publisher": "Microsoft.Azure.Monitor",
+                "settings": {},
+                "type": "AzureMonitorLinuxAgent",
+                "type_handler_version": "1.37.0"
+            },
+            "tags": {
+                "TagKey": "TagValue"
+            },
+            "type": "Microsoft.HybridCompute/machines/extensions"
+        }
+    ]
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
+
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+AZURE_OBJECT_CLASS = 'hybridcomputemachineextensions'
+
+
+class AzureRMarcmachineextensionsInfo(AzureRMModuleBase):
+    """Information class for an Azure RM arc machine extensions"""
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            name=dict(type='str', required=False),
+            machine_name=dict(type='str', required=True),
+            resource_group=dict(type='str', required=True)
+        )
+
+        self.name = None
+        self.machine_name = None
+        self.resource_group = None
+        self.log_path = None
+        self.log_mode = None
+
+        self.results = dict(
+            changed=False,
+            arcmachineextensions=[]
+        )
+
+        super(AzureRMarcmachineextensionsInfo, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                              supports_check_mode=True,
+                                                              supports_tags=False,
+                                                              facts_module=True)
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.name:
+            result = self.get_arc_machine_extension()
+        else:
+            result = self.list_arc_machine_extensions()
+
+        self.results['arcmachineextensions'] = result
+
+        return self.results
+
+    def get_arc_machine_extension(self):
+        '''
+        Gets the properties of the specified arc machine extension.
+
+        :return: List of arc machine extensions
+        '''
+        self.log("Checking if arc machine extension {0} in resource group {1} is present".format(self.name,
+                                                                                                 self.resource_group))
+
+        result = []
+        arc_machine_extension = None
+
+        try:
+            arc_machine_extension = self.hybrid_compute_management_client.machine_extensions.get(machine_name=self.machine_name,
+                                                                                                 resource_group_name=self.resource_group,
+                                                                                                 extension_name=self.name)
+        except ResourceNotFoundError as ex:
+            self.log("Could not find arc machine extension {0} in resource group {1}".format(self.name, self.resource_group))
+            return []
+        except HttpResponseError as ex:
+            if ex.error.code == 'InvalidSubscriptionId':
+                self.log("Could not find subscription id")
+                return []
+            else:
+                raise Exception(ex)
+        if arc_machine_extension:
+            result = [self.serialize_obj(arc_machine_extension, AZURE_OBJECT_CLASS)]
+
+        return result
+
+    def list_arc_machine_extensions(self):
+        '''
+        Gets the properties of the specified arc machine extensions in resource group or subscription.
+
+        :return: List of arc machine extensions
+        '''
+
+        result = []
+        arc_machine_extensions = None
+
+        self.log("Checking if the arc machine extensions in resource group {0} and machine name {1} are present".format(self.resource_group,
+                                                                                                                        self.machine_name))
+        arc_machine_extensions_mgmt_client = self.hybrid_compute_management_client.machine_extensions
+        arc_machine_extensions = arc_machine_extensions_mgmt_client.list(resource_group_name=self.resource_group,
+                                                                         machine_name=self.machine_name)
+        if arc_machine_extensions:
+            # it seems the exception is thrown when iterating through arc_machine_extensions, not when setting arc_machine_extensions
+            try:
+                for item in arc_machine_extensions:
+                    result.append(self.serialize_obj(item, AZURE_OBJECT_CLASS))
+            except ResourceNotFoundError as ex:
+                self.log("Could not find resource group {0}".format(self.resource_group))
+            except HttpResponseError as ex:
+                if ex.error.code == 'InvalidSubscriptionId':
+                    self.log("Could not find subscription id")
+                else:
+                    raise Exception(ex)
+
+        return result
+
+
+def main():
+    """Main execution"""
+    AzureRMarcmachineextensionsInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_arcmachineextensions_info.py
+++ b/plugins/modules/azure_rm_arcmachineextensions_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2025 Klaas Demter (@Klaas-)
+# Copyright (c) 2026 Klaas Weyermann (@Klaas-)
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: azure_rm_arcmachineextensions_info
-version_added: "3.9.0"
+version_added: "3.17.0"
 short_description: Get arc machine extensions
 description:
     - Get arc machine extensions
@@ -34,7 +34,7 @@ extends_documentation_fragment:
     - azure.azcollection.azure
 
 author:
-    - Klaas Demter (@Klaas-)
+    - Klaas Weyermann (@Klaas-)
 '''
 
 EXAMPLES = '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ azure-mgmt-hdinsight==9.1.0b1
 azure-mgmt-iothub==3.0.0
 azure-mgmt-keyvault==12.1.1
 azure-mgmt-loganalytics==13.0.0b7
+azure-mgmt-hybridcompute==9.0.0
 azure-mgmt-managedservices==7.0.0b2
 azure-mgmt-managementgroups==1.1.0b2
 azure-mgmt-marketplaceordering==1.2.0b2

--- a/tests/integration/targets/azure_rm_arcmachineextensions/aliases
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+shippable/azure/group15
+destructive

--- a/tests/integration/targets/azure_rm_arcmachineextensions/meta/main.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/main.yml
@@ -3,10 +3,17 @@
   ansible.builtin.set_fact:
     arc_extensions_rg: "{{ resource_group }}-arc-extensions"
 
+- name: Set variables for test
+  ansible.builtin.set_fact:
+    vm_name: "arc-ext-vm-{{ 999999999 | random }}"
+    location: eastus
+    vm_size: Standard_D2s_v3
+    admin_username: arcadmin
+
 - name: Create resource group for Azure Arc extensions test
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ arc_extensions_rg }}"
-    location: eastus2
+    location: "{{ location }}"
 
 - name: Run Azure Arc Machine Extensions tests
   block:

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Set Arc extensions test resource group name
+  ansible.builtin.set_fact:
+    arc_extensions_rg: "{{ resource_group }}-arc-extensions"
+
+- name: Create resource group for Azure Arc extensions test
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ arc_extensions_rg }}"
+    location: eastus2
+
+- name: Run Azure Arc Machine Extensions tests
+  block:
+    - name: Create Azure VM
+      ansible.builtin.include_tasks: setup.yml
+
+    - name: Prepare Azure VM for Azure Arc
+      ansible.builtin.include_tasks: prepare_vm_for_arc.yml
+
+    - name: Onboard VM to Azure Arc
+      ansible.builtin.include_tasks: onboard_arc.yml
+
+    - name: Test arc machine extensions
+      ansible.builtin.include_tasks: test_extensions.yml
+
+  always:
+    - name: Force delete the entire resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ arc_extensions_rg }}"
+        force_delete_nonempty: true
+        state: absent

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/onboard_arc.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/onboard_arc.yml
@@ -1,0 +1,26 @@
+---
+# Onboard the VM to Azure Arc using the azure_arc role
+- name: Onboard VM to Azure Arc
+  ansible.builtin.import_role:
+    name: azure_arc
+  vars:
+    azure_arc_resource_group: "{{ arc_extensions_rg }}"
+    azure_arc_subscription_id: "{{ azure_subscription_id }}"
+    azure_arc_tenant_id: "{{ azure_tenant }}"
+    azure_arc_tags:
+      environment: "test"
+      purpose: "arc-extensions-test"
+      managed_by: "ansible-tests"
+  delegate_to: arc_test_vm
+
+- name: Assert that Arc role set the resource ID
+  ansible.builtin.assert:
+    that:
+      - azure_arc_resource_id is defined
+      - azure_arc_resource_id | length > 0
+    success_msg: "Azure Arc role set resource ID: {{ azure_arc_resource_id }}"
+    fail_msg: "Azure Arc role did not set azure_arc_resource_id"
+
+- name: Extract arc machine name from resource ID
+  ansible.builtin.set_fact:
+    arc_machine_name: "{{ azure_arc_resource_id.split('/')[-1] }}"

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/prepare_vm_for_arc.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/prepare_vm_for_arc.yml
@@ -1,0 +1,49 @@
+---
+# Prepare Azure VM for Arc evaluation per the following documentation:
+# https://learn.microsoft.com/en-us/azure/azure-arc/servers/plan-evaluate-on-azure-virtual-machine
+
+# Set required env variable
+- name: Add MSFT_ARC_TEST to bashrc
+  ansible.builtin.lineinfile:
+    path: ~/.bashrc
+    line: 'export MSFT_ARC_TEST=true'
+  delegate_to: arc_test_vm
+
+- name: Set MSFT_ARC_TEST for systemd services
+  ansible.builtin.shell: |
+    systemctl set-environment MSFT_ARC_TEST=true
+  become: true
+  delegate_to: arc_test_vm
+  changed_when: true
+  # noqa command-instead-of-module
+
+# Stop and disable Azure VM Guest Agent
+- name: Stop Azure VM Guest Agent (walinuxagent)
+  ansible.builtin.systemd:
+    name: walinuxagent
+    state: stopped
+  become: true
+  delegate_to: arc_test_vm
+  failed_when: false
+
+- name: Disable Azure VM Guest Agent (walinuxagent)
+  ansible.builtin.systemd:
+    name: walinuxagent
+    enabled: false
+  become: true
+  delegate_to: arc_test_vm
+  failed_when: false
+
+- name: Verify walinuxagent is disabled
+  ansible.builtin.systemd:
+    name: walinuxagent
+  become: true
+  delegate_to: arc_test_vm
+
+# Block access to Azure IMDS endpoint
+- name: Block access to Azure IMDS endpoints via iptables
+  ansible.builtin.shell: |
+    iptables -I OUTPUT 1 -d 169.254.169.254 -j REJECT
+  become: true
+  delegate_to: arc_test_vm
+  changed_when: true

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/setup.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/setup.yml
@@ -1,0 +1,110 @@
+---
+- name: Set some variables
+  ansible.builtin.set_fact:
+    vm_name: "arc-ext-vm-{{ 999999999 | random }}"
+    location: eastus
+    vm_size: Standard_D2s_v3
+    admin_username: arcadmin
+
+- name: Create virtual network
+  azure.azcollection.azure_rm_virtualnetwork:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}-vnet"
+    address_prefixes: "10.0.0.0/16"
+    location: "{{ location }}"
+
+- name: Create subnet
+  azure.azcollection.azure_rm_subnet:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}-subnet"
+    virtual_network: "{{ vm_name }}-vnet"
+    address_prefix: "10.0.1.0/24"
+
+- name: Create public IP
+  azure.azcollection.azure_rm_publicipaddress:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}-public-ip"
+    allocation_method: Static
+    sku: Standard
+    location: "{{ location }}"
+
+- name: Create NSG with inbound SSH access
+  azure.azcollection.azure_rm_securitygroup:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}-nsg"
+    location: "{{ location }}"
+    rules:
+      - name: AllowSSH
+        protocol: Tcp
+        destination_port_range: 22
+        access: Allow
+        priority: 1001
+        direction: Inbound
+
+- name: Create NIC
+  azure.azcollection.azure_rm_networkinterface:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}-nic"
+    virtual_network: "{{ vm_name }}-vnet"
+    subnet: "{{ vm_name }}-subnet"
+    ip_configurations:
+      - name: default
+        primary: true
+        public_ip_address_name: "{{ vm_name }}-public-ip"
+    security_group_name: "{{ vm_name }}-nsg"
+    location: "{{ location }}"
+
+- name: Read the public key for SSH authentication
+  ansible.builtin.slurp:
+    src: "~/.ansible/test/id_rsa.pub"
+  register: ssh_public_key_content
+
+- name: Create Azure VM for Arc evaluation (Ubuntu 22.04 LTS)
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}"
+    vm_size: "{{ vm_size }}"
+    location: "{{ location }}"
+    admin_username: "{{ admin_username }}"
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: "/home/{{ admin_username }}/.ssh/authorized_keys"
+        key_data: "{{ ssh_public_key_content.content | b64decode | trim }}"
+    network_interfaces: "{{ vm_name }}-nic"
+    managed_disk_type: StandardSSD_LRS
+    os_disk_caching: ReadWrite
+    image:
+      offer: 0001-com-ubuntu-server-jammy
+      publisher: Canonical
+      sku: 22_04-lts-gen2
+      version: latest
+
+- name: Get VM public IP for connection
+  azure.azcollection.azure_rm_publicipaddress_info:
+    resource_group: "{{ arc_extensions_rg }}"
+    name: "{{ vm_name }}-public-ip"
+  register: vm_public_ip
+
+- name: Set VM connection facts
+  ansible.builtin.set_fact:
+    vm_ssh_host: "{{ vm_public_ip.publicipaddresses[0].ip_address }}"
+    vm_ssh_user: "{{ admin_username }}"
+
+- name: Wait for SSH to become available
+  ansible.builtin.wait_for:
+    host: "{{ vm_ssh_host }}"
+    port: 22
+    delay: 30
+    timeout: 300
+    state: started
+  delegate_to: localhost
+
+- name: Add VM to inventory
+  ansible.builtin.add_host:
+    name: arc_test_vm
+    ansible_host: "{{ vm_ssh_host }}"
+    ansible_user: "{{ admin_username }}"
+    ansible_connection: ssh
+    ansible_ssh_private_key_file: "~/.ansible/test/id_rsa"
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+    ansible_python_interpreter: /usr/bin/python3

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/setup.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/setup.yml
@@ -1,11 +1,4 @@
 ---
-- name: Set some variables
-  ansible.builtin.set_fact:
-    vm_name: "arc-ext-vm-{{ 999999999 | random }}"
-    location: eastus
-    vm_size: Standard_D2s_v3
-    admin_username: arcadmin
-
 - name: Create virtual network
   azure.azcollection.azure_rm_virtualnetwork:
     resource_group: "{{ arc_extensions_rg }}"

--- a/tests/integration/targets/azure_rm_arcmachineextensions/tasks/test_extensions.yml
+++ b/tests/integration/targets/azure_rm_arcmachineextensions/tasks/test_extensions.yml
@@ -1,0 +1,243 @@
+---
+# Integration tests for azure_rm_arcmachineextensions and azure_rm_arcmachineextensions_info
+
+# List extensions on a fresh arc machine
+- name: List all arc machine extensions before any are added
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: extensions_before
+
+- name: Assert listing extensions succeeds
+  ansible.builtin.assert:
+    that:
+      - extensions_before.arcmachineextensions is defined
+
+# Get a non-existent extension (should return empty list)
+- name: Get a non-existent extension by name
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: "NonExistentExtension"
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: nonexistent_ext
+
+- name: Assert non-existent extension returns empty list
+  ansible.builtin.assert:
+    that:
+      - nonexistent_ext.arcmachineextensions | length == 0
+
+# Create an arc machine extension (AzureMonitorLinuxAgent)
+- name: Create arc machine extension - AzureMonitorLinuxAgent
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: present
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: AzureMonitorLinuxAgent
+    location: "{{ location }}"
+    properties:
+      publisher: Microsoft.Azure.Monitor
+      type: AzureMonitorLinuxAgent
+      auto_upgrade_minor_version: false
+      enable_automatic_upgrade: true
+    tags:
+      environment: test
+      purpose: integration-test
+  register: create_ext
+
+- name: Assert extension was created
+  ansible.builtin.assert:
+    that:
+      - create_ext.changed
+      - create_ext.arcmachineextension is not none
+      - create_ext.arcmachineextension.name == 'AzureMonitorLinuxAgent'
+
+# Create same extension again (idempotency - no change expected)
+- name: Create arc machine extension again (idempotency check)
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: present
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: AzureMonitorLinuxAgent
+    location: "{{ location }}"
+    properties:
+      publisher: Microsoft.Azure.Monitor
+      type: AzureMonitorLinuxAgent
+      auto_upgrade_minor_version: false
+      enable_automatic_upgrade: true
+    tags:
+      environment: test
+      purpose: integration-test
+  register: create_ext_idempotent
+
+- name: Assert extension creation is idempotent
+  ansible.builtin.assert:
+    that:
+      - not create_ext_idempotent.changed
+
+
+# Get the created extension by name (info module)
+- name: Get arc machine extension by name
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: AzureMonitorLinuxAgent
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: get_ext
+
+- name: Assert extension info is returned correctly
+  ansible.builtin.assert:
+    that:
+      - get_ext.arcmachineextensions | length == 1
+      - get_ext.arcmachineextensions[0].name == 'AzureMonitorLinuxAgent'
+      - "'Microsoft.Azure.Monitor' in get_ext.arcmachineextensions[0].properties.publisher"
+
+# List all extensions (should include the one we created)
+- name: List all arc machine extensions
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: list_ext
+
+- name: Assert our extension appears in the list
+  ansible.builtin.assert:
+    that:
+      - list_ext.arcmachineextensions | length >= 1
+      - list_ext.arcmachineextensions | selectattr('name', 'equalto', 'AzureMonitorLinuxAgent') | list | length == 1
+
+# Update extension tags
+- name: Update arc machine extension tags
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: present
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: AzureMonitorLinuxAgent
+    location: "{{ location }}"
+    properties:
+      publisher: Microsoft.Azure.Monitor
+      type: AzureMonitorLinuxAgent
+      auto_upgrade_minor_version: false
+      enable_automatic_upgrade: true
+    tags:
+      environment: test
+      purpose: integration-test
+      updated: "true"
+  register: update_ext_tags
+
+- name: Assert extension was updated with new tags
+  ansible.builtin.assert:
+    that:
+      - update_ext_tags.changed
+
+- name: Verify updated tags via info module
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: AzureMonitorLinuxAgent
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: verify_tags
+
+- name: Assert tags were updated
+  ansible.builtin.assert:
+    that:
+      - verify_tags.arcmachineextensions[0].tags.updated == "true"
+
+# Check mode - create a new extension (should report changed but not create)
+- name: Create extension in check mode
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: present
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: CustomScript
+    location: "{{ location }}"
+    properties:
+      publisher: Microsoft.Azure.Extensions
+      type: CustomScript
+      auto_upgrade_minor_version: true
+      enable_automatic_upgrade: false
+      settings:
+        commandToExecute: "echo hello"
+  check_mode: true
+  register: check_create_ext
+
+- name: Assert check mode reports changed
+  ansible.builtin.assert:
+    that:
+      - check_create_ext.changed
+
+- name: Verify extension was not actually created
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: CustomScript
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: check_create_verify
+
+- name: Assert extension does not exist after check mode
+  ansible.builtin.assert:
+    that:
+      - check_create_verify.arcmachineextensions | length == 0
+
+# Check mode - delete existing extension (should report changed but not delete)
+- name: Delete extension in check mode
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: absent
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: AzureMonitorLinuxAgent
+  check_mode: true
+  register: check_delete_ext
+
+- name: Assert check mode delete reports changed
+  ansible.builtin.assert:
+    that:
+      - check_delete_ext.changed
+
+- name: Verify extension still exists after check mode delete
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: AzureMonitorLinuxAgent
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: check_delete_verify
+
+- name: Assert extension still exists
+  ansible.builtin.assert:
+    that:
+      - check_delete_verify.arcmachineextensions | length == 1
+
+# Delete the arc machine extension
+- name: Delete arc machine extension - AzureMonitorLinuxAgent
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: absent
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: AzureMonitorLinuxAgent
+  register: delete_ext
+
+- name: Assert extension was deleted
+  ansible.builtin.assert:
+    that:
+      - delete_ext.changed
+
+# Confirm extension is gone via info module
+- name: Verify extension no longer exists
+  azure.azcollection.azure_rm_arcmachineextensions_info:
+    name: AzureMonitorLinuxAgent
+    machine_name: "{{ arc_machine_name }}"
+    resource_group: "{{ arc_extensions_rg }}"
+  register: deleted_ext_info
+
+- name: Assert extension is gone
+  ansible.builtin.assert:
+    that:
+      - deleted_ext_info.arcmachineextensions | length == 0
+
+# Delete same extension again (idempotency - no change expected)
+- name: Delete arc machine extension again (idempotency check)
+  azure.azcollection.azure_rm_arcmachineextensions:
+    state: absent
+    resource_group: "{{ arc_extensions_rg }}"
+    machine_name: "{{ arc_machine_name }}"
+    name: AzureMonitorLinuxAgent
+  register: delete_ext_idempotent
+
+- name: Assert deletion is idempotent
+  ansible.builtin.assert:
+    that:
+      - not delete_ext_idempotent.changed


### PR DESCRIPTION
##### SUMMARY
This is a new module for azure arc machine extensions. I am unsure how to test this, it needs a non-azure machine that is connected to azure via arc to be able to test this properly.

I have found several issues in the azure rest api for this though.
So stuff like updating tags does not work, auto upgrade minor version does not work, get and list should return the same information about an extension but do not. I've opened up MSFT cases about them, for one I also created a github issue:
https://github.com/Azure/azure-rest-api-specs/issues/37591


##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME
azure_rm_arcmachineextensions
azure_rm_arcmachineextensions_info

