### PR TITLE
Fix 2093: Enhance azure_rm_keyvaultcertificate to support re-import of existing certificates.

### DIFF
--- a/plugins/modules/azure_rm_keyvaultcertificate.py
+++ b/plugins/modules/azure_rm_keyvaultcertificate.py
@@ -567,7 +567,6 @@ try:
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.serialization import pkcs12
     except Exception:
-        x509 = None
         hashes = None
         pkcs12 = None
     from azure.core.polling import LROPoller

--- a/plugins/modules/azure_rm_keyvaultcertificate.py
+++ b/plugins/modules/azure_rm_keyvaultcertificate.py
@@ -226,6 +226,24 @@ EXAMPLES = '''
     enabled: true
     state: generate
 
+- name: Rotate Key Vault Certificate with a renewed PEM bundle
+  azure_rm_keyvaultcertificate:
+    vault_uri: https://vault{{ rpfx }}.vault.azure.net
+    name: fredcerticate
+    cert_data: "{{ lookup('file', 'new_cert.pem') }}" # PEM must include private key + cert
+    policy:
+      content_type: "application/x-pem-file"
+    state: import
+
+- name: Rotate Key Vault Certificate with a renewed PFX bundle
+  azure_rm_keyvaultcertificate:
+    vault_uri: https://vault{{ rpfx }}.vault.azure.net
+    name: fredcerticate
+    cert_data: "{{ lookup('file', 'new_cert.pfx') | b64encode }}" # PFX must include private key + cert
+    password: Password@****
+    policy:
+      content_type: "application/x-pkcs12"
+    state: import
 
 - name: Update the keyvault certificate
   azure_rm_keyvaultcertificate:
@@ -544,6 +562,14 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 try:
     from azure.keyvault.certificates import CertificateClient, CertificatePolicy, LifetimeAction
     import base64
+    import hashlib
+    try:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.serialization import pkcs12
+    except Exception:
+        x509 = None
+        hashes = None
+        pkcs12 = None
     from azure.core.polling import LROPoller
 except ImportError:
     # This is handled in azure_rm_common
@@ -720,6 +746,52 @@ def deleted_certificatebundle_to_dict(certificate):
     return response
 
 
+def _cert_data_thumbprint_sha1(cert_data_str, content_type=None, password=None):
+    """
+    Returns SHA-1 thumbprint (bytes) of the leaf certificate contained in cert_data_str.
+    Supports PEM ('-----BEGIN CERTIFICATE-----') and PKCS12 (application/x-pkcs12) if cryptography is available.
+    Returns None when parsing fails (caller should decide fallback behavior).
+    """
+    try:
+        # PEM: extract first CERT block and hash its DER
+        if "-----BEGIN CERTIFICATE-----" in cert_data_str:
+            lines = cert_data_str.strip().splitlines()
+            collecting = False
+            b64 = []
+            for ln in lines:
+                if ln.startswith("-----BEGIN CERTIFICATE-----"):
+                    collecting = True
+                    b64 = []
+                    continue
+                if ln.startswith("-----END CERTIFICATE-----"):
+                    collecting = False
+                    der = base64.b64decode("".join(b64))
+                    return hashlib.sha1(der).digest()
+                if collecting:
+                    b64.append(ln.strip())
+
+        # PKCS#12 (PFX): parse via cryptography if available
+        if content_type and content_type.lower() in ("application/x-pkcs12", "application/x-pfx"):
+            if pkcs12 and hashes:
+                try:
+                    raw = base64.b64decode(cert_data_str)
+                except Exception:
+                    raw = cert_data_str.encode("utf-8", "ignore")
+                pk = pkcs12.load_key_and_certificates(raw, None if password in (None, "") else password.encode("utf-8"))
+                if pk and pk[1]:
+                    return pk[1].fingerprint(hashes.SHA1())
+            return None
+
+        # Fallback: attempt base64->DER->SHA1
+        try:
+            der = base64.b64decode(cert_data_str)
+            return hashlib.sha1(der).digest()
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+
 policy_spec = dict(
     issuer_name=dict(type='str', choices=['self', 'unknown']),
     subject=dict(type='str'),
@@ -761,7 +833,7 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
                                     policy=dict(type='dict', options=policy_spec),
                                     enabled=dict(type='bool'),
                                     password=dict(type='str', no_log=True),
-                                    cert_data=dict(type='str'),
+                                    cert_data=dict(type='str', no_log=True),
                                     state=dict(
                                         type='str',
                                         required=True,
@@ -777,7 +849,7 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
 
         self.results = dict(changed=False)
         self._client = None
-        required_if = [('state', 'import', ['cert_data', 'password'])]
+        required_if = [('state', 'import', ['cert_data'])]
 
         super(AzureRMKeyVaultCertificate,
               self).__init__(derived_arg_spec=self.module_arg_spec,
@@ -801,6 +873,9 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
 
         del_response = self.get_deleted_certificate()
         response = self.get_certificate()
+
+        if self.state == 'import' and del_response is not None and response is None:
+            self.fail("The certificate {0} is soft-deleted and recoverable; recover or purge before importing".format(self.name))
 
         if self.state == 'delete':
             if response is not None:
@@ -842,6 +917,28 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
                     changed = True
                     if not self.check_mode:
                         response = self.update_certificate_properties()
+
+                if self.state == 'import' and self.cert_data:
+                    existing_thumb_b64 = response['properties'].get('x509_thumbprint')
+                    existing_thumb = None
+                    if existing_thumb_b64:
+                        try:
+                            existing_thumb = base64.b64decode(existing_thumb_b64)
+                        except Exception:
+                            existing_thumb = None
+
+                    new_thumb = _cert_data_thumbprint_sha1(self.cert_data, (self.policy or {}).get('content_type'), password=self.password)
+
+                    should_import = False
+                    if new_thumb is None or existing_thumb is None:
+                        should_import = True
+                    else:
+                        should_import = (new_thumb != existing_thumb)
+
+                    if should_import:
+                        changed = True
+                        if not self.check_mode:
+                            response = self.import_certificate()
             else:
                 changed = True
                 if self.state == 'import':
@@ -883,7 +980,7 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
         self.log("Create the certificate {0}".format(self.name))
 
         lifetime_actions = []
-        for item in self.policy['lifetime_actions']:
+        for item in (self.policy.get('lifetime_actions') or []):
             lifetime_actions.append(LifetimeAction(**item))
 
         try:
@@ -926,8 +1023,21 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
         self.log("Import the certificate {0}".format(self.name))
 
         try:
+            raw_bytes = None
+            ct = (self.policy or {}).get('content_type')
+            if ct and ct.lower() in ("application/x-pkcs12", "application/x-pfx"):
+                # Expect cert_data to be Base64 text of the PFX; decode to raw bytes
+                try:
+                    raw_bytes = base64.b64decode(self.cert_data)
+                except Exception:
+                    # raw binary encoded as latin-1-safe text; avoid utf-8
+                    raw_bytes = self.cert_data.encode("latin-1")
+            else:
+                # PEM or unknown: treat as text content; SDK accepts PEM bytes
+                raw_bytes = self.cert_data.encode('utf-8')
+
             response = self._client.import_certificate(certificate_name=self.name,
-                                                       certificate_bytes=self.cert_data.encode('utf-8'),
+                                                       certificate_bytes=raw_bytes,
                                                        enabled=self.enabled,
                                                        password=self.password,
                                                        tags=self.tags)
@@ -1011,7 +1121,7 @@ class AzureRMKeyVaultCertificate(AzureRMModuleBaseExt):
         self.log("Update the certificate policy {0}".format(self.name))
 
         lifetime_actions = []
-        for item in self.policy['lifetime_actions']:
+        for item in (self.policy.get('lifetime_actions') or []):
             lifetime_actions.append(LifetimeAction(**item))
 
         policy = CertificatePolicy(subject=self.policy.get('subject'),

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -221,19 +221,19 @@
           - facts['certificates'] | length == 0
 
     - name: Generate test RSA private key (PEM)
-      community.crypto.openssl_privatekey:
-        path: "{{ playbook_dir }}/cert.key"
-        type: RSA
-        size: 2048
+      ansible.builtin.command:
+        cmd: >
+          openssl genrsa -out "{{ playbook_dir }}/cert.key" 2048
+      args:
+        creates: "{{ playbook_dir }}/cert.key"
 
     - name: Generate self-signed certificate (PEM)
-      community.crypto.openssl_certificate:
-        path: "{{ playbook_dir }}/cert.crt"
-        privatekey_path: "{{ playbook_dir }}/cert.key"
-        provider: selfsigned
-        subject:
-          common_name: "ansible-test"
-        valid_days: 365
+      ansible.builtin.command:
+        cmd: >
+          openssl req -x509 -new -nodes -key "{{ playbook_dir }}/cert.key"
+          -sha256 -days 365 -subj "/CN=ansible-test" -out "{{ playbook_dir }}/cert.crt"
+      args:
+        creates: "{{ playbook_dir }}/cert.crt"
 
     - name: Build PEM bundle (key + cert) for Key Vault import
       ansible.builtin.copy:
@@ -242,7 +242,7 @@
         content: |
           {{ lookup('file', playbook_dir ~ '/cert.key') }}
           {{ lookup('file', playbook_dir ~ '/cert.crt') }}
-    
+
     - name: Import new certificate for rotation
       azure.azcollection.azure_rm_keyvaultcertificate:
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
@@ -256,7 +256,7 @@
     - name: Assert the keyvault certificate rotated
       ansible.builtin.assert:
         that: rotate_result is changed
-    
+
     - name: Re-import same certificate PEM (idempotent check)
       azure.azcollection.azure_rm_keyvaultcertificate:
         vault_uri: https://vault{{ rpfx }}.vault.azure.net

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -281,7 +281,7 @@
           -passout pass:{{ cert_password }}
       args:
         creates: "{{ playbook_dir }}/cert.pfx"
-    
+
     - name: Import PKCS#12 certificate
       azure.azcollection.azure_rm_keyvaultcertificate:
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
@@ -292,11 +292,11 @@
         policy:
           content_type: "application/x-pkcs12"
       register: rotate_pfx_result
-    
+
     - name: Assert the keyvault certificate PKCS#12 rotated
       ansible.builtin.assert:
         that: rotate_pfx_result is changed
-    
+
     - name: Re-import same certificate PFX (idempotent check)
       azure.azcollection.azure_rm_keyvaultcertificate:
         vault_uri: https://vault{{ rpfx }}.vault.azure.net

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -220,6 +220,57 @@
         that:
           - facts['certificates'] | length == 0
 
+    - name: Generate test RSA private key (PEM)
+      community.crypto.openssl_privatekey:
+        path: "{{ playbook_dir }}/cert.key"
+        type: RSA
+        size: 2048
+
+    - name: Generate self-signed certificate (PEM)
+      community.crypto.openssl_certificate:
+        path: "{{ playbook_dir }}/cert.crt"
+        privatekey_path: "{{ playbook_dir }}/cert.key"
+        provider: selfsigned
+        subject:
+          common_name: "ansible-test"
+        valid_days: 365
+
+    - name: Build PEM bundle (key + cert) for Key Vault import
+      ansible.builtin.copy:
+        dest: "{{ cert_file }}"
+        mode: "0600"
+        content: |
+          {{ lookup('file', playbook_dir ~ '/cert.key') }}
+          {{ lookup('file', playbook_dir ~ '/cert.crt') }}
+    
+    - name: Import new certificate for rotation
+      azure.azcollection.azure_rm_keyvaultcertificate:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        name: "cert{{ rpfx }}"
+        cert_data: "{{ lookup('file', cert_file) }}"
+        state: import
+        policy:
+          content_type: "application/x-pem-file"
+      register: rotate_result
+
+    - name: Assert the keyvault certificate rotated
+      ansible.builtin.assert:
+        that: rotate_result is changed
+    
+    - name: Re-import same certificate PEM (idempotent check)
+      azure.azcollection.azure_rm_keyvaultcertificate:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        name: "cert{{ rpfx }}"
+        cert_data: "{{ lookup('file', cert_file) }}"
+        state: import
+        policy:
+          content_type: "application/x-pem-file"
+      register: idempotent_result
+
+    - name: Assert no change on re-import
+      ansible.builtin.assert:
+        that: idempotent_result is not changed
+
     - name: Delete instance of Key Vault
       azure.azcollection.azure_rm_keyvault:
         resource_group: "{{ resource_group }}-keyvaultcertificate"

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -271,6 +271,47 @@
       ansible.builtin.assert:
         that: idempotent_result is not changed
 
+    - name: Generate PKCS#12 bundle from generated key and cert
+      ansible.builtin.command:
+        cmd: >
+          openssl pkcs12 -export
+          -inkey "{{ playbook_dir }}/cert.key"
+          -in "{{ playbook_dir }}/cert.crt"
+          -out "{{ playbook_dir }}/cert.pfx"
+          -passout pass:{{ cert_password }}
+      args:
+        creates: "{{ playbook_dir }}/cert.pfx"
+    
+    - name: Import PKCS#12 certificate
+      azure.azcollection.azure_rm_keyvaultcertificate:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        name: "cert-pfx-{{ rpfx }}"
+        cert_data: "{{ lookup('file', playbook_dir ~ '/cert.pfx') | b64encode }}"
+        password: "{{ cert_password }}"
+        state: import
+        policy:
+          content_type: "application/x-pkcs12"
+      register: rotate_pfx_result
+    
+    - name: Assert the keyvault certificate PKCS#12 rotated
+      ansible.builtin.assert:
+        that: rotate_pfx_result is changed
+    
+    - name: Re-import same certificate PFX (idempotent check)
+      azure.azcollection.azure_rm_keyvaultcertificate:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        name: "cert-pfx-{{ rpfx }}"
+        cert_data: "{{ lookup('file', playbook_dir ~ '/cert.pfx') | b64encode }}"
+        password: "{{ cert_password }}"
+        state: import
+        policy:
+          content_type: "application/x-pkcs12"
+      register: idempotent_pfx_result
+
+    - name: Assert no change on re-import of PFX
+      ansible.builtin.assert:
+        that: idempotent_pfx_result is not changed
+
     - name: Delete instance of Key Vault
       azure.azcollection.azure_rm_keyvault:
         resource_group: "{{ resource_group }}-keyvaultcertificate"


### PR DESCRIPTION
##### SUMMARY
Fix #2093 by supporting idempotent re-import (rotation) of an existing Key Vault certificate when `state: import` is used and the provided `cert_data` differs from the latest version stored in Key Vault. 

Key changes:
1. When certificate already exists, this module computes a SHA-1 thumbprint of the cert_data. If the thumbprint differs from the latest version's thumbprint in Key Vault, the module imports a new version, else, no-op.
2. PEM/PKCS#12 input handling:
 - PEM: Accepts combined bundle (private key + certificate) as UTF-8 bytes. 
 - PKCS#12: Accepts Base64 text and decodes to raw bytes before calling the SDK (avoid UTF-8 surrogate errors). password is used when provided. 
3. If the certificate name is `soft-deleted` (recoverable), `state: import` fails early with an error message (avoid Azure's raw 409). 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_keyvaultcertificate.py

##### ADDITIONAL INFORMATION
- All existing parameters and states retain their behavior. 
- New logic only enhances import behavior when the certificate already exists. 
- Improves robustness for PEM and PKCS#12 (PFX) inputs and adds a soft-delete guard that surfaces an error when the target certificate name is soft-deleted. 
````
Before (issue #2093):
- state: import on an existing cert → no new version; often no-op even when data differs.

After (this PR):
- state: import on existing cert:
  - If cert_data differs (thumbprint mismatch) → new version imported (changed: true)
  - If identical → no-op (changed: false)
- state: import on soft-deleted name → clear error: recover or purge first.
````
