### PR TITLE
Add tests for auth_mode=login in storageaccount

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -920,6 +920,7 @@ def compare_cors(cors1, cors2):
             return False
     return True
 
+
 class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
     def __init__(self):

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -17,6 +17,17 @@ short_description: Manage Azure storage accounts
 description:
     - Create, update or delete a storage account.
 options:
+    auth_mode:
+        description:
+            - The mode in which to run the command. C(login) mode will directly use your login credentials for the authentication.
+            - The legacy C(key) mode will attempt to query for an account key if no authentication parameters for the account are provided.
+            - Can also be set via the environment variable C(AZURE_STORAGE_AUTH_MODE).
+        default: key
+        type: str
+        choices:
+            - key
+            - login
+        version_added: "3.10.0"
     resource_group:
         description:
             - Name of the resource group to use.
@@ -848,6 +859,7 @@ import time
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AZURE_SUCCESS_STATE
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import env_fallback
 
 try:
     from azure.mgmt.storage.models import (Identity, UserAssignedIdentity)
@@ -908,12 +920,17 @@ def compare_cors(cors1, cors2):
             return False
     return True
 
-
 class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
     def __init__(self):
 
         self.module_arg_spec = dict(
+            auth_mode=dict(
+                type='str',
+                choices=['key', 'login'],
+                fallback=(env_fallback, ['AZURE_STORAGE_AUTH_MODE']),
+                default="key"
+            ),
             account_type=dict(type='str',
                               choices=['Premium_LRS', 'Standard_GRS', 'Standard_LRS', 'Standard_RAGRS', 'Standard_ZRS', 'Premium_ZRS',
                                        'Standard_RAGZRS', 'Standard_GZRS'],
@@ -1125,7 +1142,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             account_obj = self.storage_client.storage_accounts.get_properties(self.resource_group, self.name)
             blob_mgmt_props = self.storage_client.blob_services.get_service_properties(self.resource_group, self.name)
             if self.kind != "FileStorage":
-                blob_client_props = self.get_blob_service_client(self.resource_group, self.name).get_service_properties()
+                blob_client_props = self.get_blob_service_client(self.resource_group, self.name, self.auth_mode).get_service_properties()
         except Exception:
             pass
 
@@ -1667,7 +1684,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         if self.kind == "FileStorage":
             return False
         self.log('Checking for existing blob containers')
-        blob_service = self.get_blob_service_client(self.resource_group, self.name)
+        blob_service = self.get_blob_service_client(self.resource_group, self.name, self.auth_mode)
         try:
             response = blob_service.list_containers()
         except Exception:
@@ -1691,7 +1708,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         if self.kind == "FileStorage":
             return
         try:
-            self.get_blob_service_client(self.resource_group, self.name).set_service_properties(static_website=self.static_website)
+            self.get_blob_service_client(self.resource_group, self.name, self.auth_mode).set_service_properties(static_website=self.static_website)
         except Exception as exc:
             self.fail("Failed to set static website config: {0}".format(str(exc)))
 

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -21,6 +21,17 @@ description:
     - Get facts for one storage account or all storage accounts within a resource group.
 
 options:
+    auth_mode:
+        description:
+            - The mode in which to run the command. C(login) mode will directly use your login credentials for the authentication.
+            - The legacy C(key) mode will attempt to query for an account key if no authentication parameters for the account are provided.
+            - Can also be set via the environment variable C(AZURE_STORAGE_AUTH_MODE).
+        default: key
+        type: str
+        choices:
+            - key
+            - login
+        version_added: "3.10.0"
     name:
         description:
             - Only show results for a specific account.
@@ -629,6 +640,7 @@ storageaccounts:
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import env_fallback
 
 
 AZURE_OBJECT_CLASS = 'StorageAccount'
@@ -638,6 +650,12 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
     def __init__(self):
 
         self.module_arg_spec = dict(
+            auth_mode=dict(
+                type='str',
+                choices=['key', 'login'],
+                fallback=(env_fallback, ['AZURE_STORAGE_AUTH_MODE']),
+                default="key"
+            ),
             name=dict(type='str'),
             resource_group=dict(type='str', aliases=['resource_group_name']),
             tags=dict(type='list', elements='str'),
@@ -904,7 +922,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         if kind == "FileStorage":
             return None
         try:
-            return self.get_blob_service_client(resource_group, name).get_service_properties()
+            return self.get_blob_service_client(resource_group, name, self.auth_mode).get_service_properties()
         except Exception:
             pass
         return None

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -386,7 +386,7 @@
         that:
           - filestorage_output is changed
           - filestorage_output.state.sku_name == "Premium_ZRS"
-    
+
     - name: Re-create a new storage account with auth_mode=login
       azure.azcollection.azure_rm_storageaccount:
         resource_group: "{{ resource_group }}-storageaccount"

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -64,6 +64,7 @@
         - "{{ storage_account_name_default }}06"
         - "{{ storage_account_name_default }}07"
         - "{{ storage_account_name_default }}08"
+        - "{{ storage_account_name_default }}09"
 
     - name: Create new storage account with defaults (omitted parameters)
       azure.azcollection.azure_rm_storageaccount:
@@ -113,22 +114,6 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-
-    - name: Create storage account using login auth mode
-      azure.azcollection.azure_rm_storageaccount:
-        resource_group: "{{ resource_group }}-storageaccount"
-        name: "{{ storage_account_name_default }}02"
-        account_type: Standard_LRS
-        kind: StorageV2
-        auth_mode: login
-        static_website:
-          enabled: false
-      register: output
-    - name: Assert storage account created with login auth mode
-      ansible.builtin.assert:
-        that:
-          - output is changed
-
 
     - name: Enable storage account static website
       azure.azcollection.azure_rm_storageaccount:
@@ -401,6 +386,21 @@
         that:
           - filestorage_output is changed
           - filestorage_output.state.sku_name == "Premium_ZRS"
+    
+    - name: Re-create a new storage account with auth_mode=login
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}09"
+        account_type: Standard_LRS
+        kind: StorageV2
+        auth_mode: login
+        static_website:
+          enabled: false
+      register: output
+    - name: Assert storage account created with login auth mode
+      ansible.builtin.assert:
+        that:
+          - output is changed
 
     - name: Create new storage account with explicit parameters
       azure.azcollection.azure_rm_storageaccount:

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -114,6 +114,22 @@
         that:
           - output is not changed
 
+    - name: Create storage account using login auth mode
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}02"
+        account_type: Standard_LRS
+        kind: StorageV2
+        auth_mode: login
+        static_website:
+          enabled: false
+      register: output
+    - name: Assert storage account created with login auth mode
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+
     - name: Enable storage account static website
       azure.azcollection.azure_rm_storageaccount:
         resource_group: "{{ resource_group }}-storageaccount"


### PR DESCRIPTION
This PR adds integration test task for the new `auth_mode` parameter introduced in PR #2079.
- Covers `azure_rm_storageaccount` with auth_mode=login

Related to #2079