### PR TITLE
Added support for Elastic Cluster in azure_rm_postgresqlflexibleserver

### DIFF
--- a/plugins/modules/azure_rm_postgresqlflexiblebackup.py
+++ b/plugins/modules/azure_rm_postgresqlflexiblebackup.py
@@ -212,8 +212,8 @@ class AzureRMPostgreSqlFlexibleBackup(AzureRMModuleBase):
 
         try:
             response = self.postgresql_flexible_client.backups_automatic_and_on_demand.begin_create(resource_group_name=self.resource_group,
-                                                                            server_name=self.server_name,
-                                                                            backup_name=self.backup_name)
+                                                                                                    server_name=self.server_name,
+                                                                                                    backup_name=self.backup_name)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 
@@ -231,8 +231,8 @@ class AzureRMPostgreSqlFlexibleBackup(AzureRMModuleBase):
         self.log("Deleting the PostgreSQL Flexible Backup instance {0}".format(self.backup_name))
         try:
             self.postgresql_flexible_client.backups_automatic_and_on_demand.begin_delete(resource_group_name=self.resource_group,
-                                                                 server_name=self.server_name,
-                                                                 backup_name=self.backup_name)
+                                                                                         server_name=self.server_name,
+                                                                                         backup_name=self.backup_name)
         except Exception as ec:
             self.log('Error attempting to delete the PostgreSQL Flexible Backup instance.')
             self.fail("Error deleting the PostgreSQL Flexible Backup instance: {0}".format(str(ec)))
@@ -247,8 +247,8 @@ class AzureRMPostgreSqlFlexibleBackup(AzureRMModuleBase):
         found = False
         try:
             response = self.postgresql_flexible_client.backups_automatic_and_on_demand.get(resource_group_name=self.resource_group,
-                                                                   server_name=self.server_name,
-                                                                   backup_name=self.backup_name)
+                                                                                           server_name=self.server_name,
+                                                                                           backup_name=self.backup_name)
             found = True
             self.log("Response : {0}".format(response))
             self.log("PostgreSQL Flexible Backup instance : {0} found".format(response.name))

--- a/plugins/modules/azure_rm_postgresqlflexiblebackup.py
+++ b/plugins/modules/azure_rm_postgresqlflexiblebackup.py
@@ -211,7 +211,7 @@ class AzureRMPostgreSqlFlexibleBackup(AzureRMModuleBase):
         self.log("Creating the PostgreSQL Flexible Backup instance {0}".format(self.backup_name))
 
         try:
-            response = self.postgresql_flexible_client.backups.begin_create(resource_group_name=self.resource_group,
+            response = self.postgresql_flexible_client.backups_automatic_and_on_demand.begin_create(resource_group_name=self.resource_group,
                                                                             server_name=self.server_name,
                                                                             backup_name=self.backup_name)
             if isinstance(response, LROPoller):
@@ -230,7 +230,7 @@ class AzureRMPostgreSqlFlexibleBackup(AzureRMModuleBase):
         '''
         self.log("Deleting the PostgreSQL Flexible Backup instance {0}".format(self.backup_name))
         try:
-            self.postgresql_flexible_client.backups.begin_delete(resource_group_name=self.resource_group,
+            self.postgresql_flexible_client.backups_automatic_and_on_demand.begin_delete(resource_group_name=self.resource_group,
                                                                  server_name=self.server_name,
                                                                  backup_name=self.backup_name)
         except Exception as ec:
@@ -246,7 +246,7 @@ class AzureRMPostgreSqlFlexibleBackup(AzureRMModuleBase):
         self.log("Checking if the PostgreSQL Flexible Backup instance {0} is present".format(self.backup_name))
         found = False
         try:
-            response = self.postgresql_flexible_client.backups.get(resource_group_name=self.resource_group,
+            response = self.postgresql_flexible_client.backups_automatic_and_on_demand.get(resource_group_name=self.resource_group,
                                                                    server_name=self.server_name,
                                                                    backup_name=self.backup_name)
             found = True

--- a/plugins/modules/azure_rm_postgresqlflexiblebackup_info.py
+++ b/plugins/modules/azure_rm_postgresqlflexiblebackup_info.py
@@ -158,9 +158,9 @@ class AzureRMPostgreSqlFlexibleBackupInfo(AzureRMModuleBase):
         response = None
         results = []
         try:
-            response = self.postgresql_flexible_client.backups.get(resource_group_name=self.resource_group,
-                                                                   server_name=self.server_name,
-                                                                   backup_name=self.backup_name)
+            response = self.postgresql_flexible_client.backups_automatic_and_on_demand.get(resource_group_name=self.resource_group,
+                                                                                           server_name=self.server_name,
+                                                                                           backup_name=self.backup_name)
             self.log("Response : {0}".format(response))
         except ResourceNotFoundError:
             self.log('Could not get backup facts for PostgreSQL Flexible Server.')
@@ -174,8 +174,8 @@ class AzureRMPostgreSqlFlexibleBackupInfo(AzureRMModuleBase):
         response = None
         results = []
         try:
-            response = self.postgresql_flexible_client.backups.list_by_server(resource_group_name=self.resource_group,
-                                                                              server_name=self.server_name)
+            response = self.postgresql_flexible_client.backups_automatic_and_on_demand.list_by_server(resource_group_name=self.resource_group,
+                                                                                                      server_name=self.server_name)
             self.log("Response : {0}".format(response))
         except Exception as ec:
             self.log('Could not list backups facts for PostgreSQL Flexible Servers.')

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -845,7 +845,8 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                     update_fields = [
                         'sku', 'storage', 'cluster', 'backup', 'high_availability',
                         'maintenance_window', 'auth_config', 'identity', 'tags',
-                        'version', 'network', 'availability_zone', 'create_mode'
+                        'version', 'network', 'availability_zone', 'create_mode',
+                        'fully_qualified_domain_name'
                     ]
                     desired = {k: self.parameters.get(k) for k in update_fields}
                     current = {k: old_response.get(k) for k in update_fields}

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -845,8 +845,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                     update_fields = [
                         'sku', 'storage', 'cluster', 'backup', 'high_availability',
                         'maintenance_window', 'auth_config', 'identity', 'tags',
-                        'version', 'network', 'availability_zone', 'create_mode',
-                        'fully_qualified_domain_name'
+                        'version', 'network', 'availability_zone', 'create_mode'
                     ]
                     desired = {k: self.parameters.get(k) for k in update_fields}
                     current = {k: old_response.get(k) for k in update_fields}

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -81,7 +81,6 @@ options:
             - '15'
             - '16'
             - '17'
-            - '18'
     fully_qualified_domain_name:
         description:
             - The fully qualified domain name of a server.
@@ -712,7 +711,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             ),
             version=dict(
                 type='str',
-                choices=['11', '12', '13', '14', '15', '16', '17', '18']
+                choices=['11', '12', '13', '14', '15', '16', '17']
             ),
             fully_qualified_domain_name=dict(
                 type='str',
@@ -1053,12 +1052,9 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             result['auth_config']['tenant_id'] = item.auth_config.tenant_id
         else:
             result['auth_config'] = None
-        cluster_obj = getattr(item, 'cluster', None)
-        if cluster_obj is None and hasattr(item, 'properties'):
-            cluster_obj = getattr(item.properties, 'cluster', None)
-        if cluster_obj is not None:
-            result['cluster']['cluster_size'] = getattr(cluster_obj, 'cluster_size', None)
-            result['cluster']['default_database_name'] = getattr(cluster_obj, 'default_database_name', None)
+        if item.cluster is not None:
+            result['cluster']['cluster_size'] = item.cluster.cluster_size
+            result['cluster']['default_database_name'] = item.cluster.default_database_name
         else:
             result['cluster']['cluster_size'] = None
             result['cluster']['default_database_name'] = None

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -1128,22 +1128,17 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             result['auth_config']['tenant_id'] = item.auth_config.tenant_id
         else:
             result['auth_config'] = None
-        cluster_obj = None
-        if hasattr(item, 'cluster') and getattr(item, 'cluster') is not None:
-            cluster_obj = getattr(item, 'cluster')
-        elif hasattr(item, 'properties') and hasattr(item.properties, 'cluster') and getattr(item.properties, 'cluster') is not None:
-            cluster_obj = getattr(item.properties, 'cluster')
+        if 'cluster' not in result or result['cluster'] is None:
+            result['cluster'] = {}
+        cluster_obj = getattr(item, 'cluster', None)
+        if cluster_obj is None and hasattr(item, 'properties'):
+            cluster_obj = getattr(item.properties, 'cluster', None)
         if cluster_obj is not None:
-            cluster_size = getattr(cluster_obj, 'cluster_size', None)
-            if cluster_size is None:
-                cluster_size = getattr(cluster_obj, 'clusterSize', None)
-
-            default_db = getattr(cluster_obj, 'default_database_name', None)
-            if default_db is None:
-                default_db = getattr(cluster_obj, 'defaultDatabaseName', None)
-
-            result['cluster']['cluster_size'] = cluster_size
-            result['cluster']['default_database_name'] = default_db
+            result['cluster']['cluster_size'] = getattr(cluster_obj, 'cluster_size', None)
+            result['cluster']['default_database_name'] = getattr(cluster_obj, 'default_database_name', None)
+        else:
+            result['cluster']['cluster_size'] = None
+            result['cluster']['default_database_name'] = None
 
         return result
 

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -624,7 +624,7 @@ servers:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-    import azure.mgmt.rdbms.postgresql_flexibleservers.models as PostgreSQLFlexibleModels
+    from azure.mgmt.postgresqlflexibleservers import models as PostgreSQLFlexibleModels
     from azure.core.exceptions import ResourceNotFoundError
     from azure.core.polling import LROPoller
 except ImportError:
@@ -787,7 +787,6 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
         self.resource_group = None
         self.name = None
         self.parameters = dict()
-        self.update_parameters = dict()
         self.tags = None
         self.is_start = None
         self.is_stop = None
@@ -820,11 +819,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                 setattr(self, key, kwargs[key])
             elif kwargs[key] is not None:
                 self.parameters[key] = kwargs[key]
-                for key in ['location', 'sku', 'administrator_login_password', 'storage', 'cluster',
-                            'backup', 'high_availability', 'maintenance_window', 'auth_config']:
-                    self.update_parameters[key] = kwargs[key]
 
-        old_response = None
         response = None
         changed = False
 
@@ -832,128 +827,59 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
 
         if "location" not in self.parameters:
             self.parameters["location"] = resource_group.location
-            self.update_parameters["location"] = resource_group.location
 
         old_response = self.get_postgresqlflexibleserver()
 
-        if not old_response:
-            self.log("PostgreSQL Flexible Server instance doesn't exist")
-            if self.state == 'present':
-                if not self.check_mode:
+        if self.state == 'present':
+            if not self.check_mode:
+                if not old_response:
+                    # Create
                     if self.identity:
                         update_identity, new_identity = self.update_managed_identity(new_identity=self.identity)
                         if update_identity:
                             self.parameters['identity'] = new_identity
                     response = self.create_postgresqlflexibleserver(self.parameters)
-                    if self.is_stop:
-                        self.stop_postgresqlflexibleserver()
-                    elif self.is_start:
-                        self.start_postgresqlflexibleserver()
-                    elif self.is_restart:
-                        self.restart_postgresqlflexibleserver()
-                changed = True
-            else:
-                self.log("PostgreSQL Flexible Server instance doesn't exist, Don't need to delete")
-        else:
-            self.log("PostgreSQL Flexible Server instance already exists")
-            if self.state == 'present':
-                update_flag = False
-                if self.update_parameters.get('sku') is not None:
-                    for key in self.update_parameters['sku'].keys():
-                        if self.update_parameters['sku'][key] is not None and self.update_parameters['sku'][key] != old_response['sku'].get(key):
-                            update_flag = True
-                        else:
-                            self.update_parameters['sku'][key] = old_response['sku'].get(key)
-
-                if self.update_parameters.get('storage') is not None and self.update_parameters['storage'] != old_response['storage']:
-                    update_flag = True
-                else:
-                    self.update_parameters['storage'] = old_response['storage']
-
-                if self.update_parameters.get('cluster') is not None:
-                    for key in self.update_parameters['cluster'].keys():
-                        if (self.update_parameters['cluster'][key] is not None) and\
-                                (self.update_parameters['cluster'][key] != old_response['cluster'].get(key)):
-                            update_flag = True
-                        else:
-                            self.update_parameters['cluster'][key] = old_response['cluster'].get(key)
-
-                if self.update_parameters.get('backup') is not None:
-                    for key in self.update_parameters['backup'].keys():
-                        if self.update_parameters['backup'][key] is not None and self.update_parameters['backup'][key] != old_response['backup'].get(key):
-                            update_flag = True
-                        else:
-                            self.update_parameters['backup'][key] = old_response['backup'].get(key)
-
-                if self.update_parameters.get('high_availability') is not None:
-                    for key in self.update_parameters['high_availability'].keys():
-                        if (self.update_parameters['high_availability'][key] is not None) and\
-                                (self.update_parameters['high_availability'][key] != old_response['high_availability'].get(key)):
-                            update_flag = True
-                        else:
-                            self.update_parameters['high_availability'][key] = old_response['high_availability'].get(key)
-
-                if self.update_parameters.get('maintenance_window') is not None:
-                    for key in self.update_parameters['maintenance_window'].keys():
-                        if (self.update_parameters['maintenance_window'][key] is not None) and\
-                                (self.update_parameters['maintenance_window'][key] != old_response['maintenance_window'].get(key)):
-                            update_flag = True
-                        else:
-                            self.update_parameters['maintenance_window'][key] = old_response['maintenance_window'].get(key)
-
-                if self.identity:
-                    update_identity, new_identity = self.update_managed_identity(new_identity=self.identity,
-                                                                                 curr_identity=old_response.get('identity', {}))
-                    if update_identity:
-                        self.update_parameters['identity'] = new_identity
-                        update_flag = True
-
-                update_tags, new_tags = self.update_tags(old_response['tags'])
-                self.update_parameters['tags'] = new_tags
-                if update_tags:
-                    update_flag = True
-
-                if self.auth_config is not None and not self.default_compare({}, self.auth_config, old_response['auth_config'], '', dict(compare=[])):
-                    update_flag = True
-                else:
-                    self.auth_config = old_response['auth_config']
-
-                if update_flag:
                     changed = True
-                    if not self.check_mode:
-                        response = self.update_postgresqlflexibleserver(self.update_parameters, old_response)
+                else:
+                    # Compare updating fields only
+                    update_fields = [
+                        'sku', 'storage', 'cluster', 'backup', 'high_availability',
+                        'maintenance_window', 'auth_config', 'identity', 'tags',
+                        'version', 'network', 'availability_zone', 'create_mode'
+                    ]
+                    desired = {k: self.parameters.get(k) for k in update_fields}
+                    current = {k: old_response.get(k) for k in update_fields}
+                    if not self.default_compare({}, desired, current, '', dict(compare=[])):
+                        # Update (PUT)
+                        response = self.update_postgresqlflexibleserver(self.parameters, old_response)
+                        changed = True
                     else:
                         response = old_response
-                    if self.is_stop:
-                        self.stop_postgresqlflexibleserver()
-                        changed = True
-                    elif self.is_start:
-                        self.start_postgresqlflexibleserver()
-                        changed = True
-                    elif self.is_restart:
-                        self.restart_postgresqlflexibleserver()
-                        changed = True
-                else:
-                    if not self.check_mode:
-                        if self.is_stop:
-                            self.stop_postgresqlflexibleserver()
-                            changed = True
-                        elif self.is_start:
-                            self.start_postgresqlflexibleserver()
-                            changed = True
-                        elif self.is_restart:
-                            self.restart_postgresqlflexibleserver()
-                            changed = True
-                    response = old_response
+                        changed = False
+
+                if self.is_stop:
+                    self.stop_postgresqlflexibleserver()
+                    changed = True
+                elif self.is_start:
+                    self.start_postgresqlflexibleserver()
+                    changed = True
+                elif self.is_restart:
+                    self.restart_postgresqlflexibleserver()
+                    changed = True
+
             else:
-                self.log("PostgreSQL Flexible Server instance already exist, will be deleted")
+                response = old_response
+
+        elif self.state == 'absent':
+            if old_response:
                 changed = True
                 if not self.check_mode:
                     response = self.delete_postgresqlflexibleserver()
-
+            else:
+                self.log("PostgreSQL Flexible Server instance doesn't exist, nothing to delete.")
+                response = {}
         self.results['changed'] = changed
         self.results['state'] = response
-
         return self.results
 
     def update_postgresqlflexibleserver(self, body, old_response):
@@ -964,16 +890,28 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
         self.log("Updating the PostgreSQL Flexible Server instance {0}".format(self.name))
         try:
             for key in ['location', 'sku', 'storage', 'cluster', 'backup', 'high_availability',
-                        'maintenance_window', 'auth_config', 'identity', 'tags', 'version']:
+                        'maintenance_window', 'auth_config', 'identity', 'tags', 'version',
+                        'network', 'availability_zone', 'create_mode']:
                 if key not in body or body[key] is None:
                     body[key] = old_response.get(key)
+
+            # Guard immutable cluster default_database_name
+            old_cluster = old_response.get('cluster', {}) or {}
+            new_cluster = body.get('cluster', {}) or {}
+            if old_cluster.get('cluster_size') is not None:
+                if 'default_database_name' in new_cluster:
+                    if new_cluster['default_database_name'] and new_cluster['default_database_name'] != old_cluster.get('default_database_name'):
+                        self.fail("Changing 'cluster.default_database_name' is not supported after cluster creation.")
+
             # Remove cluster block if server is not part of an elastic cluster
             if old_response.get('cluster', {}).get('cluster_size') is None:
                 body.pop('cluster', None)
 
-            response = self.postgresql_flexible_client.servers.begin_create_or_update(resource_group_name=self.resource_group,
-                                                                                      server_name=self.name,
-                                                                                      parameters=body)
+            response = self.postgresql_flexible_client.servers.begin_create_or_update(
+                resource_group_name=self.resource_group,
+                server_name=self.name,
+                parameters=body
+            )
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -830,6 +830,20 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
 
         old_response = self.get_postgresqlflexibleserver()
 
+        current_tags = old_response.get('tags') if old_response else None
+        if self.tags is not None:
+            try:
+                append = getattr(self, 'append_tags', True)
+            except AttributeError:
+                append = True
+            self.parameters['tags'] = (current_tags or {})
+            if append:
+                self.parameters['tags'].update(self.tags or {})
+            else:
+                self.parameters['tags'] = self.tags or {}
+        elif current_tags is not None:
+            self.parameters['tags'] = current_tags
+
         if self.state == 'present':
             if not self.check_mode:
                 if not old_response:

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -1128,9 +1128,22 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             result['auth_config']['tenant_id'] = item.auth_config.tenant_id
         else:
             result['auth_config'] = None
-        if hasattr(item, 'properties') and hasattr(item.properties, 'cluster'):
-            result['cluster']['cluster_size'] = getattr(item.properties.cluster, 'cluster_size', None)
-            result['cluster']['default_database_name'] = getattr(item.properties.cluster, 'default_database_name', None)
+        cluster_obj = None
+        if hasattr(item, 'cluster') and getattr(item, 'cluster') is not None:
+            cluster_obj = getattr(item, 'cluster')
+        elif hasattr(item, 'properties') and hasattr(item.properties, 'cluster') and getattr(item.properties, 'cluster') is not None:
+            cluster_obj = getattr(item.properties, 'cluster')
+        if cluster_obj is not None:
+            cluster_size = getattr(cluster_obj, 'cluster_size', None)
+            if cluster_size is None:
+                cluster_size = getattr(cluster_obj, 'clusterSize', None)
+
+            default_db = getattr(cluster_obj, 'default_database_name', None)
+            if default_db is None:
+                default_db = getattr(cluster_obj, 'defaultDatabaseName', None)
+
+            result['cluster']['cluster_size'] = cluster_size
+            result['cluster']['default_database_name'] = default_db
 
         return result
 

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -882,18 +882,16 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
         self.results['state'] = response
         return self.results
 
-    def update_postgresqlflexibleserver(self, body, old_response):
+    def update_postgresqlflexibleserver(self, body):
         '''
         Updates PostgreSQL Flexible Server with the specified configuration.
         :return: deserialized PostgreSQL Flexible Server instance state dictionary
         '''
         self.log("Updating the PostgreSQL Flexible Server instance {0}".format(self.name))
         try:
-            response = self.postgresql_flexible_client.servers.begin_create_or_update(
-                resource_group_name=self.resource_group,
-                server_name=self.name,
-                parameters=body
-            )
+            response = self.postgresql_flexible_client.servers.begin_create_or_update(resource_group_name=self.resource_group,
+                                                                                      server_name=self.name,
+                                                                                      parameters=body)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -921,7 +921,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                 if update_flag:
                     changed = True
                     if not self.check_mode:
-                        response = self.update_postgresqlflexibleserver(self.update_parameters)
+                        response = self.update_postgresqlflexibleserver(self.update_parameters, old_response)
                     else:
                         response = old_response
                     if self.is_stop:
@@ -956,14 +956,18 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
 
         return self.results
 
-    def update_postgresqlflexibleserver(self, body):
+    def update_postgresqlflexibleserver(self, body, old_response):
         '''
         Updates PostgreSQL Flexible Server with the specified configuration.
         :return: deserialized PostgreSQL Flexible Server instance state dictionary
         '''
         self.log("Updating the PostgreSQL Flexible Server instance {0}".format(self.name))
         try:
-            # structure of parameters for update must be changed
+            for key in ['location', 'sku', 'storage', 'cluster', 'backup', 'high_availability',
+                        'maintenance_window', 'auth_config', 'identity', 'tags', 'version']:
+                if key not in body or body[key] is None:
+                    body[key] = old_response.get(key)
+
             response = self.postgresql_flexible_client.servers.begin_create_or_update(resource_group_name=self.resource_group,
                                                                                       server_name=self.name,
                                                                                       parameters=body)
@@ -1128,8 +1132,6 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             result['auth_config']['tenant_id'] = item.auth_config.tenant_id
         else:
             result['auth_config'] = None
-        if 'cluster' not in result or result['cluster'] is None:
-            result['cluster'] = {}
         cluster_obj = getattr(item, 'cluster', None)
         if cluster_obj is None and hasattr(item, 'properties'):
             cluster_obj = getattr(item.properties, 'cluster', None)

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -81,6 +81,7 @@ options:
             - '15'
             - '16'
             - '17'
+            - '18'
     fully_qualified_domain_name:
         description:
             - The fully qualified domain name of a server.
@@ -711,7 +712,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             ),
             version=dict(
                 type='str',
-                choices=['11', '12', '13', '14', '15', '16', '17']
+                choices=['11', '12', '13', '14', '15', '16', '17', '18']
             ),
             fully_qualified_domain_name=dict(
                 type='str',
@@ -841,14 +842,13 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                     response = self.create_postgresqlflexibleserver(self.parameters)
                     changed = True
                 else:
-                    # Compare updating fields only
                     update_fields = [
                         'sku', 'storage', 'cluster', 'backup', 'high_availability',
                         'maintenance_window', 'auth_config', 'identity', 'tags',
                         'version', 'network', 'availability_zone', 'create_mode'
                     ]
-                    desired = {k: v for k, v in self.parameters.items() if k in update_fields and v is not None}
-                    current = {k: v for k, v in old_response.items() if k in update_fields and v is not None}
+                    desired = {k: self.parameters.get(k) for k in update_fields}
+                    current = {k: old_response.get(k) for k in update_fields}
                     if not self.default_compare({}, desired, current, '', dict(compare=[])):
                         # Update (PUT)
                         response = self.update_postgresqlflexibleserver(self.parameters, old_response)
@@ -889,24 +889,6 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
         '''
         self.log("Updating the PostgreSQL Flexible Server instance {0}".format(self.name))
         try:
-            for key in ['location', 'sku', 'storage', 'cluster', 'backup', 'high_availability',
-                        'maintenance_window', 'auth_config', 'identity', 'tags', 'version',
-                        'network', 'availability_zone', 'create_mode']:
-                if key not in body or body[key] is None:
-                    body[key] = old_response.get(key)
-
-            # Guard immutable cluster default_database_name
-            old_cluster = old_response.get('cluster', {}) or {}
-            new_cluster = body.get('cluster', {}) or {}
-            if old_cluster.get('cluster_size') is not None:
-                if 'default_database_name' in new_cluster:
-                    if new_cluster['default_database_name'] and new_cluster['default_database_name'] != old_cluster.get('default_database_name'):
-                        self.fail("Changing 'cluster.default_database_name' is not supported after cluster creation.")
-
-            # Remove cluster block if server is not part of an elastic cluster
-            if old_response.get('cluster', {}).get('cluster_size') is None:
-                body.pop('cluster', None)
-
             response = self.postgresql_flexible_client.servers.begin_create_or_update(
                 resource_group_name=self.resource_group,
                 server_name=self.name,

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -847,8 +847,8 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                         'maintenance_window', 'auth_config', 'identity', 'tags',
                         'version', 'network', 'availability_zone', 'create_mode'
                     ]
-                    desired = {k: self.parameters.get(k) for k in update_fields}
-                    current = {k: old_response.get(k) for k in update_fields}
+                    desired = {k: v for k, v in self.parameters.items() if k in update_fields and v is not None}
+                    current = {k: v for k, v in old_response.items() if k in update_fields and v is not None}
                     if not self.default_compare({}, desired, current, '', dict(compare=[])):
                         # Update (PUT)
                         response = self.update_postgresqlflexibleserver(self.parameters, old_response)

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -851,7 +851,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                     current = {k: old_response.get(k) for k in update_fields}
                     if not self.default_compare({}, desired, current, '', dict(compare=[])):
                         # Update (PUT)
-                        response = self.update_postgresqlflexibleserver(self.parameters, old_response)
+                        response = self.update_postgresqlflexibleserver(self.parameters)
                         changed = True
                     else:
                         response = old_response

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -868,8 +868,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                     update_fields = [
                         'sku', 'storage', 'cluster', 'backup', 'high_availability',
                         'maintenance_window', 'auth_config', 'identity', 'tags',
-                        'version', 'network', 'availability_zone', 'create_mode'
-                    ]
+                        'version', 'network', 'availability_zone']
                     desired = {k: self.parameters.get(k) for k in update_fields}
                     current = {k: old_response.get(k) for k in update_fields}
                     if not self.default_compare({}, desired, current, '', dict(compare=[])):

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2024 xuzhang3 (@xuzhang3), Fred-sun (@Fred-sun)
+# Copyright (c) 2024 xuzhang3 (@xuzhang3), Fred-sun (@Fred-sun), zunyangc (@zunyangc)
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -147,6 +147,9 @@ options:
                 description:
                     - Indicates whether custom window is enabled or disabled.
                 type: str
