### PR TITLE
Modify azure_rm_virtualnetworkgatewaynatrule.py test group --- group13

### DIFF
--- a/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/aliases
+++ b/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-shippable/azure/group2
+shippable/azure/group13
 destructive


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Balance the test time of group2(approximately 3 hours) and group 13(approximately 20 minutes).
After the update, group2 will take approximately 2 hours. group13 takes approximately 70 minutes.


