### PR TITLE
Fixes #2105: azure_rm_storageaccount added support to handle resource instance rules

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -178,11 +178,14 @@ options:
                         description:
                             - The complete path to the subnet.
                         type: str
+                        required: true
                     action:
                         description:
                             - The only logical I(action=Allow) because this setting is only accessible when I(default_action=Deny).
                         default: 'Allow'
                         type: str
+                        choices:
+                            - Allow
             ip_rules:
                 description:
                     - A list of IP addresses or ranges in CIDR format.
@@ -193,11 +196,14 @@ options:
                         description:
                             - The IP address or range.
                         type: str
+                        required: true
                     action:
                         description:
                             - The only logical I(action=Allow) because this setting is only accessible when I(default_action=Deny).
                         default: 'Allow'
                         type: str
+                        choices:
+                            - Allow
             resource_access_rules:
                 description:
                     - List of resource instance rules that allow specific Azure resources to access storage account when public network access is restricted.
@@ -210,13 +216,13 @@ options:
                     resource_id:
                         description:
                             - The full ARM resource ID of the Azure resource instance.
-                            - Must start with C(/subscriptions/).
                         type: str
                         required: true
                     tenant_id:
                         description:
-                            - The Azure Active Directory tenant ID of the resource instance. Defaults to the current tenant id.
+                            - The Azure Active Directory tenant ID of the resource instance.
                         type: str
+                        required: true
     blob_cors:
         description:
             - Specifies CORS rules for the Blob service.
@@ -550,7 +556,6 @@ EXAMPLES = '''
       bypass: AzureServices
       resource_access_rules: []
 '''
