### PR TITLE
Update lookup plugins to use auth_source

### DIFF
--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2016 Matt Davis, <mdavis@ansible.com>
+# Copyright: (c) 2016 Chris Houseknecht, <house@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Azure doc fragment
+    DOCUMENTATION = r'''
+
+options:
+    subscription_id:
+        description:
+            - Your Azure subscription Id.
+        type: str
+        env:
+          - name: AZURE_SUBSCRIPTION_ID
+    client_id:
+        description:
+            - Azure client ID. Use when authenticating with a Service Principal or Managed Identity (msi).
+            - Can also be set via the C(AZURE_CLIENT_ID) environment variable.
+        type: str
+        env:
+          - name: AZURE_CLIENT_ID
+    secret:
+        description:
+            - Azure client secret. Use when authenticating with a Service Principal.
+        type: str
+        env:
+          - name: AZURE_SECRET
+    tenant:
+        description:
+            - Azure tenant ID. Use when authenticating with a Service Principal.
+        type: str
+        env:
+          - name: AZURE_TENANT
+    cloud_environment:
+        description:
+            - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),
+              C(AzureUSGovernment)), or a metadata discovery endpoint URL (required for Azure Stack). Can also be set via credential file profile or
+              the C(AZURE_CLOUD_ENVIRONMENT) environment variable.
+        type: str
+        default: AzureCloud
+        version_added: '0.0.1'
+        env:
+          - name: AZURE_CLOUD_ENVIRONMENT
+    auth_source:
+        description:
+            - Controls the source of the credentials to use for authentication.
+            - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
+            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
+            - When set to C(env), the credentials will be read from the environment variables
+            - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable
+              C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if more than one is present otherwise the default
+              az cli subscription is used.
+            - When set to C(msi), the host machine must be an azure resource with an enabled MSI extension. C(subscription_id) or the
+              environment variable C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if the resource is granted
+              access to more than one subscription, otherwise the first subscription is chosen.
+            - The C(msi) was added in Ansible 2.6.
+        type: str
+        default: auto
+        choices:
+        - auto
+        - cli
+        - env
+        - msi
+        env:
+          - name: ANSIBLE_AZURE_AUTH_SOURCE
+requirements:
+    - python >= 2.7
+    - The host that executes this module must have the azure.azcollection collection installed via galaxy
+    - All python packages listed in collection's requirements.txt must be installed via pip on the host that executes modules from azure.azcollection
+    - Full installation instructions may be found https://galaxy.ansible.com/azure/azcollection
+
+notes:
+    - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
+      in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login).
+    - Authentication is also possible using a service principal.
+    - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
+      variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
+    - "Alternatively, credentials can be stored in ~/.azure/credentials. This is an ini file containing
+      a [default] section and the following keys: subscription_id, client_id, secret and tenant."
+
+seealso:
+    - name: Sign in with Azure CLI
+      link: https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest
+      description: How to authenticate using the C(az login) command.
+    '''

--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -26,18 +26,19 @@ options:
     vault_url:
         description: Url of Azure Key Vault.
         required: True
-    client_id:
-        description: Client id of service principal that has access to the Azure Key Vault
-    secret:
-        description: Secret of the service principal.
     tenant:
-        description: Tenant id of service principal.
         aliases:
           - tenant_id
     use_msi:
-        description: MSI token autodiscover, default is true.
+        description:
+          - MSI token autodiscover.
+          - The default is to try MSI authentication first, then use auth_source, You can disable MSI entirely
+            by setting this to False.
+        default: true
     use_cli:
-        description: When I(use_cli=True), get the 'az login' credential authentication, default is false.
+        description:
+          - When I(use_cli=True), get the 'az login' credential authentication, default if false.
+          - Deprecated, please use I(auth_source=cli) instead.
     cloud_type:
         description: Specify which cloud, such as C(azure), C(usgovcloudapi).
 notes:
@@ -50,6 +51,9 @@ notes:
       AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID.
     - Authentication via C(az login) is also supported. Set I(use_cli=true) when using Azure CLI.
     - To use a plugin from a collection, please reference the full namespace, collection name, and lookup plugin name that you want to use.
+
+extends_documentation_fragment:
+    - azure.azcollection.azure_plugin
 """
 
 EXAMPLE = """
