### PR TITLE
Fix #1915: Update CI pipeline to include latest ansible-core

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -2,4 +2,3 @@
 skip_list:
   - yaml[line-length]
   - sanity[cannot-ignore]
-  - no-handler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.16
-          - stable-2.17
+          # - stable-2.16 # End Of Life July 2025 https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+          # - stable-2.17 # End Of Life Nov 2025
           - stable-2.18
+          - stable-2.19
+          - stable-2.20
           - devel
     runs-on: ubuntu-latest
     steps:

--- a/plugins/modules/azure_rm_eventhub_info.py
+++ b/plugins/modules/azure_rm_eventhub_info.py
@@ -39,7 +39,7 @@ author:
 
 EXAMPLES = '''
 - name: Get facts of specific Event hub
-  community.azure.azure_rm_eventhub_info:
+  azure.azcollection.azure_rm_eventhub_info:
     resource_group: myResourceGroup
     name: myEventHub
 '''

--- a/plugins/modules/azure_rm_expressroute_info.py
+++ b/plugins/modules/azure_rm_expressroute_info.py
@@ -43,7 +43,7 @@ author:
 
 EXAMPLES = '''
 - name: Get facts of specific expressroute
-  community.azure.azure_rm_expressroute_info:
+  azure.azcollection.azure_rm_expressroute_info:
     resource_group: myResourceGroup
     name: myExpressRoute
     tags:

--- a/plugins/modules/azure_rm_notificationhub_info.py
+++ b/plugins/modules/azure_rm_notificationhub_info.py
@@ -42,7 +42,7 @@ author:
 
 EXAMPLES = '''
 - name: Get facts of specific notification hub
