### PR TITLE
Fix #2138: Force JSON output for cli queries to avoid parsing errors

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1817,13 +1817,13 @@ class AzureRMAuth(object):
         subscription_id = subscription_id or self._get_env('subscription_id')
         if not subscription_id:
             try:
-                cmd = ["az", "account", "show", "--query", "id"]
+                cmd = ["az", "account", "show", "--query", "id", "-o", "json"]
                 subscription_id = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip().strip('"')
             except Exception as ec:
                 raise CLIError("Obtain the az login's subscription occurred exception as {0}".format(ec))
 
         try:
-            cmd = ["az", "cloud", "show", "--query", "name"]
+            cmd = ["az", "cloud", "show", "--query", "name", "-o", "json"]
             cloud_name = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip().strip('"')
             all_clouds = [x[1] for x in inspect.getmembers(azure_cloud) if isinstance(x[1], azure_cloud.Cloud)]
             matched_clouds = [x for x in all_clouds if x.name == cloud_name]


### PR DESCRIPTION
##### SUMMARY
Fix #2138. Explicitly set `-o json` when invoking `az account show` and `az cloud show` to ensure consistent output format regardless of user CLI config.
This prevents failures when `core.output` is set to 'table', which breaks cloud name parsing and causes 'multiple matching clouds' errors.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_common.py

##### ADDITIONAL INFORMATION
This PR fixes a bug in CLI-based authentication (`auth_source: cli`) where the Azure CLI output format could cause parsing failures.

Previously, the module relied on the user's default Azure CLI output format. If `az config set core.output=table` was set, the output of `az cloud show --query name` would include headers like Result, breaking the logic that matches the active cloud.