### PR TITLE
fix: wrong conditional for vmss presence

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -849,7 +849,7 @@ class AzureHost(object):
             new_hostvars['virtual_machine_memoryMB'] = self._vm_model['properties']['hardwareProfile'].get('memoryMB')
             new_hostvars['virtual_machine_processors'] = self._vm_model['properties']['hardwareProfile'].get('processors')
 
-        if len(self.nics) == 0:
+        if self._vmss:
             # Set the attribute information related to the Uniform VMSS instance
             # Set os compute name, os name, os version and hyper V generation
             resource_group = new_hostvars['resource_group']

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -849,7 +849,7 @@ class AzureHost(object):
             new_hostvars['virtual_machine_memoryMB'] = self._vm_model['properties']['hardwareProfile'].get('memoryMB')
             new_hostvars['virtual_machine_processors'] = self._vm_model['properties']['hardwareProfile'].get('processors')
 
-        if self._vmss:
+        if len(self.nics) == 0 and self._vmss:
             # Set the attribute information related to the Uniform VMSS instance
             # Set os compute name, os name, os version and hyper V generation
             resource_group = new_hostvars['resource_group']


### PR DESCRIPTION
##### SUMMARY
There can be nic without vmss which would error the code.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm

##### ADDITIONAL INFORMATION
```python
new_hostvars = dict(
            # (...)
            vmss=dict(
                id=self._vmss['id'],
                name=self._vmss['name'],
            ) if self._vmss else {},
            # (...)
        )
        # (...)

        if len(self.nics) == 0:
            # Set the attribute information related to the Uniform VMSS instance
            # Set os compute name, os name, os version and hyper V generation
            resource_group = new_hostvars['resource_group']
            vmss_name = new_hostvars['vmss']['name']
```
Is failing if `len(self.nics) == 0` and `self._vmss is None`