### PR TITLE
Code default should reflect default provided by doc_fragment

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -231,7 +231,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         self.azure_auth = None
 
-        self._batch_fetch = False
+        self._batch_fetch = True
 
     def verify_file(self, path):
         '''


### PR DESCRIPTION
##### SUMMARY
No functionnal change.
True value is coming from plugins\doc_fragments\azure_rm.py
Just put same value returned by `self.get_option('batch_fetch')` in the code (for comprehension).

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
inventory azure_rm.py

##### ADDITIONAL INFORMATION