-
 
 RETURN = '''
 state:
@@ -1008,14 +1013,28 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 options=dict(
                     bypass=dict(type='str', default='AzureServices', no_log=False),
                     default_action=dict(type='str', choices=['Allow', 'Deny'], default='Allow'),
-                    virtual_network_rules=dict(type='list', elements='dict'),
-                    ip_rules=dict(type='list', elements='dict'),
+                    virtual_network_rules=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            id=dict(type='str', required=True),
+                            action=dict(type='str', choices=['Allow'], default='Allow'),
+                        ),
+                    ),
+                    ip_rules=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            value=dict(type='str', required=True),
+                            action=dict(type='str', choices=['Allow'], default='Allow'),
+                        ),
+                    ),
                     resource_access_rules=dict(
                         type='list',
                         elements='dict',
                         options=dict(
                             resource_id=dict(type='str', required=True),
-                            tenant_id=dict(type='str'),
+                            tenant_id=dict(type='str', required=True),
                         ),
                     ),
                 ),
@@ -1032,16 +1051,20 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                         type='dict',
                         options=dict(
                             blob=dict(
-                                type='dict', options=blob_spec
+                                type='dict',
+                                options=blob_spec
                             ),
                             table=dict(
-                                type='dict', options=table_spec
+                                type='dict',
+                                options=table_spec
                             ),
                             queue=dict(
-                                type='dict', options=queue_spec
+                                type='dict',
+                                options=queue_spec
                             ),
                             file=dict(
-                                type='dict', options=file_spec
+                                type='dict',
+                                options=file_spec
                             )
                         )
                     ),
@@ -1305,36 +1328,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             if account_obj.network_rule_set.ip_rules:
                 for rule in account_obj.network_rule_set.ip_rules:
                     account_dict['network_acls']['ip_rules'].append(dict(value=rule.ip_address_or_range, action=rule.action))
-            account_dict['encryption'] = dict()
-            if account_obj.encryption:
-                account_dict['encryption']['require_infrastructure_encryption'] = account_obj.encryption.require_infrastructure_encryption
-                account_dict['encryption']['key_source'] = account_obj.encryption.key_source
-                if account_obj.encryption.services:
-                    account_dict['encryption']['services'] = dict()
-                    if account_obj.encryption.services.file:
-                        account_dict['encryption']['services']['file'] = dict(enabled=True)
-                    if account_obj.encryption.services.table:
-                        account_dict['encryption']['services']['table'] = dict(enabled=True)
-                    if account_obj.encryption.services.queue:
-                        account_dict['encryption']['services']['queue'] = dict(enabled=True)
-                    if account_obj.encryption.services.blob:
-                        account_dict['encryption']['services']['blob'] = dict(enabled=True)
-
-                if account_obj.encryption.encryption_identity:
-                    account_dict['encryption']['encryption_identity'] = dict(
-                        encryption_user_assigned_identity=account_obj.encryption.encryption_identity.encryption_user_assigned_identity)
-                else:
-                    account_dict['encryption']['encryption_identity'] = None
-                if account_obj.encryption.key_vault_properties:
-                    account_dict['encryption']['key_vault_properties'] = dict(key_vault_uri=account_obj.encryption.key_vault_properties.key_vault_uri,
-                                                                              key_name=account_obj.encryption.key_vault_properties.key_name,
-                                                                              key_version=account_obj.encryption.key_vault_properties.key_version)
-                else:
-                    account_dict['encryption']['key_vault_properties'] = None
-
-            account_dict['identity'] = dict()
-            if account_obj.identity:
-                account_dict['identity'] = account_obj.identity.as_dict()
 
             account_dict['network_acls']['resource_access_rules'] = []
             if getattr(account_obj.network_rule_set, 'resource_access_rules', None):
@@ -1343,6 +1336,37 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                         resource_id=rule.resource_id,
                         tenant_id=rule.tenant_id
                     ))
+
+        account_dict['encryption'] = dict()
+        if account_obj.encryption:
+            account_dict['encryption']['require_infrastructure_encryption'] = account_obj.encryption.require_infrastructure_encryption
+            account_dict['encryption']['key_source'] = account_obj.encryption.key_source
+            if account_obj.encryption.services:
+                account_dict['encryption']['services'] = dict()
+                if account_obj.encryption.services.file:
+                    account_dict['encryption']['services']['file'] = dict(enabled=True)
+                if account_obj.encryption.services.table:
+                    account_dict['encryption']['services']['table'] = dict(enabled=True)
+                if account_obj.encryption.services.queue:
+                    account_dict['encryption']['services']['queue'] = dict(enabled=True)
+                if account_obj.encryption.services.blob:
+                    account_dict['encryption']['services']['blob'] = dict(enabled=True)
+
+            if account_obj.encryption.encryption_identity:
+                account_dict['encryption']['encryption_identity'] = dict(
+                    encryption_user_assigned_identity=account_obj.encryption.encryption_identity.encryption_user_assigned_identity)
+            else:
+                account_dict['encryption']['encryption_identity'] = None
+            if account_obj.encryption.key_vault_properties:
+                account_dict['encryption']['key_vault_properties'] = dict(key_vault_uri=account_obj.encryption.key_vault_properties.key_vault_uri,
+                                                                          key_name=account_obj.encryption.key_vault_properties.key_name,
+                                                                          key_version=account_obj.encryption.key_vault_properties.key_version)
+            else:
+                account_dict['encryption']['key_vault_properties'] = None
+
+        account_dict['identity'] = dict()
+        if account_obj.identity:
+            account_dict['identity'] = account_obj.identity.as_dict()
 
         return account_dict
 
@@ -1402,7 +1426,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                             tenant_id=r.get('tenant_id')
                         ) for r in (nacls.get('resource_access_rules') or [])
                     ]
-
                 nrs = models.NetworkRuleSet(
                     bypass=nacls.get('bypass'),
                     default_action=nacls.get('default_action', 'Allow'),
@@ -1416,11 +1439,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             except Exception as exc:
                 self.fail("Failed to update network ACLs: {0}".format(str(exc)))
 
-    def sort_list_of_dicts(self, rule_set, dict_key, secondary_key=None):
-        if secondary_key:
-            return sorted(rule_set, key=lambda i: (i.get(dict_key), i.get(secondary_key)))
-        return sorted(rule_set, key=lambda i: i.get(dict_key))
-
     def update_account(self):
         self.log('Update storage account {0}'.format(self.name))
         if self.network_acls:
@@ -1432,44 +1450,38 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             if self.network_acls.get('default_action', 'Allow') == 'Deny':
                 desired_rars = self.network_acls.get('resource_access_rules', None)
                 current_rars = self.account_dict['network_acls'].get('resource_access_rules', [])
+                if desired_rars is not None:
+                    desired_ids = {r.get('resource_id') for r in (desired_rars or [])}
+                    current_ids = {r.get('resource_id') for r in (current_rars or [])}
 
-                if desired_rars is not None and current_rars != []:
-                    if self.sort_list_of_dicts(desired_rars, 'resource_id', 'tenant_id') != self.sort_list_of_dicts(current_rars, 'resource_id', 'tenant_id'):
+                    if desired_ids != current_ids:
                         self.results['changed'] = True
-                        # keep account_dict in sync for local state (optional)
+                        # Keep local state in sync for readability
                         self.account_dict['network_acls']['resource_access_rules'] = desired_rars
                         self.update_network_rule_set()
-
-                if desired_rars is not None and current_rars == []:
-                    self.results['changed'] = True
-                    # keep account_dict in sync for local state (optional)
-                    self.account_dict['network_acls']['resource_access_rules'] = desired_rars
-                    self.update_network_rule_set()
 
                 if self.network_acls.get('bypass') != self.account_dict['network_acls'].get('bypass'):
                     self.results['changed'] = True
                     self.account_dict['network_acls']['bypass'] = self.network_acls['bypass']
                     self.update_network_rule_set()
 
-                if self.network_acls.get('virtual_network_rules', None) is not None and self.account_dict['network_acls']['virtual_network_rules'] != []:
-                    if self.sort_list_of_dicts(self.network_acls['virtual_network_rules'], 'id') != \
-                            self.sort_list_of_dicts(self.account_dict['network_acls']['virtual_network_rules'], 'id'):
-                        self.results['changed'] = True
-                        self.account_dict['network_acls']['virtual_network_rules'] = self.network_acls['virtual_network_rules']
-                        self.update_network_rule_set()
-                if self.network_acls.get('virtual_network_rules', None) is not None and self.account_dict['network_acls']['virtual_network_rules'] == []:
-                    self.results['changed'] = True
-                    self.update_network_rule_set()
+                if self.network_acls.get('virtual_network_rules') is not None:
+                    desired_vnet_ids = {r.get('id') for r in (self.network_acls.get('virtual_network_rules') or [])}
+                    current_vnet_ids = {r.get('id') for r in (self.account_dict['network_acls'].get('virtual_network_rules') or [])}
 
-                if self.network_acls.get('ip_rules', None) is not None and self.account_dict['network_acls']['ip_rules'] != []:
-                    if self.sort_list_of_dicts(self.network_acls['ip_rules'], 'value') != \
-                            self.sort_list_of_dicts(self.account_dict['network_acls']['ip_rules'], 'value'):
+                    if desired_vnet_ids != current_vnet_ids:
                         self.results['changed'] = True
-                        self.account_dict['network_acls']['ip_rules'] = self.network_acls['ip_rules']
+                        self.account_dict['network_acls']['virtual_network_rules'] = self.network_acls.get('virtual_network_rules') or []
                         self.update_network_rule_set()
-                if self.network_acls.get('ip_rules', None) is not None and self.account_dict['network_acls']['ip_rules'] == []:
-                    self.results['changed'] = True
-                    self.update_network_rule_set()
+
+                if self.network_acls.get('ip_rules') is not None:
+                    desired_ip_values = {r.get('value') for r in (self.network_acls.get('ip_rules') or [])}
+                    current_ip_values = {r.get('value') for r in (self.account_dict['network_acls'].get('ip_rules') or [])}
+
+                    if desired_ip_values != current_ip_values:
+                        self.results['changed'] = True
+                        self.account_dict['network_acls']['ip_rules'] = self.network_acls.get('ip_rules') or []
+                        self.update_network_rule_set()
 
         if self.enable_nfs_v3 is not None and bool(self.enable_nfs_v3) != bool(self.account_dict.get('enable_nfs_v3')):
             self.results['changed'] = True

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -200,11 +200,12 @@ options:
                         type: str
             resource_access_rules:
                 description:
-                    - A list of resource instance rules that allow specific Azure resources to access the storage account when public network access is restricted.
+                    - List of resource instance rules that allow specific Azure resources to access storage account when public network access is restricted.
                     - Each entry must include the full ARM resource ID and the tenant ID.
-                    - Supported resource types include Microsoft.DataProtection/BackupVaults, Microsoft.Synapse/workspaces, etc.
-                    - Resource instance rules only apply when I(default_action=Deny) and public network access is Enabled.
-                    - Note: These rules allow access to the public endpoint only; RBAC permissions are still required for data operations.
+                    - Supported resource types
+                      U(https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security-trusted-azure-services?source=recommendations)
+                    - Resource instance rules only apply when I(default_action=Deny) and when I(public_network_access=Enabled).
+                    - These rules allow access to the public endpoint only; RBAC permissions are still required for data operations.
                 type: list
                 elements: dict
                 suboptions:
@@ -537,10 +538,10 @@ EXAMPLES = '''
       default_action: Deny
       bypass: AzureServices
       resource_access_rules:
