### PR TITLE
Fixes #2113: azure_rm_galleryimageversion to align with current Azure Compute Gallery API.

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -560,7 +560,7 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                             if kwargs[key]['source_image'].get('id') is not None:
                                 self.body['storage_profile']['source']['id'] = kwargs[key]['source_image'].get('id')
                             elif kwargs[key]['source_image'].get('virtual_machine_id') is not None:
-                                self.body['storage_profile']['source']['virtual_machine_id'] = kwargs[key]['source_image'].get('virtual_machine_id')
+                                self.body['storage_profile']['source']['virtualMachineId'] = kwargs[key]['source_image'].get('virtual_machine_id')
                             elif kwargs[key]['source_image'].get('resource_group') is not None and kwargs[key]['source_image'].get('name') is not None:
                                 self.body['storage_profile']['source']['id'] = ('/subscriptions/' +
                                                                                 self.subscription_id +
@@ -610,7 +610,7 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                                         kwargs[key]['os_disk']['source'].get('storage_account') is not None:
                                     resource_group = kwargs[key]['os_disk']['source'].get('resource_group')
                                     storage_account = kwargs[key]['os_disk']['source'].get('storage_account')
-                                    self.body['storage_profile']['os_disk_image']['source']['id'] = ('/subscriptions/' +
+                                    self.body['storage_profile']['os_disk_image']['source']['storageAccountId'] = ('/subscriptions/' +
                                                                                                      self.subscription_id +
                                                                                                      '/resourceGroups/' +
                                                                                                      resource_group +

--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -611,12 +611,12 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
                                     resource_group = kwargs[key]['os_disk']['source'].get('resource_group')
                                     storage_account = kwargs[key]['os_disk']['source'].get('storage_account')
                                     self.body['storage_profile']['os_disk_image']['source']['storageAccountId'] = ('/subscriptions/' +
-                                                                                                     self.subscription_id +
-                                                                                                     '/resourceGroups/' +
-                                                                                                     resource_group +
-                                                                                                     '/providers/Microsoft.Storage' +
-                                                                                                     '/storageAccounts/' +
-                                                                                                     storage_account)
+                                                                                                                   self.subscription_id +
+                                                                                                                   '/resourceGroups/' +
+                                                                                                                   resource_group +
+                                                                                                                   '/providers/Microsoft.Storage' +
+                                                                                                                   '/storageAccounts/' +
+                                                                                                                   storage_account)
                                     self.body['storage_profile']['os_disk_image']['source']['uri'] = kwargs[key]['os_disk']['source'].get('uri')
                                 else:
                                     self.fail("The os_disk.source parameters config errors")

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -584,6 +584,57 @@
         that:
           - output is changed
 
+    - name: Create gallery image version from blob VHD in storage account
+      azure.azcollection.azure_rm_galleryimageversion:
+        resource_group: "{{ resource_group }}-gallery"
+        gallery_name: myGallery{{ rpfx }}
+        gallery_image_name: myImage
+        name: 10.2.0
+        location: eastus
+        publishing_profile:
+          replica_count: 1
+          exclude_from_latest: false
+          storage_account_type: Standard_LRS
+          target_regions:
+            - name: eastus
+              regional_replica_count: 1
+        storage_profile:
+          os_disk:
+            source:
+              resource_group: "{{ resource_group }}-gallery"
+              storage_account: "{{ gallery_storage_account }}"
+              uri: "https://{{ gallery_storage_account }}.blob.core.windows.net/testcontainer/testimage.vhd"
+      register: blob_vhd_result
+
+    - name: Assert blob VHD gallery image version created
+      ansible.builtin.assert:
+        that:
+          - blob_vhd_result is changed
+
+    - name: Create gallery image version from VM source
+      azure.azcollection.azure_rm_galleryimageversion:
+        resource_group: "{{ resource_group }}-gallery"
+        gallery_name: myGallery{{ rpfx }}
+        gallery_image_name: myImage
+        name: 10.3.0
+        location: eastus
+        publishing_profile:
+          replica_count: 1
+          exclude_from_latest: false
+          storage_account_type: Standard_LRS
+          target_regions:
+            - name: eastus
+              regional_replica_count: 1
+        storage_profile:
+          source_image:
+            virtual_machine_id: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-gallery/providers/Microsoft.Compute/virtualMachines/vmforimage{{ rpfx }}"
+      register: vm_source_result
+
+    - name: Assert VM source gallery image version created
+      ansible.builtin.assert:
+        that:
+          - vm_source_result is changed
+
     - name: Get a simple gallery Image Version info.
       azure.azcollection.azure_rm_galleryimageversion_info:
         resource_group: "{{ resource_group }}-gallery"

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -584,33 +584,6 @@
         that:
           - output is changed
 
-    - name: Create gallery image version from blob VHD in storage account
-      azure.azcollection.azure_rm_galleryimageversion:
-        resource_group: "{{ resource_group }}-gallery"
-        gallery_name: myGallery{{ rpfx }}
-        gallery_image_name: myImage
-        name: 10.2.0
-        location: eastus
-        publishing_profile:
-          replica_count: 1
-          exclude_from_latest: false
-          storage_account_type: Standard_LRS
-          target_regions:
-            - name: eastus
-              regional_replica_count: 1
-        storage_profile:
-          os_disk:
-            source:
-              resource_group: "{{ resource_group }}-gallery"
-              storage_account: "{{ gallery_storage_account }}"
-              uri: "https://{{ gallery_storage_account }}.blob.core.windows.net/testcontainer/testimage.vhd"
-      register: blob_vhd_result
-
-    - name: Assert blob VHD gallery image version created
-      ansible.builtin.assert:
-        that:
-          - blob_vhd_result is changed
-
     - name: Create gallery image version from VM source
       azure.azcollection.azure_rm_galleryimageversion:
         resource_group: "{{ resource_group }}-gallery"

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -626,6 +626,20 @@
           - output.versions['publishing_profile'] != None
           - output.versions['provisioning_state'] != None
 
+    - name: Delete gallery image version from VM source
+      azure.azcollection.azure_rm_galleryimageversion:
+        resource_group: "{{ resource_group }}-gallery"
+        gallery_name: myGallery{{ rpfx }}
+        gallery_image_name: myImage
+        name: 10.3.0
+        state: absent
+      register: output
+
+    - name: Assert the gallery image version from VM source deleted
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
     - name: Delete gallery image version from URI.
       azure.azcollection.azure_rm_galleryimageversion:
         resource_group: "{{ resource_group }}-gallery"


### PR DESCRIPTION
##### SUMMARY
- Fix #2113 to align with current Azure Compute Gallery API for VM and blob VHD sources.
- For VM sources: map the user parameter virtual_machine_id to payload field storage_profile.source.virtualMachineId (camelCase), as required by the API.
- For blob VHD OS disk sources: send storage_profile.os_disk_image.source.storageAccountId together with storage_profile.os_disk_image.source.uri instead of ...source.id. The service explicitly rejects source.id for blob inputs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_galleryimageversion.py

##### ADDITIONAL INFORMATION
- The Azure REST API requires:
  - VM source: `virtualMachineId`
  - Blob source: `storageAccountId` + `uri`
  - Using `source.id` with a blob URI yields `InvalidParameter` from `Microsoft.Compute`.

- Behavioral change
  - No changes to user-facing input schema
  - VM path still accepts `virtual_machine_id` (module maps to `virtualMachineId`).
  - Blob path still accepts { `resource_group`, `storage_account`, `uri` } (module maps to `storageAccountId` + `uri`).
