### PR TITLE
feat: added support for azure event hub

### DIFF
--- a/extensions/eda/plugins/event_source/azure_event_hub.py
+++ b/extensions/eda/plugins/event_source/azure_event_hub.py
@@ -1,0 +1,173 @@
+import asyncio
+import json
+import logging
+from typing import Any
+
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import ClientSecretCredential
+
+DOCUMENTATION = r"""
+---
+short_description: Receive events via a Azure Event Hub
+description:
+  - An ansible-rulebook event source plugin for receiving events
+    via Azure Event Hub
+options:
+  azure_tenant_id:
+    description:
+      - The azure tenant id
+    type: str
+    required: true
+  azure_client_id:
+    description:
+      - The azure client id
+    type: str
+    required: true
+  azure_client_secret:
+    description:
+      - The azure client secret
+    type: str
+    required: true
+  azure_namespace:
+    description:
+      - The azure event hub namespace which includes the host name
+    type: str
+    example: "test.servicebus.windows.net",
+    required: true
+  azure_event_hub_name:
+    description:
+      - The azure event hub name
+    type: str
+    required: true
+  azure_starting_position:
+    description:
+      - The starting position
+    type: str
+    default: "-1"
+  azure_consumer_group:
+    description:
+      - The name of the consumer group
+    type: str
+    default: "$Default"
+"""
+
+EXAMPLES = r"""
+- azure.azcollection.azure_event_hub:
+    "azure_tenant_id": "your_tenant_id"
+    "azure_client_id": "your_client_id"
+    "azure_client_secret": "your_client_secret"
+    "azure_namespace": "example.servicebus.windows.net"
+    "azure_event_hub_name": "your_hub_name"
+    "azure_starting_position": "-1"
+"""
+
+logger = logging.getLogger()
+
+
+REQUIRED_ARGS = [
+    "azure_tenant_id",
+    "azure_client_id",
+    "azure_client_secret",
+    "azure_namespace",
+    "azure_event_hub_name",
+]
+
+
+class AzureHubConsumer:
+    def __init__(self, queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
+        self.queue = queue
+        tenant_id = args.get("azure_tenant_id")
+        client_id = args.get("azure_client_id")
+        client_secret = args.get("azure_client_secret")
+
+        self.event_hub_namespace = args.get("azure_namespace")
+        self.event_hub_name = args.get("azure_event_hub_name")
+
+        self.consumer_group = args.get("azure_consumer_group", "$Default")
+        self.starting_position = int(args.get("azure_starting_position", "-1"))
+
+        self.credential = ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    async def on_event(self, partition_context, event):
+        if event:
+            await partition_context.update_checkpoint(event)
+            meta = {}
+            # Process message body
+            try:
+                value = event.body_as_str()
+                logger.debug(
+                    "Received event from partition %s: %s",
+                    str(partition_context.partition_id),
+                    value,
+                )
+            except UnicodeError:
+                logger.exception("Unicode error while decoding message body")
+                data = None
+            else:
+                try:
+                    data = json.loads(value)
+                except json.decoder.JSONDecodeError:
+                    logger.info("JSON decode error, storing raw value")
+                    data = value
+
+            # Add data to the event and put it into the queue
+            if data:
+                await self.queue.put({"body": data, "meta": meta})
+
+        await asyncio.sleep(0)
+
+    async def start_receiving(self):
+        client = EventHubConsumerClient(
+            fully_qualified_namespace=self.event_hub_namespace,
+            eventhub_name=self.event_hub_name,
+            consumer_group=self.consumer_group,
+            credential=self.credential,
+        )
+        async with client:
+            await client.receive(self.on_event)
+
+
+# Usage
+async def main(  # pylint: disable=R0914
+    queue: asyncio.Queue[Any],
+    args: dict[str, Any],
+) -> None:
+
+    for key in REQUIRED_ARGS:
+        if key not in args:
+            msg = f"Please provide {key} it is a required argument."
+            raise ValueError(msg)
+
+    consumer = AzureHubConsumer(queue, args)
+    await consumer.start_receiving()
+
+
+if __name__ == "__main__":
+
+    class MockQueue(asyncio.Queue[Any]):
+        """A fake queue."""
+
+        async def put(self: "MockQueue", event: dict[str, Any]) -> None:
+            """Print the event."""
+            print(event)  # noqa: T201
+
+    test_args = {
+        "azure_tenant_id": "your_tenant_id",
+        "azure_client_id": "your_client_id",
+        "azure_client_secret": "your_client_secret",
+        "azure_namespace": "example.servicebus.windows.net",
+        "azure_event_hub_name": "your_hub_name",
+        "azure_starting_position": "-1",
+    }
+
+    asyncio.run(
+        main(
+            MockQueue(),
+            test_args,
+        ),
+    )
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,5 @@ pandas
 oras
 netaddr
 azure-servicebus
+azure-eventhub
+aiohttp

--- a/tests/unit/event_source/test_azure_event_hub.py
+++ b/tests/unit/event_source/test_azure_event_hub.py
@@ -1,11 +1,11 @@
 import asyncio
-import json
 from typing import Any, Dict, Optional, Type
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from extensions.eda.plugins.event_source.azure_event_hub import main, AzureHubConsumer
+from extensions.eda.plugins.event_source.azure_event_hub import (
+    AzureHubConsumer, main)
 
 
 class MockEvent:
@@ -65,8 +65,11 @@ async def test_main_with_all_required_args() -> None:
         "azure_event_hub_name": "test_hub",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient") as mock_client_class, \
-         patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential") as mock_credential:
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient"
+    ) as mock_client_class, patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ) as mock_credential:
 
         mock_client = AsyncMock()
         mock_client_class.return_value = mock_client