-        - resource_id: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DataProtection/BackupVaults/myBackupVault"
-          tenant_id: "<tenant-guid>"
-        - resource_id: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Synapse/workspaces/mySynapseWorkspace"
-          tenant_id: "<tenant-guid>"
+        - resource_id: "/subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.DataProtection/BackupVaults/myBackupVault"
+          tenant_id: "myTenantId"
+        - resource_id: "/subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Synapse/workspaces/mySynapseWorkspace"
+          tenant_id: "myTenantId"
 
 - name: Remove all resource instance rules
   azure_rm_storageaccount:
@@ -767,8 +768,9 @@ state:
                     ],
                     "resource_access_rules": [
                         {
-                            "resource_id": "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DataProtection/BackupVaults/myBackupVault",
-                            "tenant_id": "<tenant-guid>"
+                            "resource_id": "/subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/ \
+                                            providers/Microsoft.DataProtection/BackupVaults/myBackupVault",
+                            "tenant_id": "myTenantId"
                         }
                     ]
                     }
@@ -1003,18 +1005,23 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             allow_shared_key_access=dict(type='bool'),
             allow_cross_tenant_replication=dict(type='bool'),
             default_to_o_auth_authentication=dict(type='bool'),
-            network_acls=dict(type='dict', options=dict(
-                        bypass=dict(type='str'),
-                        default_action=dict(type='str', choices=['Allow', 'Deny']),
-                        virtual_network_rules=dict(type='list', elements='dict'),
-                        ip_rules=dict(type='list', elements='dict'),
-                        resource_access_rules=dict(type='list', elements='dict', options=dict(
-                                resource_id=dict(type='str', required=True),
-                                tenant_id=dict(type='str')
-                            )
-                        )
-                    )
+            network_acls=dict(
+                type='dict',
+                options=dict(
+                    bypass=dict(type='str', default='AzureServices', no_log=False),
+                    default_action=dict(type='str', choices=['Allow', 'Deny'], default='Allow'),
+                    virtual_network_rules=dict(type='list', elements='dict'),
+                    ip_rules=dict(type='list', elements='dict'),
+                    resource_access_rules=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            resource_id=dict(type='str', required=True),
+                            tenant_id=dict(type='str'),
+                        ),
+                    ),
                 ),
