### PR TITLE
Add support for "NetworkSecurityGroupEnabled" and "Rout eTableEnabled" in private_endpoint_network_policies

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -99,6 +99,8 @@ options:
         choices:
             - Enabled
             - Disabled
+            - NetworkSecurityGroupEnabled
+            - RouteTableEnabled
     private_link_service_network_policies:
         description:
             - C(Enabled) or C(Disabled) apply network policies on private link service in the subnet.
@@ -107,8 +109,6 @@ options:
         choices:
             - Enabled
             - Disabled
-            - NetworkSecurityGroupEnabled
-            - RouteTableEnabled
     delegations:
         description:
             - An array of delegations.

--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -107,6 +107,8 @@ options:
         choices:
             - Enabled
             - Disabled
+            - NetworkSecurityGroupEnabled
+            - RouteTableEnabled
     delegations:
         description:
             - An array of delegations.
@@ -466,7 +468,7 @@ class AzureRMSubnet(AzureRMModuleBase):
             private_endpoint_network_policies=dict(
                 type='str',
                 default='Enabled',
-                choices=['Enabled', 'Disabled']
+                choices=['Enabled', 'Disabled', 'NetworkSecurityGroupEnabled', 'RouteTableEnabled']
             ),
             private_link_service_network_policies=dict(
                 type='str',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for "NetworkSecurityGroupEnabled" and "Rout
eTableEnabled" in private_endpoint_network_policies， try to fixes #2075
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_subnet.py