+                choices:
+                    - Enabled
+                    - Disabled
             start_hour:
                 description:
                     - Start hour for maintenance window.
@@ -168,6 +171,20 @@ options:
         description:
             - Availability zone information of the server
         type: str
+    cluster:
+        description:
+            - The elastic cluster properties of a server.
+        type: dict
+        suboptions:
+            cluster_size:
+                description:
+                    - The number of instances in the cluster.
+                type: int
+                required: True
+            default_database_name:
+                description:
+                    - The default database name for the cluster.
+                type: str
     create_mode:
         description:
             - The mode to create a new PostgreSQL server.
@@ -304,6 +321,34 @@ EXAMPLES = '''
     availability_zone: 1
     create_mode: Default
 
+- name: Create (or update) PostgreSQL Elastic Cluster with 3 nodes
+  azure_rm_postgresqlflexibleserver:
+    resource_group: myResourceGroup
+    name: testserver
+    sku:
+      name: Standard_B1ms
+      tier: Burstable
+    administrator_login: azureuser
+    administrator_login_password: "{{ password }}"
+    version: 17  # PostgreSQL version 17 for flexible server
+    storage:
+      storage_size_gb: 128
+    fully_qualified_domain_name: st-private-dns-zone.postgres.database.azure.com
+    backup:
+      backup_retention_days: 7
+      geo_redundant_backup: Disabled
+    maintenance_window:
+      custom_window: Enabled
+      start_hour: 8
+      start_minute: 0
+      day_of_week: 0
+    cluster:
+      cluster_size: 3
+      default_database_name: "myclusterdb"
+    point_in_time_utc: 2023-05-31T00:28:17.7279547+00:00
+    availability_zone: 1
+    create_mode: Default
+
 - name: Delete PostgreSQL Flexible Server
   azure_rm_postgresqlflexibleserver:
     resource_group: myResourceGroup
@@ -400,6 +445,24 @@ servers:
             type: str
             returned: always
             sample: 1
+        cluster:
+            description:
+                - The elastic cluster properties of a server.
+            type: complex
+            returned: always
+            contains:
+                cluster_size:
+                    description:
+                    - The number of instances in the cluster.
+                    type: int
+                    returned: always
+                    sample: 3
+                default_database_name:
+                    description:
+                    - The default database name for the cluster.
+                    type: str
+                    returned: always
+                    sample: mydb
         backup:
             description:
                 - Backup properties of a server.
@@ -576,7 +639,7 @@ sku_spec = dict(
 
 
 maintenance_window_spec = dict(
-    custom_window=dict(type='str'),
+    custom_window=dict(type='str', choices=["Enabled", "Disabled"]),
     start_hour=dict(type='int'),
     start_minute=dict(type='int'),
     day_of_week=dict(type='int'),
@@ -679,6 +742,13 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             availability_zone=dict(
                 type='str'
             ),
+            cluster=dict(
+                type='dict',
+                options=dict(
+                    cluster_size=dict(type='int', required=True),
+                    default_database_name=dict(type='str'),
+                )
+            ),
             create_mode=dict(
                 type='str',
                 choices=['Default', 'Create', 'Update', 'PointInTimeRestore']
@@ -750,8 +820,8 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                 setattr(self, key, kwargs[key])
             elif kwargs[key] is not None:
                 self.parameters[key] = kwargs[key]
-                for key in ['location', 'sku', 'administrator_login_password', 'storage', 'backup',
-                            'high_availability', 'maintenance_window', 'create_mode', 'auth_config']:
+                for key in ['location', 'sku', 'administrator_login_password', 'storage', 'cluster',
+                            'backup', 'high_availability', 'maintenance_window', 'auth_config']:
                     self.update_parameters[key] = kwargs[key]
 
         old_response = None
@@ -799,6 +869,14 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                     update_flag = True
                 else:
                     self.update_parameters['storage'] = old_response['storage']
+
+                if self.update_parameters.get('cluster') is not None:
+                    for key in self.update_parameters['cluster'].keys():
+                        if (self.update_parameters['cluster'][key] is not None) and\
+                                (self.update_parameters['cluster'][key] != old_response['cluster'].get(key)):
+                            update_flag = True
+                        else:
+                            self.update_parameters['cluster'][key] = old_response['cluster'].get(key)
 
                 if self.update_parameters.get('backup') is not None:
                     for key in self.update_parameters['backup'].keys():
@@ -886,14 +964,14 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
         self.log("Updating the PostgreSQL Flexible Server instance {0}".format(self.name))
         try:
             # structure of parameters for update must be changed
-            response = self.postgresql_flexible_client.servers.begin_update(resource_group_name=self.resource_group,
-                                                                            server_name=self.name,
-                                                                            parameters=body)
+            response = self.postgresql_flexible_client.servers.begin_create_or_update(resource_group_name=self.resource_group,
+                                                                                      server_name=self.name,
+                                                                                      parameters=body)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 
         except Exception as exc:
-            self.log('Error attempting to create the PostgreSQL Flexible Server instance.')
+            self.log('Error attempting to update the PostgreSQL Flexible Server instance.')
             self.fail("Error updating the PostgreSQL Flexible Server instance: {0}".format(str(exc)))
         return self.format_item(response)
 
@@ -904,9 +982,9 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
         '''
         self.log("Creating the PostgreSQL Flexible Server instance {0}".format(self.name))
         try:
-            response = self.postgresql_flexible_client.servers.begin_create(resource_group_name=self.resource_group,
-                                                                            server_name=self.name,
-                                                                            parameters=body)
+            response = self.postgresql_flexible_client.servers.begin_create_or_update(resource_group_name=self.resource_group,
+                                                                                      server_name=self.name,
+                                                                                      parameters=body)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 
@@ -982,7 +1060,7 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             response = self.postgresql_flexible_client.servers.get(resource_group_name=self.resource_group,
                                                                    server_name=self.name)
             self.log("Response : {0}".format(response))
-            self.log("PostgreSQL Flexible Server instance : {0} found".format(response.name))
+            self.log("PostgreSQL Flexible Server instance : {0} found".format(self.name))
         except ResourceNotFoundError as e:
             self.log('Did not find the PostgreSQL Flexible Server instance. Exception as {0}'.format(str(e)))
             return None
@@ -1010,7 +1088,8 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             source_server_resource_id=item.source_server_resource_id,
             point_in_time_utc=item.point_in_time_utc,
             availability_zone=item.availability_zone,
-            auth_config=dict()
+            auth_config=dict(),
+            cluster=dict()
         )
         if item.sku is not None:
             result['sku']['name'] = item.sku.name
@@ -1049,6 +1128,9 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             result['auth_config']['tenant_id'] = item.auth_config.tenant_id
         else:
             result['auth_config'] = None