+            ),
             blob_cors=dict(type='list', options=cors_rule_spec, elements='dict'),
             static_website=dict(type='dict', options=static_website_spec),
             is_hns_enabled=dict(type='bool'),
@@ -1027,20 +1034,16 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                         type='dict',
                         options=dict(
                             blob=dict(
-                                type='dict',
-                                options=blob_spec
+                                type='dict', options=blob_spec
                             ),
                             table=dict(
-                                type='dict',
-                                options=table_spec
+                                type='dict', options=table_spec
                             ),
                             queue=dict(
-                                type='dict',
-                                options=queue_spec
+                                type='dict', options=queue_spec
                             ),
                             file=dict(
-                                type='dict',
-                                options=file_spec
+                                type='dict', options=file_spec
                             )
                         )
                     ),
@@ -1433,8 +1436,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 current_rars = self.account_dict['network_acls'].get('resource_access_rules', [])
 
                 if desired_rars is not None and current_rars != []:
-                    if self.sort_list_of_dicts(desired_rars, 'resource_id', 'tenant_id') != \
-                    self.sort_list_of_dicts(current_rars, 'resource_id', 'tenant_id'):
+                    if self.sort_list_of_dicts(desired_rars, 'resource_id', 'tenant_id') != self.sort_list_of_dicts(current_rars, 'resource_id', 'tenant_id'):
                         self.results['changed'] = True
                         # keep account_dict in sync for local state (optional)
                         self.account_dict['network_acls']['resource_access_rules'] = desired_rars

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -201,7 +201,6 @@ options:
             resource_access_rules:
                 description:
                     - List of resource instance rules that allow specific Azure resources to access storage account when public network access is restricted.
-                    - Each entry must include the full ARM resource ID and the tenant ID.
                     - Supported resource types
                       U(https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security-trusted-azure-services?source=recommendations)
                     - Resource instance rules only apply when I(default_action=Deny) and when I(public_network_access=Enabled).

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -216,7 +216,7 @@ options:
                         required: true
                     tenant_id:
                         description:
-                            - The Azure Active Directory tenant ID of the resource instance.
+                            - The Azure Active Directory tenant ID of the resource instance. Defaults to the current tenant id.
                         type: str
     blob_cors:
         description:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -198,6 +198,26 @@ options:
                             - The only logical I(action=Allow) because this setting is only accessible when I(default_action=Deny).
                         default: 'Allow'
                         type: str