@@ -87,7 +91,7 @@ EXAMPLE = """
           client_id=client_id,
           secret=secret,
           tenant=tenant,
-          use_msi=false
+          use_msi=False
         )
       }}"
 
@@ -145,9 +149,9 @@ logger = logging.getLogger("azure.identity").setLevel(logging.ERROR)
 
 
 class LookupModule(LookupBase):
-    def lookup_secret_non_msi(self, terms, vault_url):
+    def lookup_secret_non_msi(self, terms, vault_url, auth_source):
 
-        auth_source = 'auto'
+        # Legacy use_cli will set auth_source to cli.
         if self.get_option('use_cli'):
             auth_source = 'cli'
         auth_options = dict(
@@ -176,11 +180,10 @@ class LookupModule(LookupBase):
         self.set_options(direct=kwargs)
 
         ret = []
+        # Default auth_source is auto, but we still try MSI first unless explicitly disabled.
+        auth_source = self.get_option('auth_source')
         vault_url = self.get_option('vault_url')
         use_msi = self.get_option('use_msi')
-        # If use_msi is not defined default to True.
-        if use_msi is None:
-            use_msi = True
         TOKEN_ACQUIRED = False
         token = None
 
@@ -225,4 +228,4 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Failed to fetch secret ' + term + ' from ' + vault_url + ' via MSI endpoint.')
             return ret
         else:
-            return self.lookup_secret_non_msi(terms, vault_url)
+            return self.lookup_secret_non_msi(terms, vault_url, auth_source)

--- a/plugins/lookup/azure_keyvault_secret.py
+++ b/plugins/lookup/azure_keyvault_secret.py
@@ -151,14 +151,23 @@ logger = logging.getLogger("azure.identity").setLevel(logging.ERROR)
 class LookupModule(LookupBase):
     def lookup_secret_non_msi(self, terms, vault_url, auth_source):
 
+        client_id = self.get_option('client_id')
+        secret = self.get_option('secret')
+        tenant = self.get_option('tenant')
+
         # Legacy use_cli will set auth_source to cli.
         if self.get_option('use_cli'):
             auth_source = 'cli'
+        # If auth_source is auto but no client_id or secret passed in switch to cli
+        if auth_source == 'auto':
+            if any(v is None for v in [client_id, secret, tenant]):
+                auth_source = 'cli'
+
         auth_options = dict(
             auth_source=auth_source,
-            client_id=self.get_option('client_id'),
-            secret=self.get_option('secret'),
-            tenant=self.get_option('tenant'),
+            client_id=client_id,
+            secret=secret,
+            tenant=tenant,
             is_ad_resource=True
         )
 

--- a/plugins/lookup/azure_service_principal_attribute.py
+++ b/plugins/lookup/azure_service_principal_attribute.py
@@ -75,11 +75,21 @@ class LookupModule(LookupBase):
 
         self.set_options(direct=kwargs)
 
+        auth_source = self.get_option('auth_source')
+        client_id = self.get_option('client_id')
+        secret = self.get_option('secret')
+        tenant = self.get_option('tenant')
+
+        # If auth_source is auto but no client_id or secret passed in switch to cli
+        if auth_source == 'auto':
+            if any(v is None for v in [client_id, secret, tenant]):
+                auth_source = 'cli'
+
         auth_options = dict(
-            auth_source=self.get_option('auth_source'),
-            client_id=self.get_option('client_id'),
-            secret=self.get_option('secret'),
-            tenant=self.get_option('tenant'),
+            auth_source=auth_source,
+            client_id=client_id,
+            secret=secret,
+            tenant=tenant,
             cloud_environment=self.get_option('cloud_environment'),
             is_ad_resource=True
         )

--- a/plugins/lookup/azure_service_principal_attribute.py
+++ b/plugins/lookup/azure_service_principal_attribute.py
@@ -22,19 +22,15 @@ description:
   - Describes object id of your Azure service principal account.
 options:
   client_id:
-    description: azure service principal client id.
     aliases:
       - azure_client_id
   secret:
-    description: azure service principal secret
     aliases:
       - azure_secret
   tenant:
-    description: azure tenant
     aliases:
       - azure_tenant
   cloud_environment:
-    description: azure cloud environment
     aliases:
       - azure_cloud_environment
 notes:
@@ -42,6 +38,9 @@ notes:
     - To authenticate via service principal, pass client_id, secret and tenant or set environment variables
       AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID.
     - Authentication via C(az login) is also supported.
+
+extends_documentation_fragment:
+    - azure.azcollection.azure_plugin
 """
 
 EXAMPLES = """
@@ -77,12 +76,14 @@ class LookupModule(LookupBase):
         self.set_options(direct=kwargs)
 
         auth_options = dict(
+            auth_source=self.get_option('auth_source'),
             client_id=self.get_option('client_id'),
             secret=self.get_option('secret'),
-            tenant=self.get_option('tenant', 'common'),
+            tenant=self.get_option('tenant'),
             cloud_environment=self.get_option('cloud_environment'),
             is_ad_resource=True
         )
+
         azure_auth = AzureRMAuth(**auth_options)
 
         try:


### PR DESCRIPTION
##### SUMMARY
This is an effort to make the lookup plugins use the same logic for authenticating as the rest of the ansible modules.

Fixes: #2103 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/doc_fragments/azure_plugin.py
plugins/lookup/azure_keyvault_secret.py
plugins/lookup/azure_service_principal_attribute.py

##### ADDITIONAL INFORMATION
I am looking for feedback on adding in the other auth methods, cerificate, adfs_user, etc...   Right now I created a seperate doc_fragment but maybe we can use the same one that the modules use.  If you notice it's possible to override aliases and defaults at the plugin level.

I am working on integration tests but we will need to run with different cloud-config settings to exercise the different auth modes.. 

Thoughts?