+        if hasattr(item, 'properties') and hasattr(item.properties, 'cluster'):
+            result['cluster']['cluster_size'] = getattr(item.properties.cluster, 'cluster_size', None)
+            result['cluster']['default_database_name'] = getattr(item.properties.cluster, 'default_database_name', None)
 
         return result
 

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -830,6 +830,20 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
 
         old_response = self.get_postgresqlflexibleserver()
 
+        update_identity = False
+
+        if self.identity:
+            # Get current identity from old_response
+            curr_identity = old_response.get('identity') if old_response else {}
+            update_identity, new_identity = self.update_managed_identity(
+                new_identity=self.identity,
+                curr_identity=curr_identity,
+                allow_identities_append=True,
+                patch_support=False
+            )
+            if update_identity:
+                self.parameters['identity'] = new_identity
+
         current_tags = old_response.get('tags') if old_response else None
         if self.tags is not None:
             try:
@@ -848,10 +862,6 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             if not self.check_mode:
                 if not old_response:
                     # Create
-                    if self.identity:
-                        update_identity, new_identity = self.update_managed_identity(new_identity=self.identity)
-                        if update_identity:
-                            self.parameters['identity'] = new_identity
                     response = self.create_postgresqlflexibleserver(self.parameters)
                     changed = True
                 else:

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -967,6 +967,9 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
                         'maintenance_window', 'auth_config', 'identity', 'tags', 'version']:
                 if key not in body or body[key] is None:
                     body[key] = old_response.get(key)