+            resource_access_rules:
+                description:
+                    - A list of resource instance rules that allow specific Azure resources to access the storage account when public network access is restricted.
+                    - Each entry must include the full ARM resource ID and the tenant ID.
+                    - Supported resource types include Microsoft.DataProtection/BackupVaults, Microsoft.Synapse/workspaces, etc.
+                    - Resource instance rules only apply when I(default_action=Deny) and public network access is Enabled.
+                    - Note: These rules allow access to the public endpoint only; RBAC permissions are still required for data operations.
+                type: list
+                elements: dict
+                suboptions:
+                    resource_id:
+                        description:
+                            - The full ARM resource ID of the Azure resource instance.
+                            - Must start with C(/subscriptions/).
+                        type: str
+                        required: true
+                    tenant_id:
+                        description:
+                            - The Azure Active Directory tenant ID of the resource instance.
+                        type: str
     blob_cors:
         description:
             - Specifies CORS rules for the Blob service.
@@ -505,6 +525,31 @@ EXAMPLES = '''
         key_version: 0bd2556671c64fc998095603878beb12
       encryption_identity:
         encryption_user_assigned_identity: "{{ managed_identity_ids[0] }}"
+
+- name: Configure resource instance rules for Backup Vault and Synapse
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: mystorageacct
+    account_type: Standard_LRS
+    kind: StorageV2
+    public_network_access: Enabled
+    network_acls:
+      default_action: Deny
+      bypass: AzureServices
+      resource_access_rules:
+        - resource_id: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DataProtection/BackupVaults/myBackupVault"
+          tenant_id: "<tenant-guid>"
+        - resource_id: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Synapse/workspaces/mySynapseWorkspace"
+          tenant_id: "<tenant-guid>"
+
+- name: Remove all resource instance rules
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: mystorageacct
+    network_acls:
+      default_action: Deny
+      bypass: AzureServices
+      resource_access_rules: []
 '''
 
 
@@ -718,6 +763,12 @@ state:
                         {
                             "action": "Allow",
                             "value": "123.234.123.0/24"
+                        }
+                    ],
+                    "resource_access_rules": [
+                        {
+                            "resource_id": "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DataProtection/BackupVaults/myBackupVault",
+                            "tenant_id": "<tenant-guid>"
                         }
                     ]
                     }
@@ -952,7 +1003,18 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             allow_shared_key_access=dict(type='bool'),
             allow_cross_tenant_replication=dict(type='bool'),
             default_to_o_auth_authentication=dict(type='bool'),
-            network_acls=dict(type='dict'),
+            network_acls=dict(type='dict', options=dict(
+                        bypass=dict(type='str'),
+                        default_action=dict(type='str', choices=['Allow', 'Deny']),
+                        virtual_network_rules=dict(type='list', elements='dict'),
+                        ip_rules=dict(type='list', elements='dict'),
+                        resource_access_rules=dict(type='list', elements='dict', options=dict(
+                                resource_id=dict(type='str', required=True),
+                                tenant_id=dict(type='str')
+                            )
+                        )
+                    )
+                ),
             blob_cors=dict(type='list', options=cors_rule_spec, elements='dict'),
             static_website=dict(type='dict', options=static_website_spec),
             is_hns_enabled=dict(type='bool'),
@@ -1176,7 +1238,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             default_to_o_auth_authentication=account_obj.default_to_o_auth_authentication,
             allow_cross_tenant_replication=account_obj.allow_cross_tenant_replication,
             allow_shared_key_access=account_obj.allow_shared_key_access,
-            network_acls=account_obj.network_rule_set,
             is_hns_enabled=account_obj.is_hns_enabled if account_obj.is_hns_enabled else False,
             enable_nfs_v3=account_obj.enable_nfs_v3 if hasattr(account_obj, 'enable_nfs_v3') else None,
             large_file_shares_state=account_obj.large_file_shares_state,
@@ -1274,10 +1335,17 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             if account_obj.identity:
                 account_dict['identity'] = account_obj.identity.as_dict()
 
+            account_dict['network_acls']['resource_access_rules'] = []
+            if getattr(account_obj.network_rule_set, 'resource_access_rules', None):
+                for rule in account_obj.network_rule_set.resource_access_rules:
+                    account_dict['network_acls']['resource_access_rules'].append(dict(
+                        resource_id=rule.resource_id,
+                        tenant_id=rule.tenant_id
+                    ))
+
         return account_dict
 
     def failover_account(self):
-
         if str(self.account_dict['sku_name']) not in ["Standard_GZRS", "Standard_GRS", "Standard_RAGZRS", "Standard_RAGRS"]:
             self.fail("Storage account SKU ({0}) does not support failover to a secondary region.".format(self.account_dict['sku_name']))
         try:
@@ -1303,15 +1371,54 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
     def update_network_rule_set(self):
         if not self.check_mode:
             try:
-                parameters = self.storage_models.StorageAccountUpdateParameters(network_rule_set=self.network_acls)
-                self.storage_client.storage_accounts.update(self.resource_group,
-                                                            self.name,
-                                                            parameters)
-            except Exception as exc:
-                self.fail("Failed to update account type: {0}".format(str(exc)))
+                models = self.storage_models
+                nacls = self.network_acls or {}
 
-    def sort_list_of_dicts(self, rule_set, dict_key):
-        return sorted(rule_set, key=lambda i: i[dict_key])
+                vnet_rules = None
+                if nacls.get('virtual_network_rules'):
+                    vnet_rules = [
+                        models.VirtualNetworkRule(
+                            virtual_network_resource_id=r.get('id'),
+                            action=r.get('action', 'Allow')
+                        ) for r in (nacls.get('virtual_network_rules') or [])
+                    ]
+
+                ip_rules = None
+                if nacls.get('ip_rules'):
+                    ip_rules = [
+                        models.IPRule(
+                            ip_address_or_range=r.get('value'),
+                            action=r.get('action', 'Allow')
+                        ) for r in (nacls.get('ip_rules') or [])
+                    ]
+
+                resource_access_rules = None
+                # IMPORTANT: when desired list is [], send [] (not None) to clear rules
+                if nacls.get('resource_access_rules') is not None:
+                    resource_access_rules = [
+                        models.ResourceAccessRule(
+                            resource_id=r.get('resource_id'),
+                            tenant_id=r.get('tenant_id')
+                        ) for r in (nacls.get('resource_access_rules') or [])
+                    ]
+
+                nrs = models.NetworkRuleSet(
+                    bypass=nacls.get('bypass'),
+                    default_action=nacls.get('default_action', 'Allow'),
+                    virtual_network_rules=vnet_rules,
+                    ip_rules=ip_rules,
+                    resource_access_rules=resource_access_rules
+                )
+
+                parameters = self.storage_models.StorageAccountUpdateParameters(network_rule_set=nrs)
+                self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
+            except Exception as exc:
+                self.fail("Failed to update network ACLs: {0}".format(str(exc)))
+
+    def sort_list_of_dicts(self, rule_set, dict_key, secondary_key=None):
+        if secondary_key:
+            return sorted(rule_set, key=lambda i: (i.get(dict_key), i.get(secondary_key)))
+        return sorted(rule_set, key=lambda i: i.get(dict_key))
 
     def update_account(self):
         self.log('Update storage account {0}'.format(self.name))
@@ -1322,7 +1429,24 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 self.update_network_rule_set()
 
             if self.network_acls.get('default_action', 'Allow') == 'Deny':
-                if self.network_acls['bypass'] != self.account_dict['network_acls']['bypass']:
+                desired_rars = self.network_acls.get('resource_access_rules', None)
+                current_rars = self.account_dict['network_acls'].get('resource_access_rules', [])
+
+                if desired_rars is not None and current_rars != []:
+                    if self.sort_list_of_dicts(desired_rars, 'resource_id', 'tenant_id') != \
+                    self.sort_list_of_dicts(current_rars, 'resource_id', 'tenant_id'):
+                        self.results['changed'] = True
+                        # keep account_dict in sync for local state (optional)
+                        self.account_dict['network_acls']['resource_access_rules'] = desired_rars
+                        self.update_network_rule_set()
+
+                if desired_rars is not None and current_rars == []:
+                    self.results['changed'] = True
+                    # keep account_dict in sync for local state (optional)
+                    self.account_dict['network_acls']['resource_access_rules'] = desired_rars
+                    self.update_network_rule_set()
+
+                if self.network_acls.get('bypass') != self.account_dict['network_acls'].get('bypass'):
                     self.results['changed'] = True
                     self.account_dict['network_acls']['bypass'] = self.network_acls['bypass']
                     self.update_network_rule_set()
@@ -1715,12 +1839,50 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
     def set_network_acls(self):
         try:
