### PR TITLE
Handle Azure ResourceNotFoundError during inventory serialization

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -178,6 +178,7 @@ try:
     from netaddr import IPAddress
     from azure.mgmt.network import NetworkManagementClient
     from azure.mgmt.compute import ComputeManagementClient
+    from azure.core.exceptions import ResourceNotFoundError
 except ImportError:
     Configuration = object
     parse_resource_id = object
@@ -299,8 +300,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _serialize(self, hosts):
         results = []
         for h in hosts:
-            results.append(dict(default_inventory_hostname=h.default_inventory_hostname,
-                                hostvars=h.hostvars))
+            try:
+                host_data = dict(default_inventory_hostname=h.default_inventory_hostname,
+                                hostvars=h.hostvars)
+            except ResourceNotFoundError as e:
+                continue
+            results.append(host_data)
         return results
 
     def _credential_setup(self):

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -302,7 +302,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for h in hosts:
             try:
                 host_data = dict(default_inventory_hostname=h.default_inventory_hostname,
-                                hostvars=h.hostvars)
+                                 hostvars=h.hostvars)
             except ResourceNotFoundError as e:
                 continue
             results.append(host_data)


### PR DESCRIPTION
##### SUMMARY
Add exception handling to gracefully skip VMs that are deleted between the initial listing and the detailed instance view fetch. This race condition occurs when a VM is removed from Azure while the inventory plugin is gathering detailed information (instance view, network interfaces) during the hostvars property evaluation.

The fix catches ResourceNotFoundError exceptions during the _serialize method's hostvars access, preventing inventory refresh failures when VMs are concurrently deleted.

Changes:
- Import ResourceNotFoundError from azure.core.exceptions
- Wrap hostvars access in try-except block in _serialize method
- Continue processing remaining hosts when ResourceNotFoundError occurs


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