+            # Remove cluster block if server is not part of an elastic cluster
+            if old_response.get('cluster', {}).get('cluster_size') is None:
+                body.pop('cluster', None)
 
             response = self.postgresql_flexible_client.servers.begin_create_or_update(resource_group_name=self.resource_group,
                                                                                       server_name=self.name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp>=3.13.0
 azure-cli-core==2.75.0
 azure-common==1.1.28
 azure-containerregistry==1.2.0
-azure-core==1.31.0
+azure-core==1.33.0
 azure-eventhub==5.15.0
 azure-identity==1.19.0
 azure-iot-hub==2.6.1
@@ -17,7 +17,7 @@ azure-mgmt-compute==33.0.0
 azure-mgmt-containerinstance==10.1.0
 azure-mgmt-containerregistry==10.3.0
 azure-mgmt-containerservice==32.1.0
-azure-mgmt-core==1.4.0
+azure-mgmt-core==1.6.0
 azure-mgmt-cosmosdb==10.0.0b3
 azure-mgmt-datafactory==9.0.0
 azure-mgmt-devtestlabs==10.0.0b2
@@ -35,7 +35,7 @@ azure-mgmt-mysqlflexibleservers==1.0.0b3
 azure-mgmt-network==28.0.0
 azure-mgmt-notificationhubs==8.1.0b1
 azure-mgmt-nspkg==3.0.2
-azure-mgmt-postgresqlflexibleservers==1.1.0
+azure-mgmt-postgresqlflexibleservers==2.0.0
 azure-mgmt-privatedns==1.2.0
 azure-mgmt-rdbms==10.2.0b17
 azure-mgmt-recoveryservices==3.0.0

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -109,6 +109,11 @@
           - output.state.identity.type == 'UserAssigned'
           - managed_identity_ids[0] in output.state.identity.user_assigned_identities
 
+    - name: Wait for 3 minutes to allow Azure resource state to stabilise
+      ansible.builtin.pause:
+        minutes: 3
+      changed_when: false
+
     - name: Create postgresql flexible server (Idempotent Test)
       azure.azcollection.azure_rm_postgresqlflexibleserver:
         resource_group: "{{ new_resource_group }}"

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -218,6 +218,48 @@
         that:
           - output.state.identity.type == 'None'
 
+    - name: Create postgresql elastic cluster
+      azure.azcollection.azure_rm_postgresqlflexibleserver:
+        resource_group: "{{ new_resource_group }}"
+        name: postflexible{{ rpfx }}
+        sku:
+          name: Standard_D2s_v3
+          tier: GeneralPurpose
+        administrator_login: azureuser
+        administrator_login_password: "{{ password }}"
+        version: 17
+        storage:
+          storage_size_gb: 128
+        backup:
+          backup_retention_days: 7
+          geo_redundant_backup: Disabled
+        network:
+          public_network_access: Disabled
+        maintenance_window:
+          custom_window: Enabled
+          start_hour: 8
+          start_minute: 4
+          day_of_week: 3
+        availability_zone: 2
+        cluster:
+          cluster_size: 3
+          default_database_name: "myclusterdb"
+        create_mode: Default
+        identity:
+          type: UserAssigned
+          user_assigned_identities:
+            id:
+              - "{{ managed_identity_ids[0] }}"
+        state: present
+      register: elastic_cluster_create
+
+    - name: Assert the postgresql elastic cluster is well created
+      ansible.builtin.assert:
+        that:
+          - elastic_cluster_create is changed
+          - elastic_cluster_create.state.cluster.cluster_size == 3
+          - elastic_cluster_create.state.cluster.default_database_name == 'myclusterdb'
+
     - name: Create a postgresql flexible database(check mode)
       azure.azcollection.azure_rm_postgresqlflexibledatabase:
         resource_group: "{{ new_resource_group }}"

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -109,11 +109,6 @@
           - output.state.identity.type == 'UserAssigned'
           - managed_identity_ids[0] in output.state.identity.user_assigned_identities
 
-    - name: Wait for 3 minutes to allow Azure resource state to stabilise
-      ansible.builtin.pause:
-        minutes: 3
-      changed_when: false
-
     - name: Create postgresql flexible server (Idempotent Test)
       azure.azcollection.azure_rm_postgresqlflexibleserver:
         resource_group: "{{ new_resource_group }}"

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -46,7 +46,7 @@
         version: 12
         storage:
           storage_size_gb: 128
-        fully_qualified_domain_name: st-private-dns-zone.postgres.database.azure.com
+        fully_qualified_domain_name: "st-private-dns-zone.postgres.database.azure.com"
         backup:
           backup_retention_days: 7
           geo_redundant_backup: Disabled
@@ -78,7 +78,7 @@
         version: 12
         storage:
           storage_size_gb: 128
-        fully_qualified_domain_name: st-private-dns-zone.postgres.database.azure.com
+        fully_qualified_domain_name: "st-private-dns-zone.postgres.database.azure.com"
         backup:
           backup_retention_days: 7
           geo_redundant_backup: Disabled
@@ -121,7 +121,7 @@
         version: 12
         storage:
           storage_size_gb: 128
-        fully_qualified_domain_name: st-private-dns-zone.postgres.database.azure.com
+        fully_qualified_domain_name: "st-private-dns-zone.postgres.database.azure.com"
         backup:
           backup_retention_days: 7
           geo_redundant_backup: Disabled
@@ -158,7 +158,7 @@
         version: 12
         storage:
           storage_size_gb: 256
-        fully_qualified_domain_name: st-private-dns-zone.postgres.database.azure.com
+        fully_qualified_domain_name: "st-private-dns-zone.postgres.database.azure.com"
         backup:
           backup_retention_days: 7
           geo_redundant_backup: Disabled

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -133,7 +133,7 @@
           start_minute: 4
           day_of_week: 3
         availability_zone: 2
-        # create_mode: Create  <- Azure do not store create_mode after server has been created
+        create_mode: Create
         identity:
           type: UserAssigned
           user_assigned_identities:
@@ -170,7 +170,7 @@
           start_minute: 6
           day_of_week: 6
         availability_zone: 2
-        create_mode: Update
+        create_mode: Create
         tags:
           key1: value1
           key2: value2

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -221,7 +221,7 @@
     - name: Create postgresql elastic cluster
       azure.azcollection.azure_rm_postgresqlflexibleserver:
         resource_group: "{{ new_resource_group }}"
-        name: postflexible{{ rpfx }}
+        name: postflexible{{ rpfx }}-cluster
         sku:
           name: Standard_D2s_v3
           tier: GeneralPurpose
@@ -552,6 +552,18 @@
       register: output
 
     - name: Assert the postgresql server is well deleted
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Delete postgresql elastic cluster
+      azure.azcollection.azure_rm_postgresqlflexibleserver:
+        resource_group: "{{ new_resource_group }}"
+        name: postflexible{{ rpfx }}-cluster
+        state: absent
+      register: output
+
+    - name: Assert the postgresql elastic cluster is well deleted
       ansible.builtin.assert:
         that:
           - output is changed

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -138,7 +138,7 @@
           start_minute: 4
           day_of_week: 3
         availability_zone: 2
-        create_mode: Create
+        # create_mode: Create  <- Azure do not store create_mode after server has been created
         identity:
           type: UserAssigned
           user_assigned_identities:
@@ -175,7 +175,7 @@
           start_minute: 6
           day_of_week: 6
         availability_zone: 2
-        create_mode: Create
+        create_mode: Update
         tags:
           key1: value1
           key2: value2


### PR DESCRIPTION
##### SUMMARY
Added elastic cluster support, enabling users to create and manage Citus-backed elastic clusters on Azure Database for PostgreSQL Flexible Server. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_postgresqlflexibleserver
- requirements.txt
- tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml

##### ADDITIONAL INFORMATION
References:
- https://learn.microsoft.com/en-us/rest/api/postgresql/servers/update
- https://learn.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/flexibleservers
- https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-elastic-clusters
