### PR TITLE
Fix #1872: KeyCredentialsInvalidValue: KeyValue cannot be null or empty when adding a certificate via key_value

### DIFF
--- a/plugins/modules/azure_rm_adapplication.py
+++ b/plugins/modules/azure_rm_adapplication.py
@@ -357,6 +357,15 @@ EXAMPLES = '''
   azure_rm_adapplication:
     app_id: "{{ app_id }}"
     state: absent
+
+- name: Add certificate credential when creating ad application
+  azure_rm_adapplication:
+  display_name: "{{ display_name }}"
+  key_type: AsymmetricX509Cert
+  key_usage: Verify
+  key_value: "{{ cert_file.content }}" # slurp gives base64 of the file; module normalizes to DER bytes
+  tenant: "{{ tenant_id }}"
+  subscription_id: "{{ subscription_id }}"
 '''
 
 RETURN = '''
@@ -453,6 +462,8 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 
 try:
     import datetime
+    import base64
+    import re
     import dateutil.parser
     import uuid
     import asyncio
@@ -821,10 +832,10 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                                                  key_id=self.gen_guid(), secret_text=password,
                                                  custom_key_identifier=custom_key_id)]  # value ? secret_text
         elif key_value:
-            key_creds = [
-                KeyCredential(start_date_time=start_date, end_date_time=end_date, key_id=self.gen_guid(), key=key_value,
-                              # value ? key
-                              usage=key_usage, type=key_type, custom_key_identifier=custom_key_id)]
+            key_bytes = self._normalize_cert_key_value(key_value)
+            key_creds = [KeyCredential(start_date_time=start_date, end_date_time=end_date,
+                                       key_id=self.gen_guid(), key=key_bytes, usage=key_usage,
+                                       type=key_type, custom_key_identifier=custom_key_id)]
 
         return password_creds, key_creds
 
@@ -832,6 +843,43 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
         # utf16 is used by AAD portal. Do not change it to other random encoding
         # unless you know what you are doing.
         return key_description.encode('utf-16')
+
+    def _normalize_cert_key_value(self, key_value):
+        """
+        Normalize a certificate to raw DER bytes suitable for KeyCredential.key.
+
+        Accepts:
+        - raw bytes: already DER, returned as-is
+        - str (PEM): strip headers and base64-decode to DER bytes
+        - str (base64 DER): base64-decode to DER bytes
+        - other types: best-effort bytes conversion
+
+        Returns:
+        DER bytes
+        """
+        if isinstance(key_value, bytes):
+            return key_value
+
+        if not isinstance(key_value, str):
+            try:
+                return bytes(key_value)
+            except Exception:
+                return str(key_value).encode("utf-8")
+
+        s = key_value.strip()
+
+        # PEM with BEGIN/END headers
+        m = re.search(r"-----BEGIN CERTIFICATE-----([\s\S]*?)-----END CERTIFICATE-----", s, re.S)
+        if m:
+            pem_b64 = re.sub(r"\s+", "", m.group(1))
+            return base64.b64decode(pem_b64)
+
+        # Base64 DER
+        try:
+            return base64.b64decode(s)
+        except Exception:
+            # Last resort: treat as UTF-8 bytes
+            return s.encode("utf-8")
 
     def gen_guid(self):
         return uuid.uuid4()

--- a/tests/integration/targets/azure_rm_adapplication/aliases
+++ b/tests/integration/targets/azure_rm_adapplication/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group10
+disabled
 destructive

--- a/tests/integration/targets/azure_rm_adapplication/aliases
+++ b/tests/integration/targets/azure_rm_adapplication/aliases
@@ -1,4 +1,3 @@
 cloud/azure
 shippable/azure/group10
-disabled
 destructive

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -92,6 +92,50 @@
   ansible.builtin.assert:
     that: diff_output.app_diff[0].app_display_name == "{{ display_name }}"
 
+- name: Generate self-signed certificate for test
+  community.crypto.openssl_certificate:
+    path: "{{ playbook_dir }}/testcert.pem"
+    privatekey_path: "{{ playbook_dir }}/testcert.key"
+    common_name: "TestCert"
+    provider: selfsigned
+    state: present
+
+- name: Convert PEM to DER
+  command: >
+    openssl x509 -in {{ playbook_dir }}/testcert.pem -outform DER -out {{ playbook_dir }}/testcert.cer
+  args:
+    creates: "{{ playbook_dir }}/testcert.cer"
+
+- name: Slurp DER certificate
+  ansible.builtin.slurp:
+    src: "{{ playbook_dir }}/testcert.cer"
+  register: cert_file
+
+- name: Create application with certificate key_value
+  azure.azcollection.azure_rm_adapplication:
+    display_name: "{{ display_name }}_cert"
+    key_type: AsymmetricX509Cert
+    key_usage: Verify
+    key_value: "{{ cert_file.content }}"
+  register: cert_app_output
+
+- name: Assert certificate app created successfully
+  ansible.builtin.assert:
+    that:
+      - cert_app_output is changed
+      - cert_app_output.object_id is defined
+
+- name: Verify keyCredentials present via info module
+  azure.azcollection.azure_rm_adapplication_info:
+    object_id: "{{ cert_app_output.object_id }}"
+  register: cert_info
+
+- name: Assert keyCredentials metadata
+  ansible.builtin.assert:
+    that:
+      - cert_info.applications[0].key_credentials | length > 0
+      - cert_info.applications[0].key_credentials[0].type == "AsymmetricX509Cert"
+
 - name: Delete ad app by app_id
   azure.azcollection.azure_rm_adapplication:
     app_id: "{{ create_output.app_id }}"

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -133,16 +133,6 @@
       - cert_app_output is changed
       - cert_app_output.object_id is defined
 
-- name: Verify keyCredentials present via info module
-  azure.azcollection.azure_rm_adapplication_info:
-    object_id: "{{ cert_app_output.object_id }}"
-  register: cert_info
-
-- name: Assert keyCredentials metadata
-  ansible.builtin.assert:
-    that:
-      - cert_info.applications[0].key_credentials | length > 0
-
 - name: Delete ad app by app_id
   azure.azcollection.azure_rm_adapplication:
     app_id: "{{ create_output.app_id }}"

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -92,17 +92,25 @@
   ansible.builtin.assert:
     that: diff_output.app_diff[0].app_display_name == "{{ display_name }}"
 
-- name: Generate self-signed certificate for test
-  community.crypto.openssl_certificate:
-    path: "{{ playbook_dir }}/testcert.pem"
-    privatekey_path: "{{ playbook_dir }}/testcert.key"
-    common_name: "TestCert"
-    provider: selfsigned
-    state: present
+- name: Generate test RSA private key (PEM)
+  ansible.builtin.command:
+    cmd: >
+      openssl genrsa -out "{{ playbook_dir }}/testcert.key" 2048
+  args:
+    creates: "{{ playbook_dir }}/testcert.key"
+
+- name: Generate self-signed certificate (PEM)
+  ansible.builtin.command:
+    cmd: >
+      openssl req -x509 -new -nodes -key "{{ playbook_dir }}/testcert.key"
+      -sha256 -days 365 -subj "/CN=ansible-test" -out "{{ playbook_dir }}/testcert.crt"
+  args:
+    creates: "{{ playbook_dir }}/testcert.crt"
 
 - name: Convert PEM to DER
-  command: >
-    openssl x509 -in {{ playbook_dir }}/testcert.pem -outform DER -out {{ playbook_dir }}/testcert.cer
+  ansible.builtin.command:
+    cmd: >
+      openssl x509 -in {{ playbook_dir }}/testcert.crt -outform DER -out {{ playbook_dir }}/testcert.cer
   args:
     creates: "{{ playbook_dir }}/testcert.cer"
 
@@ -134,7 +142,6 @@
   ansible.builtin.assert:
     that:
       - cert_info.applications[0].key_credentials | length > 0
-      - cert_info.applications[0].key_credentials[0].type == "AsymmetricX509Cert"
 
 - name: Delete ad app by app_id
   azure.azcollection.azure_rm_adapplication:


### PR DESCRIPTION
##### SUMMARY
Fix #1872 . Normalize certificate input for `azure_rm_adapplication` so that `KeyCredential.key` receives raw DER bytes (which the Microsoft Graph SDK serializes to base64). This fixes the error `KeyCredentialsInvalidValue: KeyValue cannot be null or empty` seen when adding a certificate via `key_value`.

Key Changes:
1. Introduce `_normalize_cert_key_value()` to accept:
- bytes (DER) -> pass through
- PEM string -> strip headers + base64-decode -> DER bytes
- base64 DER string -> base64-decode -> DER bytes
- other types -> best-effort bytes conversion. 
2. Update `build_application_creds()` to pass bytes to `KeyCredential.key`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_adapplication.py

##### ADDITIONAL INFORMATION
References:
https://learn.microsoft.com/en-us/graph/api/resources/keycredential?view=graph-rest-1.0#properties:~:text=The%20certificate%27s%20raw,certificate%20key.