-  community.azure.azure_rm_notificationhub_info:
+  azure.azcollection.azure_rm_notificationhub_info:
     resource_group: myResourceGroup
     name: myNotificationHub
 '''

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -13,9 +13,11 @@ parameters:
     type: string
     default: "2.18"
     values:
-      - "2.16" # End Of Life May 2025 https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-      - "2.17"
+      # - "2.16" # End Of Life July 2025 https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+      # - "2.17" # End Of Life Nov 2025
       - "2.18"
+      - "2.19"
+      - "2.20"
       - "devel"
   - name: MODULE_NAME
     displayName: 'Test Module'

--- a/tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdendpoint/tasks/main.yml
@@ -34,8 +34,8 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
-          - output.host_name
+          - output.id is defined
+          - output.host_name is defined
 
     - name: Update EndPoint (idempotent test)
       azure.azcollection.azure_rm_afdendpoint:
@@ -67,8 +67,8 @@
           - output.afdendpoints | length == 1
           - output.afdendpoints[0].auto_generated_domain_name_label_scope == 'TenantReuse'
           - output.afdendpoints[0].enabled_state == 'Enabled'
-          - output.afdendpoints[0].host_name
-          - output.afdendpoints[0].id
+          - output.afdendpoints[0].host_name is defined
+          - output.afdendpoints[0].id is defined
           - output.afdendpoints[0].profile_name == profile
           - output.afdendpoints[0].tags.test == 'tag value'
           - output is not changed

--- a/tests/integration/targets/azure_rm_afdorigin/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdorigin/tasks/main.yml
@@ -56,7 +56,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Update Origin (idempotent test)
       azure.azcollection.azure_rm_afdorigin:
@@ -94,7 +94,7 @@
           - output.afdorigins[0].host_name == '10.0.0.1'
           - output.afdorigins[0].http_port == 80
           - output.afdorigins[0].https_port == 443
-          - output.afdorigins[0].id
+          - output.afdorigins[0].id is defined
           - output.afdorigins[0].origin_host_header == '10.0.0.1'
           - output.afdorigins[0].priority == 1
           - output.afdorigins[0].weight == 123
@@ -119,7 +119,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Load Origin info for both
       azure.azcollection.azure_rm_afdorigin_info:

--- a/tests/integration/targets/azure_rm_afdorigingroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdorigingroup/tasks/main.yml
@@ -40,7 +40,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Update Origin Group (idempotent test)
       azure.azcollection.azure_rm_afdorigingroup:
@@ -85,7 +85,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Load info for all Origin Groups
       azure.azcollection.azure_rm_afdorigingroup_info:
@@ -111,7 +111,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Load Origin Group info
       azure.azcollection.azure_rm_afdorigingroup_info:

--- a/tests/integration/targets/azure_rm_afdroute/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdroute/tasks/main.yml
@@ -93,7 +93,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Update Route (idempotent test)
       azure.azcollection.azure_rm_afdroute:
@@ -119,7 +119,7 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.id
+          - output.id is defined
 
     - name: Load Route info
       azure.azcollection.azure_rm_afdroute_info:
@@ -134,7 +134,7 @@
         that:
           - output.afdroutes | length == 1
           - output.afdroutes[0].enabled_state == 'Enabled'
-          - output.afdroutes[0].id
+          - output.afdroutes[0].id is defined
           - output.afdroutes[0].rule_sets | length == 1
           - output is not changed
 
@@ -164,7 +164,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Update Route (idempotent test)
       azure.azcollection.azure_rm_afdroute:
@@ -192,7 +192,7 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.id
+          - output.id is defined
 
     - name: Delete Route
       azure.azcollection.azure_rm_afdroute:
@@ -208,7 +208,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Delete Route (idempotent test)
       azure.azcollection.azure_rm_afdroute:

--- a/tests/integration/targets/azure_rm_afdrules/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdrules/tasks/main.yml
@@ -63,7 +63,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Update Rule 1 (idempotent test)
       azure.azcollection.azure_rm_afdrules:
@@ -97,7 +97,7 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.id
+          - output.id is defined
 
     - name: Load Rule info
       azure.azcollection.azure_rm_afdrules_info:
@@ -113,7 +113,7 @@
           - output.afdrules | length == 1
           - output.afdrules[0].actions | length == 2
           - output.afdrules[0].conditions | length == 1
-          - output.afdrules[0].id
+          - output.afdrules[0].id is defined
           - output.afdrules[0].match_processing_behavior == "Continue"
           - output.afdrules[0].order == 1
           - output.afdrules[0].rule_set_name == "{{ ruleset }}"
@@ -132,7 +132,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Delete Rule (idempotent test)
       azure.azcollection.azure_rm_afdrules:

--- a/tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
@@ -84,7 +84,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id is none
+          - output.id is defined
 
     - name: Load info for all Rulesets
       azure.azcollection.azure_rm_afdruleset_info:

--- a/tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_afdruleset/tasks/main.yml
@@ -31,7 +31,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Update Ruleset (idempotent test)
       azure.azcollection.azure_rm_afdruleset:
@@ -58,7 +58,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Load info for all Rulesets
       azure.azcollection.azure_rm_afdruleset_info:
@@ -84,7 +84,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is none
 
     - name: Load info for all Rulesets
       azure.azcollection.azure_rm_afdruleset_info:

--- a/tests/integration/targets/azure_rm_aksagentpool/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aksagentpool/tasks/main.yml
@@ -196,7 +196,7 @@
         #   - 3
       register: output
 
-    - name: Assert the node agent pool udpated
+    - name: Assert the node agent pool updated
       ansible.builtin.assert:
         that:
           - output is changed

--- a/tests/integration/targets/azure_rm_aksagentpool/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aksagentpool/tasks/main.yml
@@ -127,8 +127,8 @@
         security_profile:
           enable_vtpm: true
           enable_secure_boot: true
-        availability_zones:
-          - 3
+        # availability_zones:  <- OverconstrainedZonalAllocationRequest
+        #   - 3
       register: output
 
     - name: Assert the node agent pool created
@@ -154,8 +154,8 @@
         security_profile:
           enable_vtpm: true
           enable_secure_boot: true
-        availability_zones:
-          - 3
+        # availability_zones:  <- OverconstrainedZonalAllocationRequest
+        #   - 3
       register: output
 
     - name: Assert the node agent pool not changed
@@ -192,8 +192,8 @@
         security_profile:
           enable_vtpm: false
           enable_secure_boot: false
-        availability_zones:
-          - 3
+        # availability_zones:  <- OverconstrainedZonalAllocationRequest
+        #   - 3
       register: output
 
     - name: Assert the node agent pool udpated
@@ -211,7 +211,7 @@
     - name: Assert node agent configuration
       ansible.builtin.assert:
         that:
-          - output.aks_agent_pools[0].availability_zones == [3]
+          # - output.aks_agent_pools[0].availability_zones == [3]
           - output.aks_agent_pools[0].min_count == 2
           - output.aks_agent_pools[0].max_count == 20
           - output.aks_agent_pools[0].type_properties_type == "VirtualMachineScaleSets"
@@ -237,8 +237,8 @@
         min_count: 1
         max_count: 10
         orchestrator_version: "{{ agentpool_version.azure_orchestrator_version[0] }}"
-        availability_zones:
-          - 3
+        # availability_zones:  <- OverconstrainedZonalAllocationRequest
+        #   - 3
         kubelet_disk_type: OS
         workload_runtime: OCIContainer
         os_sku: Ubuntu
@@ -281,8 +281,8 @@
         min_count: 1
         max_count: 10
         orchestrator_version: "{{ agentpool_version.azure_orchestrator_version[0] }}"
-        availability_zones:
-          - 3
+        # availability_zones:  <- OverconstrainedZonalAllocationRequest
+        #   - 3
         kubelet_disk_type: OS
         workload_runtime: OCIContainer
         os_sku: Ubuntu

--- a/tests/integration/targets/azure_rm_autoscale/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_autoscale/tasks/main.yml
@@ -109,7 +109,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Create auto scaling (idemponent)
       azure.azcollection.azure_rm_autoscale:
@@ -136,7 +136,7 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.id
+          - output.id is defined
 
     - name: Update auto scaling
       azure.azcollection.azure_rm_autoscale:

--- a/tests/integration/targets/azure_rm_autoscale/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_autoscale/tasks/main.yml
@@ -111,7 +111,7 @@
           - output is changed
           - output.id is defined
 
-    - name: Create auto scaling (idemponent)
+    - name: Create auto scaling (idempotent)
       azure.azcollection.azure_rm_autoscale:
         resource_group: "{{ resource_group }}-autoscale"
         name: "{{ name_rpfx }}"

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -30,7 +30,7 @@
         scope: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-gallery"
         assignee_object_id: "{{ object_id }}"
         role_definition_id: "/providers/Microsoft.Authorization/roleDefinitions/{{ az_role_definition_id }}"
-      register: az_role_assignment_create
+      register: az_role_assignment_create_by_id
       ignore_errors: true
 
     - name: Create first key vault
@@ -705,9 +705,9 @@
 
     - name: Delete Role Assignment by id
       azure.azcollection.azure_rm_roleassignment:
-        id: "{{ az_role_assignment_create.id }}"
+        id: "{{ az_role_assignment_create_by_id.id }}"
         state: absent
-      when: az_role_assignment_create is changed
+      # when: az_role_assignment_create is changed  <- no-handler error by ansible-lint
 
     - name: Delete the public IP address
       azure.azcollection.azure_rm_publicipaddress:

--- a/tests/integration/targets/azure_rm_image/tasks/azure_test_encrypted.yml
+++ b/tests/integration/targets/azure_rm_image/tasks/azure_test_encrypted.yml
@@ -36,7 +36,7 @@
   ansible.builtin.assert:
     that:
       - output is changed
-      - output.id
+      - output.id is defined
 
 - name: Create an image from VM (idempotent)
   azure.azcollection.azure_rm_image:
@@ -53,7 +53,7 @@
   ansible.builtin.assert:
     that:
       - output is not changed
-      - output.id
+      - output.id is defined
 
 - name: Gather information about image created
   azure.azcollection.azure_rm_image_info:

--- a/tests/integration/targets/azure_rm_image/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_image/tasks/main.yml
@@ -112,7 +112,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Create an image from VM (idempotent)
       azure.azcollection.azure_rm_image:
@@ -127,7 +127,7 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.id
+          - output.id is defined
 
     - name: Gather information about image created
       azure.azcollection.azure_rm_image_info:

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -147,7 +147,7 @@
     - name: Assert certificate facts
       ansible.builtin.assert:
         that:
-          - facts['certificates'][0]['name']
+          - facts['certificates'][0]['name'] is defined
           - facts['certificates'][0]['properties']['tags'] | length == 2
           - facts['certificates'][0]['properties']['attributes']['enabled'] is false
           - facts['certificates'][0]['policy']['validity_in_months'] == 38

--- a/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
@@ -52,7 +52,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state
+          - output.state is defined
 
     - name: Create new managed disk succesfully
       azure.azcollection.azure_rm_manageddisk:
@@ -347,7 +347,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state
+          - output.state is defined
 
     - name: Gather Resource Group info
       azure.azcollection.azure_rm_resourcegroup_info:
@@ -396,7 +396,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state
+          - output.state is defined
           - output.state.tags.testtag1 is not defined
           - output.state.tags.testtag2 == 'TestValue2'
 
@@ -413,7 +413,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state
+          - output.state is defined
           - output.state.tags.testtag1 is not defined
           - output.state.tags.testtag2 == 'TestValue2'
           - output.state.tags.TestTag3 == 'TestValue3'

--- a/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
@@ -54,7 +54,7 @@
           - output is changed
           - output.state is defined
 
-    - name: Create new managed disk succesfully
+    - name: Create new managed disk successfully
       azure.azcollection.azure_rm_manageddisk:
         resource_group: "{{ resource_group }}-manageddisk"
         name: "md{{ rpfx }}1"
@@ -319,7 +319,7 @@
         name: 'test{{ rpfx }}'
       register: access_output
 
-    - name: Create new managed disk succesfully
+    - name: Create new managed disk successfully
       azure.azcollection.azure_rm_manageddisk:
         resource_group: "{{ resource_group }}-manageddisk"
         name: "md{{ rpfx }}7"

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -126,8 +126,8 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state.id
-          - output.state.ip_configuration.primary
+          - output.state.id is defined
+          - output.state.ip_configuration.primary == True
 
     - name: Get fact of the new created NIC
       azure.azcollection.azure_rm_networkinterface_info:
@@ -507,7 +507,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id != ''
+          - output.id is defined
 
     - name: Get Application security group
       azure.azcollection.azure_rm_applicationsecuritygroup_info:

--- a/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
@@ -135,7 +135,7 @@
           - output.state.provisioning_state == 'Succeeded'
           - output.state.private_dns_zone_configs | length == 1
           - output.state.private_dns_zone_configs[0].name == 'default'
-          - output.state.private_dns_zone_configs[0].private_dns_zone_id
+          - output.state.private_dns_zone_configs[0].private_dns_zone_id is defined
           - output.state.private_dns_zone_configs[0].record_sets | length == 1
           - output.state.private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
           - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
@@ -143,7 +143,7 @@
           - output.state.private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
           - output.state.private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
           - output.state.private_dns_zone_configs[0].record_sets[0].record_type == 'A'
-          - output.state.private_dns_zone_configs[0].record_sets[0].ttl
+          - output.state.private_dns_zone_configs[0].record_sets[0].ttl is defined
 
     - name: Create zone group for private endpoint - idempotent
       azure.azcollection.azure_rm_privateendpointdnszonegroup:
@@ -175,7 +175,7 @@
           - output.groups[0].provisioning_state == 'Succeeded'
           - output.groups[0].private_dns_zone_configs | length == 1
           - output.groups[0].private_dns_zone_configs[0].name == 'default'
-          - output.groups[0].private_dns_zone_configs[0].private_dns_zone_id
+          - output.groups[0].private_dns_zone_configs[0].private_dns_zone_id is defined
           - output.groups[0].private_dns_zone_configs[0].record_sets | length == 1
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
@@ -183,7 +183,7 @@
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_type == 'A'
-          - output.groups[0].private_dns_zone_configs[0].record_sets[0].ttl
+          - output.groups[0].private_dns_zone_configs[0].record_sets[0].ttl is defined
 
     - name: Get all zone groups for private endpoint
       azure.azcollection.azure_rm_privateendpointdnszonegroup_info:
@@ -200,7 +200,7 @@
           - output.groups[0].provisioning_state == 'Succeeded'
           - output.groups[0].private_dns_zone_configs | length == 1
           - output.groups[0].private_dns_zone_configs[0].name == 'default'
-          - output.groups[0].private_dns_zone_configs[0].private_dns_zone_id
+          - output.groups[0].private_dns_zone_configs[0].private_dns_zone_id is defined
           - output.groups[0].private_dns_zone_configs[0].record_sets | length == 1
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
@@ -208,7 +208,7 @@
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
           - output.groups[0].private_dns_zone_configs[0].record_sets[0].record_type == 'A'
-          - output.groups[0].private_dns_zone_configs[0].record_sets[0].ttl
+          - output.groups[0].private_dns_zone_configs[0].record_sets[0].ttl is defined
 
     - name: Update zone group for private endpoint
       azure.azcollection.azure_rm_privateendpointdnszonegroup:
@@ -228,7 +228,7 @@
           - output.state.provisioning_state == 'Succeeded'
           - output.state.private_dns_zone_configs | length == 1
           - output.state.private_dns_zone_configs[0].name == 'default-updated'
-          - output.state.private_dns_zone_configs[0].private_dns_zone_id
+          - output.state.private_dns_zone_configs[0].private_dns_zone_id is defined
           - output.state.private_dns_zone_configs[0].record_sets | length == 1
           - output.state.private_dns_zone_configs[0].record_sets[0].fqdn == 'postgresqlsrv-{{ rpfx }}.privatelink.postgres.database.azure.com'
           - output.state.private_dns_zone_configs[0].record_sets[0].ip_addresses | length == 1
@@ -236,7 +236,7 @@
           - output.state.private_dns_zone_configs[0].record_sets[0].provisioning_state == 'Succeeded'
           - output.state.private_dns_zone_configs[0].record_sets[0].record_set_name == 'postgresqlsrv-{{ rpfx }}'
           - output.state.private_dns_zone_configs[0].record_sets[0].record_type == 'A'
-          - output.state.private_dns_zone_configs[0].record_sets[0].ttl
+          - output.state.private_dns_zone_configs[0].record_sets[0].ttl is defined
 
     - name: Delete zone group for private endpoint - check mode
       azure.azcollection.azure_rm_privateendpointdnszonegroup:

--- a/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpointdnszonegroup/tasks/main.yml
@@ -130,7 +130,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state.id
+          - output.state.id is defined
           - output.state.name == 'zone-group-{{ rpfx }}'
           - output.state.provisioning_state == 'Succeeded'
           - output.state.private_dns_zone_configs | length == 1
@@ -170,7 +170,7 @@
         that:
           - output is not changed
           - output.groups | length == 1
-          - output.groups[0].id
+          - output.groups[0].id is defined
           - output.groups[0].name == 'zone-group-{{ rpfx }}'
           - output.groups[0].provisioning_state == 'Succeeded'
           - output.groups[0].private_dns_zone_configs | length == 1
@@ -195,7 +195,7 @@
         that:
           - output is not changed
           - output.groups | length == 1
-          - output.groups[0].id
+          - output.groups[0].id is defined
           - output.groups[0].name == 'zone-group-{{ rpfx }}'
           - output.groups[0].provisioning_state == 'Succeeded'
           - output.groups[0].private_dns_zone_configs | length == 1
@@ -223,7 +223,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.state.id
+          - output.state.id is defined
           - output.state.name == 'zone-group-{{ rpfx }}'
           - output.state.provisioning_state == 'Succeeded'
           - output.state.private_dns_zone_configs | length == 1

--- a/tests/integration/targets/azure_rm_roleassignment/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_roleassignment/tasks/main.yml
@@ -110,7 +110,7 @@
         id: "/subscriptions/{{ az_resource_group.resourcegroups[0].id.split('/')[2] }}/resourceGroups/{{ resource_group | upper }}/providers/Microsoft.Authorization/roleAssignments/{{ uuid }}"
         assignee_object_id: "{{ az_role_assignments.roleassignments[0].principal_id }}"
         role_definition_id: "/subscriptions/{{ az_resource_group.resourcegroups[0].id.split('/')[2] }}/providers/Microsoft.Authorization/roleDefinitions/{{ az_role_definition_guid }}"
-      register: az_role_assignment_create
+      register: az_role_assignment_create_by_id
 
     - name: Create role assignment with name
       azure.azcollection.azure_rm_roleassignment:
@@ -168,10 +168,10 @@
 
     - name: Delete Role Assignment by id
       azure.azcollection.azure_rm_roleassignment:
-        id: "{{ az_role_assignment_create.id }}"
+        id: "{{ az_role_assignment_create_by_id.id }}"
         state: absent
       register: az_role_assignment_delete
-      when: az_role_assignment_create is changed
+      # when: az_role_assignment_create is changed  <- no-handler error by ansible-lint
 
     - name: Create role assignment with name
       azure.azcollection.azure_rm_roleassignment:
@@ -179,7 +179,7 @@
         assignee_object_id: "{{ az_role_assignments.roleassignments[0].principal_id }}"
         role_definition_id: "/subscriptions/{{ az_resource_group.resourcegroups[0].id.split('/')[2] }}/providers/Microsoft.Authorization/roleDefinitions/{{ az_role_definition_guid }}"
         name: "{{ uuid }}"
-      register: az_role_assignment_create
+      register: az_role_assignment_create_by_name
       ignore_errors: true
 
     - name: Delete Role by Name

--- a/tests/integration/targets/azure_rm_routetable/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_routetable/tasks/main.yml
@@ -23,7 +23,7 @@
     - name: Assert check mode
       ansible.builtin.assert:
         that:
-          - not output.id
+          - output.id is not defined
           - output is changed
 
     - name: Create a route table
@@ -38,7 +38,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Create a route table (idemponent)
       azure.azcollection.azure_rm_routetable:
@@ -79,7 +79,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - not output.id
+          - output.id is not defined
 
     - name: Create route
       azure.azcollection.azure_rm_route:
@@ -94,7 +94,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
 
     - name: Create route (idemponent)
       azure.azcollection.azure_rm_route:

--- a/tests/integration/targets/azure_rm_routetable/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_routetable/tasks/main.yml
@@ -23,7 +23,7 @@
     - name: Assert check mode
       ansible.builtin.assert:
         that:
-          - output.id is not defined
+          - output.id is none
           - output is changed
 
     - name: Create a route table
@@ -79,7 +79,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id is not defined
+          - output.id is none
 
     - name: Create route
       azure.azcollection.azure_rm_route:

--- a/tests/integration/targets/azure_rm_routetable/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_routetable/tasks/main.yml
@@ -96,7 +96,7 @@
           - output is changed
           - output.id is defined
 
-    - name: Create route (idemponent)
+    - name: Create route (idempotent)
       azure.azcollection.azure_rm_route:
         name: "{{ route_name }}"
         resource_group: "{{ resource_group }}-routetable"
@@ -171,7 +171,7 @@
         that:
           - output is changed
 
-    - name: Delete route (idemponent)
+    - name: Delete route (idempotent)
       azure.azcollection.azure_rm_route:
         name: "{{ route_name }}"
         resource_group: "{{ resource_group }}-routetable"
@@ -203,7 +203,7 @@
         that:
           - output is changed
 
-    - name: Delete route table (idemponent)
+    - name: Delete route table (idempotent)
       azure.azcollection.azure_rm_routetable:
         name: "{{ name_rpfx }}"
         resource_group: "{{ resource_group }}-routetable"

--- a/tests/integration/targets/azure_rm_routetable/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_routetable/tasks/main.yml
@@ -40,7 +40,7 @@
           - output is changed
           - output.id is defined
 
-    - name: Create a route table (idemponent)
+    - name: Create a route table (idempotent)
       azure.azcollection.azure_rm_routetable:
         name: "{{ name_rpfx }}"
         resource_group: "{{ resource_group }}-routetable"

--- a/tests/integration/targets/azure_rm_servicebus/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_servicebus/tasks/main.yml
@@ -46,9 +46,9 @@
     - name: Assert the namespace created
       ansible.builtin.assert:
         that:
-          - output.id
+          - output.id is defined
           - output is changed
-          - output.tags
+          - output.tags is defined
 
     - name: Create a namespace (idempontent)
       azure.azcollection.azure_rm_servicebus:
@@ -183,7 +183,7 @@
           key1: value1
       register: output
 
-    - name: Assert the service bus udpated
+    - name: Assert the service bus updated
       ansible.builtin.assert:
         that:
           - output is changed
@@ -217,7 +217,7 @@
     - name: Assert the queue created
       ansible.builtin.assert:
         that:
-          - queue.id
+          - queue.id is defined
           - queue is changed
 
     - name: Create a topic (check mode)
@@ -250,7 +250,7 @@
       ansible.builtin.assert:
         that:
           - output is changed
-          - output.id
+          - output.id is defined
           - "'subscription_count' not in output"
 
     - name: Create a topic (idempontent)
@@ -287,7 +287,7 @@
     - name: Assert the subscription created
       ansible.builtin.assert:
         that:
-          - subs.id
+          - subs.id is defined
           - subs is changed
 
     - name: Retrive topic
@@ -302,7 +302,7 @@
     - name: Assert the topic facts
       ansible.builtin.assert:
         that:
-          - "facts.servicebuses | length == 1"
+          - "facts.servicebuses | length == 1
           - facts.servicebuses[0].id == output.id
           - facts.servicebuses[0].subscription_count == 1
           - facts.servicebuses[0].sas_policies.testpolicy
@@ -329,7 +329,7 @@
       ansible.builtin.assert:
         that:
           - facts.servicebuses[0].subscription_count == 0
-          - "facts.servicebuses | length == 1"
+          - "facts.servicebuses | length == 1
 
     - name: Delete topic
       azure.azcollection.azure_rm_servicebustopic:
@@ -350,7 +350,7 @@
     - name: Assert the topic facts
       ansible.builtin.assert:
         that:
-          - "facts.servicebuses | length == 0"
+          - "facts.servicebuses | length == 0
 
     - name: Delete queue
       azure.azcollection.azure_rm_servicebusqueue:

--- a/tests/integration/targets/azure_rm_servicebus/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_servicebus/tasks/main.yml
@@ -302,10 +302,10 @@
     - name: Assert the topic facts
       ansible.builtin.assert:
         that:
-          - "facts.servicebuses | length == 1
+          - facts.servicebuses | length == 1
           - facts.servicebuses[0].id == output.id
           - facts.servicebuses[0].subscription_count == 1
-          - facts.servicebuses[0].sas_policies.testpolicy
+          - facts.servicebuses[0].sas_policies.testpolicy is defined
           - facts.servicebuses[0].sas_policies.testpolicy.rights == 'manage'
 
     - name: Delete subscription
@@ -329,7 +329,7 @@
       ansible.builtin.assert:
         that:
           - facts.servicebuses[0].subscription_count == 0
-          - "facts.servicebuses | length == 1
+          - facts.servicebuses | length == 1
 
     - name: Delete topic
       azure.azcollection.azure_rm_servicebustopic:
@@ -350,7 +350,7 @@
     - name: Assert the topic facts
       ansible.builtin.assert:
         that:
-          - "facts.servicebuses | length == 0
+          - facts.servicebuses | length == 0
 
     - name: Delete queue
       azure.azcollection.azure_rm_servicebusqueue:

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -923,7 +923,7 @@
         managed_identity_unique: "{{ item }}"
         managed_identity_action: 'delete'
         managed_identity_location: "{{ location }}"
-        resource_group: "{{ resource_group }}-webapp01"
+        new_resource_group: "{{ resource_group }}-webapp01"
       with_items:
         - '1'
         - '2'

--- a/tests/integration/targets/azure_rm_webapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webapp/tasks/main.yml
@@ -923,7 +923,7 @@
         managed_identity_unique: "{{ item }}"
         managed_identity_action: 'delete'
         managed_identity_location: "{{ location }}"
-        new_resource_group: "{{ resource_group }}-webapp01"
+        resource_group: "{{ resource_group }}-webapp01"
       with_items:
         - '1'
         - '2'

--- a/tests/integration/targets/azure_rm_workspace/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_workspace/tasks/main.yml
@@ -47,7 +47,7 @@
           - output is changed
           - output.intelligence_packs | length > 0
 
-    - name: Create workspace (idempontent)
+    - name: Create workspace (idempotent)
       azure.azcollection.azure_rm_loganalyticsworkspace:
         name: "{{ name_rpfx }}"
         resource_group: "{{ resource_group }}-workspace"

--- a/tests/integration/targets/azure_rm_workspace/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_workspace/tasks/main.yml
@@ -45,7 +45,7 @@
         that:
           - output.retention_in_days == 40
           - output is changed
-          - output.intelligence_packs
+          - output.intelligence_packs | length > 0
 
     - name: Create workspace (idempontent)
       azure.azcollection.azure_rm_loganalyticsworkspace:

--- a/tests/integration_common_tasks/managed_identity.yml
+++ b/tests/integration_common_tasks/managed_identity.yml
@@ -1,11 +1,16 @@
 ---
+- name: Normalize RG & subscription for managed identity ops
+  ansible.builtin.set_fact:
+    mi_rg: "{{ new_resource_group | default(resource_group) }}"
+    mi_sub: "{{ azure_subscription_id | default(lookup('env', 'AZURE_SUBSCRIPTION_ID')) }}"
+
 - name: Set user managed identity name
   ansible.builtin.set_fact:
     identity_name: "ansible-test-{{ managed_identity_test_unique }}-identity-{{ managed_identity_unique }}"
 
 - name: Set user managed identity ID base path
   ansible.builtin.set_fact:
-    base_path: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}"
+    base_path: "/subscriptions/{{ mi_sub }}/resourceGroups/{{ mi_rg }}"
 
 - name: Set user managed identity ID
   ansible.builtin.set_fact:
@@ -18,7 +23,7 @@
 
 - name: Create the user managed identity - {{ identity_name }}
   azure.azcollection.azure_rm_resource:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ mi_rg }}"
     provider: ManagedIdentity
     resource_type: userAssignedIdentities
     resource_name: "{{ identity_name }}"
@@ -31,7 +36,7 @@
 - name: Lookup service principal object id for identity {{ identity_name }}
   azure.azcollection.azure_rm_resource_info:
     api_version: "2023-01-31"
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ mi_rg }}"
     provider: ManagedIdentity
     resource_type: userAssignedIdentities
     resource_name: "{{ identity_name }}"
@@ -49,7 +54,7 @@
 
 - name: Destroy the user managed identity - {{ identity_name }}
   azure.azcollection.azure_rm_resource:
-    resource_group: "{{ resource_group }}"
+    resource_group: "{{ mi_rg }}"
     provider: ManagedIdentity
     resource_type: userAssignedIdentities
     resource_name: "{{ identity_name }}"

--- a/tests/integration_common_tasks/managed_identity.yml
+++ b/tests/integration_common_tasks/managed_identity.yml
@@ -10,7 +10,7 @@
 
 - name: Set user managed identity ID base path
   ansible.builtin.set_fact:
-    base_path: "/subscriptions/{{ mi_sub }}/resourceGroups/{{ mi_rg }}"
+    base_path: "/subscriptions/{{ mi_sub }}/resourcegroups/{{ mi_rg }}"
 
 - name: Set user managed identity ID
   ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY
No functionality changes.
Fix #1915. 
- Updates the CI pipeline configuration to support the latest ansible-core versions (2.19 and 2.20) while phasing out older versions (2.16 and 2.17) that have reached their end of life.
- Fix integration tests to meet the requirements of ansible-core and ansible-lint (removed `no-handler`)
- Fix typos