-            parameters = self.storage_models.StorageAccountUpdateParameters(network_rule_set=self.network_acls)
-            self.storage_client.storage_accounts.update(self.resource_group,
-                                                        self.name,
-                                                        parameters)
+            models = self.storage_models
+            nacls = self.network_acls or {}
+
+            def build_network_rule_set(nacls_local):
+                vnet_rules = None
+                if nacls_local.get('virtual_network_rules'):
+                    vnet_rules = [
+                        models.VirtualNetworkRule(
+                            virtual_network_resource_id=r.get('id'),
+                            action=r.get('action', 'Allow')
+                        ) for r in (nacls_local.get('virtual_network_rules') or [])
+                    ]
+
+                ip_rules = None
+                if nacls_local.get('ip_rules'):
+                    ip_rules = [
+                        models.IPRule(
+                            ip_address_or_range=r.get('value'),
+                            action=r.get('action', 'Allow')
+                        ) for r in (nacls_local.get('ip_rules') or [])
+                    ]
+
+                resource_access_rules = None
+                if nacls_local.get('resource_access_rules'):
+                    resource_access_rules = [
+                        models.ResourceAccessRule(
+                            resource_id=r.get('resource_id'),
+                            tenant_id=r.get('tenant_id')
+                        ) for r in (nacls_local.get('resource_access_rules') or [])
+                    ]
+
+                return models.NetworkRuleSet(
+                    bypass=nacls_local.get('bypass'),
+                    default_action=nacls_local.get('default_action', 'Allow'),
+                    virtual_network_rules=vnet_rules,
+                    ip_rules=ip_rules,
+                    resource_access_rules=resource_access_rules
+                )
+
+            nrs = build_network_rule_set(nacls)
+            parameters = self.storage_models.StorageAccountUpdateParameters(network_rule_set=nrs)
+            self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
         except Exception as exc:
-            self.fail("Failed to update account type: {0}".format(str(exc)))
+            self.fail("Failed to update network ACLs: {0}".format(str(exc)))
 
 
 def main():

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -204,7 +204,6 @@ options:
                     - Supported resource types
                       U(https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security-trusted-azure-services?source=recommendations)
                     - Resource instance rules only apply when I(default_action=Deny) and when I(public_network_access=Enabled).
-                    - These rules allow access to the public endpoint only; RBAC permissions are still required for data operations.
                 type: list
                 elements: dict
                 suboptions:

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -344,7 +344,7 @@ storageaccounts:
             sample: true
         network_acls:
             description:
-                - A set of firewall and virtual network rules
+                - A set of firewall, virtual network and resource instance rules.
             returned: always
             type: dict
             sample: {
@@ -366,7 +366,13 @@ storageaccounts:
                             "action": "Allow",
                             "value": "123.234.123.0/24"
                         }
-                    ]
+                        ],
+                    "resource_access_rules": [
+                        {
+                            "resource_id": "/subscriptions/.../BackupVaults/myBackupVault",
+                            "tenant_id": "myTenantId"
+                        }
+                        ]
                     }
         provisioning_state:
             description:
@@ -810,17 +816,28 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
             account_dict['network_acls'] = dict(
                 bypass=account_obj.network_rule_set.bypass,
                 default_action=account_obj.network_rule_set.default_action,
-                ip_rules=account_obj.network_rule_set.ip_rules
             )
-            if account_obj.network_rule_set.virtual_network_rules:
-                account_dict['network_acls']['virtual_network_rules'] = []
-                for rule in account_obj.network_rule_set.virtual_network_rules:
-                    account_dict['network_acls']['virtual_network_rules'].append(dict(id=rule.virtual_network_resource_id, action=rule.action))
 
+            account_dict['network_acls']['virtual_network_rules'] = []
+            if account_obj.network_rule_set.virtual_network_rules:
+                for rule in account_obj.network_rule_set.virtual_network_rules:
+                    account_dict['network_acls']['virtual_network_rules'].append(
+                        dict(id=rule.virtual_network_resource_id, action=rule.action)
+                    )
+
+            account_dict['network_acls']['ip_rules'] = []
             if account_obj.network_rule_set.ip_rules:
-                account_dict['network_acls']['ip_rules'] = []
                 for rule in account_obj.network_rule_set.ip_rules:
-                    account_dict['network_acls']['ip_rules'].append(dict(value=rule.ip_address_or_range, action=rule.action))
+                    account_dict['network_acls']['ip_rules'].append(
+                        dict(value=rule.ip_address_or_range, action=rule.action)
+                    )
+
+            account_dict['network_acls']['resource_access_rules'] = []
+            if getattr(account_obj.network_rule_set, 'resource_access_rules', None):
+                for rule in account_obj.network_rule_set.resource_access_rules:
+                    account_dict['network_acls']['resource_access_rules'].append(
+                        dict(resource_id=rule.resource_id, tenant_id=rule.tenant_id)
+                    )
 
         account_dict['primary_endpoints'] = None
         if account_obj.primary_endpoints:
@@ -835,10 +852,10 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         account_dict['secondary_endpoints'] = None
         if account_obj.secondary_endpoints:
             account_dict['secondary_endpoints'] = dict(
-                blob=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.primary_endpoints.blob, 'blob'),
-                file=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.primary_endpoints.file, 'file'),
-                queue=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.primary_endpoints.queue, 'queue'),
-                table=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.primary_endpoints.table, 'table'),
+                blob=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.secondary_endpoints.blob, 'blob'),
+                file=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.secondary_endpoints.file, 'file'),
+                queue=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.secondary_endpoints.queue, 'queue'),
+                table=self.format_endpoint_dict(account_dict['name'], account_key[1], account_obj.secondary_endpoints.table, 'table'),
             )
             if account_key[1]:
                 account_dict['secondary_endpoints']['key'] = '{0}'.format(account_key[1])
@@ -848,11 +865,11 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         blob_mgmt_props = self.get_blob_mgmt_props(account_dict['resource_group'], account_dict['name'])
         if blob_mgmt_props and blob_mgmt_props.cors and blob_mgmt_props.cors.cors_rules:
             account_dict['blob_cors'] = [dict(
-                allowed_origins=to_native(x.allowed_origins),
-                allowed_methods=to_native(x.allowed_methods),
+                allowed_origins=[to_native(o) for o in x.allowed_origins],
+                allowed_methods=[to_native(m) for m in x.allowed_methods],
                 max_age_in_seconds=x.max_age_in_seconds,
-                exposed_headers=to_native(x.exposed_headers),
-                allowed_headers=to_native(x.allowed_headers)
+                exposed_headers=[to_native(h) for h in x.exposed_headers],
+                allowed_headers=[to_native(h) for h in x.allowed_headers],
             ) for x in blob_mgmt_props.cors.cors_rules]
         blob_client_props = self.get_blob_client_props(account_dict['resource_group'], account_dict['name'], account_dict['kind'])
         if blob_client_props and blob_client_props['static_website']:

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -65,6 +65,7 @@
         - "{{ storage_account_name_default }}07"
         - "{{ storage_account_name_default }}08"
         - "{{ storage_account_name_default }}09"
+        - "{{ storage_account_name_default }}10"
 
     - name: Create new storage account with defaults (omitted parameters)
       azure.azcollection.azure_rm_storageaccount:
@@ -449,6 +450,40 @@
           - explicit_output.state.network_acls.bypass == "AzureServices"
           - explicit_output.state.network_acls.default_action == "Deny"
           - explicit_output.state.network_acls.ip_rules | length == 1
+
+    - name: Create storage account with resource_access_rules
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}10"
+        account_type: Standard_LRS
+        kind: StorageV2
+        public_network_access: Enabled
+        network_acls:
+          default_action: Deny
+          bypass: AzureServices
+          resource_access_rules:
+            - resource_id: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-storageaccount/providers/Microsoft.DataProtection/BackupVaults/testVault"
+              tenant_id: "{{ tenant_id }}"
+            - resource_id: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-storageaccount/providers/Microsoft.ApiManagement/service/testAPI"
+              tenant_id: "{{ tenant_id }}"
+      register: resource_acl_output
+    - name: Assert resource_access_rules applied
+      ansible.builtin.assert:
+        that:
+          - resource_acl_output is changed
+          - resource_acl_output.state.network_acls.resource_access_rules | length == 2
+          - resource_acl_output.state.network_acls.resource_access_rules[0].tenant_id == tenant_id
+
+    - name: Gather storage account facts for resource_access_rules
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}10"
+      register: resource_acl_info
+    - name: Assert resource_access_rules in facts
+      ansible.builtin.assert:
+        that:
+          - resource_acl_info.storageaccounts[0].network_acls.resource_access_rules | length == 2
+          - resource_acl_info.storageaccounts[0].network_acls.default_action == "Deny"
 
     - name: Update existing storage account (idempotence)
       azure.azcollection.azure_rm_storageaccount:


### PR DESCRIPTION
##### SUMMARY
- Fixes issue #2105  where azure_rm_storageaccount.network_acls did not support Azure Storage resource instance network rules (resourceAccessRules), preventing configuration of resource-based firewall exceptions.
- Enhance azure_rm_storageaccount to correctly handle resource instance rules for supported Azure services (e.g., Backup Vaults, Synapse workspaces, Event Hub namespaces).

- Key changes:
  - Added new suboption under network_acls
  - Implemented SDK model mapping for NetworkRuleSet.resource_access_rules
  - Updated idempotency logic
  - Updated module documentation
  - Integration tests added under tests/integration/targets/azure_rm_storageaccount
  - Updated azure_rm_storageaccount_info to return resource instance rules in facts.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_storageaccount.py
- plugins/modules/azure_rm_storageaccount_info.py