@@ -78,7 +81,7 @@ async def test_main_with_all_required_args() -> None:
         mock_credential.assert_called_once_with(
             tenant_id="test_tenant_id",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         mock_client_class.assert_called_once()
         mock_client.receive.assert_called_once()
@@ -95,7 +98,9 @@ async def test_azure_hub_consumer_on_event_json() -> None:
         "azure_event_hub_name": "test_hub",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
         consumer = AzureHubConsumer(queue, args)
 
         partition_context = MockPartitionContext()
@@ -118,7 +123,9 @@ async def test_azure_hub_consumer_on_event_raw_string() -> None:
         "azure_event_hub_name": "test_hub",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
         consumer = AzureHubConsumer(queue, args)
 
         partition_context = MockPartitionContext()
@@ -141,13 +148,17 @@ async def test_azure_hub_consumer_on_event_unicode_error() -> None:
         "azure_event_hub_name": "test_hub",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
         consumer = AzureHubConsumer(queue, args)
 
         partition_context = MockPartitionContext()
         event = MockEvent('{"message": "Hello World"}')
 
-        with patch.object(event, 'body_as_str', side_effect=UnicodeError("Unicode decode error")):
+        with patch.object(
+            event, "body_as_str", side_effect=UnicodeError("Unicode decode error")
+        ):
             await consumer.on_event(partition_context, event)
 
         # Should not put anything in queue when there's a Unicode error
@@ -165,7 +176,9 @@ async def test_azure_hub_consumer_on_event_no_event() -> None:
         "azure_event_hub_name": "test_hub",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
         consumer = AzureHubConsumer(queue, args)
 
         partition_context = MockPartitionContext()
@@ -188,7 +201,9 @@ async def test_azure_hub_consumer_initialization() -> None:
         "azure_starting_position": "5",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential") as mock_credential:
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ) as mock_credential:
         queue: asyncio.Queue[Any] = asyncio.Queue()
         consumer = AzureHubConsumer(queue, args)
 
@@ -200,7 +215,7 @@ async def test_azure_hub_consumer_initialization() -> None:
         mock_credential.assert_called_once_with(
             tenant_id="test_tenant_id",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
 
 
@@ -214,7 +229,9 @@ async def test_azure_hub_consumer_defaults() -> None:
         "azure_event_hub_name": "test_hub",
     }
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
         queue: asyncio.Queue[Any] = asyncio.Queue()
         consumer = AzureHubConsumer(queue, args)
 
@@ -234,8 +251,12 @@ async def test_azure_hub_consumer_start_receiving() -> None:
 
     events = [MockEvent('{"test": "data"}')]
 
-    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"), \
-         patch("extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient", return_value=MockEventHubConsumerClient(events)):
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ), patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient",
+        return_value=MockEventHubConsumerClient(events),
+    ):
 
         queue: asyncio.Queue[Any] = asyncio.Queue()
         consumer = AzureHubConsumer(queue, args)

