### PR TITLE
Don't pin third party packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.0
+aiohttp>=3.13.0
 azure-cli-core==2.75.0
 azure-common==1.1.28
 azure-containerregistry==1.2.0
@@ -54,9 +54,9 @@ azure-nspkg==3.0.2
 azure-servicebus==7.14.2
 azure-storage-blob==12.23.0b1
 msgraph-sdk==1.6.0
-netaddr==1.3.0
-oras==0.2.38
-packaging==25.0
-pandas==2.3.3
-requests==2.32.5
-xmltodict==1.0.2
+netaddr>=1.3.0
+oras>=0.2.38
+packaging>=25.0
+pandas>=2.3.3
+requests>=2.32.5
+xmltodict>=1.0.2


### PR DESCRIPTION
##### SUMMARY
For third party packages we don't allow upper bound pins <= or fixed pins == because they can result in conflicts during EE builds.

##### ISSUE TYPE
- Bugfix Pull Request