### PR TITLE
Remove azure-iot-hub from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ azure-containerregistry==1.2.0
 azure-core==1.38.0
 azure-eventhub==5.15.0
 azure-identity==1.19.0
-azure-iot-hub==2.6.1
 azure-keyvault==4.2.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-apimanagement==4.0.1


### PR DESCRIPTION
##### SUMMARY
Removed azure-iot-hub dependency from requirements.

Fixes #1511.
Resubmission of https://github.com/ansible-collections/azure/pull/1512

`azure-iot-hub` has a dependency on a deprecated package `azure-uamqp-python` that prevents builds on ARM. No updates has been made to the packages since this was raised almost two years ago so requesting again to remove this non-core package to unblock builds on ARM.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