--- a/tests/unit/event_source/test_azure_event_hub.py
+++ b/tests/unit/event_source/test_azure_event_hub.py
@@ -1,0 +1,246 @@
+import asyncio
+import json
+from typing import Any, Dict, Optional, Type
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from extensions.eda.plugins.event_source.azure_event_hub import main, AzureHubConsumer
+
+
+class MockEvent:
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    def body_as_str(self) -> str:
+        return self._body
+
+
+class MockPartitionContext:
+    def __init__(self, partition_id: str = "0") -> None:
+        self.partition_id = partition_id
+
+    async def update_checkpoint(self, event: MockEvent) -> None:
+        pass
+
+
+class MockEventHubConsumerClient:
+    def __init__(self, events: list[MockEvent]) -> None:
+        self.events = events
+
+    async def __aenter__(self) -> "MockEventHubConsumerClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Any,
+    ) -> None:
+        pass
+
+    async def receive(self, on_event_callback) -> None:
+        partition_context = MockPartitionContext()
+        for event in self.events:
+            await on_event_callback(partition_context, event)
+
+
+@pytest.mark.asyncio
+async def test_main_missing_required_args() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {"azure_tenant_id": "test_tenant"}
+
+    with pytest.raises(ValueError, match="Please provide azure_client_id"):
+        await main(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_main_with_all_required_args() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient") as mock_client_class, \
+         patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential") as mock_credential:
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.receive = AsyncMock()
+
+        await main(queue, args)
+
+        mock_credential.assert_called_once_with(
+            tenant_id="test_tenant_id",
+            client_id="test_client_id",
+            client_secret="test_client_secret"
+        )
+        mock_client_class.assert_called_once()
+        mock_client.receive.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_on_event_json() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+        consumer = AzureHubConsumer(queue, args)
+
+        partition_context = MockPartitionContext()
+        event = MockEvent('{"message": "Hello World"}')
+
+        await consumer.on_event(partition_context, event)
+
+        result = await queue.get()
+        assert result == {"body": {"message": "Hello World"}, "meta": {}}
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_on_event_raw_string() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+        consumer = AzureHubConsumer(queue, args)
+
+        partition_context = MockPartitionContext()
+        event = MockEvent("Hello World")
+
+        await consumer.on_event(partition_context, event)
+
+        result = await queue.get()
+        assert result == {"body": "Hello World", "meta": {}}
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_on_event_unicode_error() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+        consumer = AzureHubConsumer(queue, args)
+
+        partition_context = MockPartitionContext()
+        event = MockEvent('{"message": "Hello World"}')
+
+        with patch.object(event, 'body_as_str', side_effect=UnicodeError("Unicode decode error")):
+            await consumer.on_event(partition_context, event)
+
+        # Should not put anything in queue when there's a Unicode error
+        assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_on_event_no_event() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+        consumer = AzureHubConsumer(queue, args)
+
+        partition_context = MockPartitionContext()
+
+        await consumer.on_event(partition_context, None)
+
+        # Should not put anything in queue when event is None
+        assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_initialization() -> None:
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+        "azure_consumer_group": "custom_group",
+        "azure_starting_position": "5",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential") as mock_credential:
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        consumer = AzureHubConsumer(queue, args)
+
+        assert consumer.event_hub_namespace == "test.servicebus.windows.net"
+        assert consumer.event_hub_name == "test_hub"
+        assert consumer.consumer_group == "custom_group"
+        assert consumer.starting_position == 5
+
+        mock_credential.assert_called_once_with(
+            tenant_id="test_tenant_id",
+            client_id="test_client_id",
+            client_secret="test_client_secret"
+        )
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_defaults() -> None:
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"):
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        consumer = AzureHubConsumer(queue, args)
+
+        assert consumer.consumer_group == "$Default"
+        assert consumer.starting_position == -1
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_start_receiving() -> None:
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    events = [MockEvent('{"test": "data"}')]
+
+    with patch("extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"), \
+         patch("extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient", return_value=MockEventHubConsumerClient(events)):
+
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        consumer = AzureHubConsumer(queue, args)
+
+        await consumer.start_receiving()
+
+        result = await queue.get()
+        assert result == {"body": {"test": "data"}, "meta": {}}

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,1 +1,3 @@
 azure-servicebus
+azure-eventhub
+aiohttp


### PR DESCRIPTION
##### SUMMARY

This PR adds support for azure_event_hub with the Microsoft Entra OAuth credentials. You would need to provide the following

* azure_tenant_id
* azure_client_id
* azure_client_secret
* azure_namespace
* azure_event_hub_name



##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure.azcollection.azure_event_hub

##### ADDITIONAL INFORMATION

```
- azure.azcollection.azure_event_hub:
    "azure_tenant_id": "your_tenant_id"
    "azure_client_id": "your_client_id"
    "azure_client_secret": "your_client_secret"
    "azure_namespace": "example.servicebus.windows.net"
    "azure_event_hub_name": "your_hub_name"
    "azure_starting_position": "-1"
```
