### PR TITLE
Optimize ADO CI pipeline: Redistribute AFD tests

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -489,7 +489,7 @@ class AzureRMModuleBase(object):
         # self.debug = self.module.params.get('debug')
 
         # delegate auth to AzureRMAuth class (shared with all plugin types)
-        self.azure_auth = AzureRMAuth(fail_impl=self.fail, is_ad_resource=is_ad_resource, **self.module.params)
+        self.azure_auth = AzureRMAuth(module=self.module, fail_impl=self.fail, is_ad_resource=is_ad_resource, **self.module.params)
 
         # common parameter validation
         if self.module.params.get('tags'):
@@ -1606,8 +1606,9 @@ class AzureRMAuth(object):
                  tenant=None, ad_user=None, password=None, cloud_environment='AzureCloud', cert_validation_mode='validate',
                  api_profile='latest', adfs_authority_url=None, fail_impl=None, is_ad_resource=False,
                  x509_certificate_path=None, thumbprint=None, track1_cred=False,
-                 disable_instance_discovery=False, **kwargs):
+                 disable_instance_discovery=False, module=None, **kwargs):
 
+        self.module = module
         if fail_impl:
             self._fail_impl = fail_impl
         else:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -304,7 +304,6 @@ from base64 import b64encode, b64decode
 from hashlib import sha256
 from hmac import HMAC
 from time import time
-import subprocess
 
 try:
     from urllib import (urlencode, quote_plus)

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1819,13 +1819,21 @@ class AzureRMAuth(object):
         if not subscription_id:
             try:
                 cmd = ["az", "account", "show", "--query", "id", "-o", "json"]
-                subscription_id = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip().strip('"')
+                # subscription_id = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip().strip('"')
+                rc, out, err = self.module.run_command(cmd)
+                if rc != 0:
+                    raise Exception(err)
+                subscription_id = out.strip().strip('"')
             except Exception as ec:
                 raise CLIError("Obtain the az login's subscription occurred exception as {0}".format(ec))
 
         try:
             cmd = ["az", "cloud", "show", "--query", "name", "-o", "json"]
-            cloud_name = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip().strip('"')
+            # cloud_name = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip().strip('"')
+            rc, out, err = self.module.run_command(cmd)
+            if rc != 0:
+                raise Exception(err)
+            cloud_name = out.strip().strip('"')
             all_clouds = [x[1] for x in inspect.getmembers(azure_cloud) if isinstance(x[1], azure_cloud.Cloud)]
             matched_clouds = [x for x in all_clouds if x.name == cloud_name]
         except Exception as ec:

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -265,13 +265,13 @@ jobs:
           test.key: '14'
         "Python${{ parameters.PYTHON_VER }}_15":
           test.key: '15'
-        "Python${{ parameters.PYTHON_VER }}_15":
+        "Python${{ parameters.PYTHON_VER }}_16":
           test.key: '16'
-        "Python${{ parameters.PYTHON_VER }}_15":
+        "Python${{ parameters.PYTHON_VER }}_17":
           test.key: '17'
-        "Python${{ parameters.PYTHON_VER }}_15":
+        "Python${{ parameters.PYTHON_VER }}_18":
           test.key: '18'
-        "Python${{ parameters.PYTHON_VER }}_15":
+        "Python${{ parameters.PYTHON_VER }}_19":
           test.key: '19'
 
     steps:

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -265,6 +265,14 @@ jobs:
           test.key: '14'
         "Python${{ parameters.PYTHON_VER }}_15":
           test.key: '15'
+        "Python${{ parameters.PYTHON_VER }}_15":
+          test.key: '16'
+        "Python${{ parameters.PYTHON_VER }}_15":
+          test.key: '17'
+        "Python${{ parameters.PYTHON_VER }}_15":
+          test.key: '18'
+        "Python${{ parameters.PYTHON_VER }}_15":
+          test.key: '19'
 
     steps:
       - task: UsePythonVersion@0

--- a/tests/integration/targets/azure_rm_afdendpoint/aliases
+++ b/tests/integration/targets/azure_rm_afdendpoint/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-shippable/azure/group6
+shippable/azure/group16

