### PR TITLE
Idempotency fix: Change IP configuration to construct list instead of set

### DIFF
--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -925,13 +925,13 @@ class AzureRMNetworkInterface(AzureRMModuleBaseExt):
             private_ip_allocation_method=to_native(item.get('private_ip_allocation_method')),
             public_ip_address_name=(to_native(item.get('public_ip_address').get('name'))
                                     if item.get('public_ip_address') else to_native(item.get('public_ip_address_name'))),
-            load_balancer_backend_address_pools=(set([to_native(self.backend_addr_pool_id(id))
-                                                      for id in item.get('load_balancer_backend_address_pools')])
+            load_balancer_backend_address_pools=(sorted({to_native(self.backend_addr_pool_id(id))
+                                                      for id in item.get('load_balancer_backend_address_pools', [])})
                                                  if item.get('load_balancer_backend_address_pools') else None),
-            application_gateway_backend_address_pools=(set([to_native(self.gateway_backend_addr_pool_id(id))
-                                                           for id in item.get('application_gateway_backend_address_pools')])
+            application_gateway_backend_address_pools=(sorted({to_native(self.gateway_backend_addr_pool_id(id))
+                                                           for id in item.get('application_gateway_backend_address_pools', [])})
                                                        if item.get('application_gateway_backend_address_pools') else None),
-            application_security_groups=(set([to_native(asg_id) for asg_id in item.get('application_security_groups')])
+            application_security_groups=(sorted({to_native(asg_id) for asg_id in item.get('application_security_groups', [])})
                                          if item.get('application_security_groups') else None),
             name=to_native(item.get('name')),
             private_ip_address_version=to_native(item.get('private_ip_address_version')),

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -926,10 +926,10 @@ class AzureRMNetworkInterface(AzureRMModuleBaseExt):
             public_ip_address_name=(to_native(item.get('public_ip_address').get('name'))
                                     if item.get('public_ip_address') else to_native(item.get('public_ip_address_name'))),
             load_balancer_backend_address_pools=(sorted({to_native(self.backend_addr_pool_id(id))
-                                                      for id in item.get('load_balancer_backend_address_pools', [])})
+                                                         for id in item.get('load_balancer_backend_address_pools', [])})
                                                  if item.get('load_balancer_backend_address_pools') else None),
             application_gateway_backend_address_pools=(sorted({to_native(self.gateway_backend_addr_pool_id(id))
-                                                           for id in item.get('application_gateway_backend_address_pools', [])})
+                                                               for id in item.get('application_gateway_backend_address_pools', [])})
                                                        if item.get('application_gateway_backend_address_pools') else None),
             application_security_groups=(sorted({to_native(asg_id) for asg_id in item.get('application_security_groups', [])})
                                          if item.get('application_security_groups') else None),


### PR DESCRIPTION
##### SUMMARY
Change IP configuration to construct list instead of set. ADO idempotency failure comes from using set(...) in `construct_ip_configuration_set`. `default_compare` is list-aware (it sorts lists) but it is not set-aware and ends up comparing stringified sets, which is order‑unstable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_networkinterface.py