--- a/tests/integration/targets/azure_rm_afdorigin/aliases
+++ b/tests/integration/targets/azure_rm_afdorigin/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-shippable/azure/group6
+shippable/azure/group17

--- a/tests/integration/targets/azure_rm_afdorigingroup/aliases
+++ b/tests/integration/targets/azure_rm_afdorigingroup/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-shippable/azure/group6
+shippable/azure/group17

--- a/tests/integration/targets/azure_rm_afdroute/aliases
+++ b/tests/integration/targets/azure_rm_afdroute/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-shippable/azure/group6
+shippable/azure/group18

--- a/tests/integration/targets/azure_rm_afdrules/aliases
+++ b/tests/integration/targets/azure_rm_afdrules/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-shippable/azure/group6
+shippable/azure/group19

--- a/tests/integration/targets/azure_rm_afdruleset/aliases
+++ b/tests/integration/targets/azure_rm_afdruleset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-shippable/azure/group6
+shippable/azure/group19

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -56,9 +56,6 @@
         address_prefixes_cidr:
           - 10.1.0.0/16
           - 172.100.0.0/16
-        dns_servers:
-          - 127.0.0.1
-          - 127.0.0.2
       register: vnet_output
     - name: Create a subnet
       azure.azcollection.azure_rm_subnet:
@@ -1112,12 +1109,10 @@
             url_path_maps:
               - "path_mappings"
       register: output
-
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
           - output is changed
-
 
     - name: Try to create v2 instance of Application Gateway with autoscale configuration and trusted root certificates - no update
       azure.azcollection.azure_rm_appgateway:
@@ -1283,7 +1278,6 @@
             url_path_maps:
               - "path_mappings"
       register: output
-
     - name: Assert the resource instance is not updated
       ansible.builtin.assert:
         that:
@@ -1515,7 +1509,6 @@
           firewall_policy:
             name: "wafpolicy{{ rpfx }}"
       register: output
-
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
@@ -1684,7 +1677,6 @@
           firewall_policy:
             name: "wafpolicy{{ rpfx }}"
       register: output
-
     - name: Assert the resource instance is not updated
       ansible.builtin.assert:
         that:
@@ -1853,7 +1845,6 @@
           firewall_policy:
             name: "wafpolicy{{ rpfx }}"
       register: output
-
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
@@ -2015,7 +2006,6 @@
           firewall_policy:
             name: "wafpolicy{{ rpfx }}"
       register: output
-
     - name: Assert the resource instance is not updated
       ansible.builtin.assert:
         that:

--- a/tests/integration/targets/azure_rm_webappaccessrestriction/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webappaccessrestriction/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Create a new resource group for webapp access restriction test
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}-webappaccessrestriction"
-    location: eastus2
+    location: westus2
 
 - name: For webapp access restriction test
   block:

--- a/tests/integration/targets/azure_rm_webappvnetconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_webappvnetconnection/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Create a new resource group for webapp vnet connection test
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}-webappvnetconnection"
-    location: eastus2
+    location: westus2
 
 - name: For webapp vnet connection test
   block:


### PR DESCRIPTION
##### SUMMARY
No functionality change. To reduce overall CI pipeline duration. To fix latest pylint-issue on `subprocess.run`

##### ADDITIONAL INFORMATION
- Add new test groups (16, 17, 18, 19) to `pr-pipelines` for parallel execution
- Move AFD-related test targets (`afdendpoint`, `afdorigin`, `afdorigingroup`, `afdroutes`, `afdrules`, `afdruleset`) to new groups for better load balancing
- Update `azure_rm_webappaccessrestriction` and `azure_rm_webappvnetconnection` test regions to `westus2` to avoid quota issues
- Remove `dns_server` in `azure_rm_appgateway` test to reduce the task duration for deleting app gateway.
- Replacing `subprocess.run` by `module.run_command` to fix sanity error on `devel` pylint check.


References: https://learn.microsoft.com/en-us/azure/frontdoor/front-door-faq#what-is-the-estimated-time-for-deploying-an-azure-front-door--does-my-front-door-remain-operational-during-the-update-process-