### PR TITLE
HCI improve calls

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -543,9 +543,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._enqueue_get(url=next_link, api_version=self._hybridcompute_api_version, handler=self._on_archcivm_page_response)
 
         for archcivm in response['value']:
-            url = '{0}/providers/Microsoft.AzureStackHCI/virtualMachineInstances'.format(archcivm['id'])
-            # Stack HCI instances look close enough to regular VMs that we can share the handler impl...
-            self._enqueue_get(url=url, api_version=self._stackhci_api_version, handler=self._on_vm_page_response, handler_args=dict(archcivm=archcivm))
+            if archcivm.get('kind') == 'HCI':
+                url = '{0}/providers/Microsoft.AzureStackHCI/virtualMachineInstances'.format(archcivm['id'])
+                # Stack HCI instances look close enough to regular VMs that we can share the handler impl...
+                self._enqueue_get(url=url, api_version=self._stackhci_api_version, handler=self._on_vm_page_response, handler_args=dict(archcivm=archcivm))
 
     def _on_vmss_page_response(self, response):
         next_link = response.get('nextLink')

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -371,14 +371,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         url = url.format(subscriptionId=self._clientconfig.subscription_id, rg=rg)
         self._enqueue_get(url=url, api_version=self._hybridcompute_api_version, handler=self._on_arc_page_response)
 
-    def _enqueue_arcvm_list(self, rg='*'):
+    def _enqueue_archcivm_list(self, rg='*'):
         if not rg or rg == '*':
             url = '/subscriptions/{subscriptionId}/providers/Microsoft.HybridCompute/machines'
         else:
             url = '/subscriptions/{subscriptionId}/resourceGroups/{rg}/providers/Microsoft.HybridCompute/machines'
 
         url = url.format(subscriptionId=self._clientconfig.subscription_id, rg=rg)
-        self._enqueue_get(url=url, api_version=self._hybridcompute_api_version, handler=self._on_arcvm_page_response)
+        self._enqueue_get(url=url, api_version=self._hybridcompute_api_version, handler=self._on_archcivm_page_response)
 
     def _enqueue_vmss_list(self, rg=None):
         if not rg or rg == '*':
@@ -401,7 +401,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._enqueue_arc_list(arc_rg)
 
         for vm_rg in self.get_option('include_hcivm_resource_groups'):
-            self._enqueue_arcvm_list(vm_rg)
+            self._enqueue_archcivm_list(vm_rg)
 
         if os.environ.get('ANSIBLE_AZURE_VMSS_RESOURCE_GROUPS'):
             for vmss_rg in os.environ['ANSIBLE_AZURE_VMSS_RESOURCE_GROUPS'].split(","):
@@ -511,19 +511,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         except Empty:
             pass
 
-    def _on_vm_page_response(self, response, vmss=None, arcvm=None):
+    def _on_vm_page_response(self, response, vmss=None, archcivm=None):
         next_link = response.get('nextLink')
 
         if next_link:
             self._enqueue_get(url=next_link, api_version=self._compute_api_version, handler=self._on_vm_page_response,
-                              handler_args=dict(vmss=vmss, arcvm=arcvm))
+                              handler_args=dict(vmss=vmss, archcivm=archcivm))
 
         if 'value' in response:
             for h in response['value']:
                 display.debug("AzureHost raw response:")
                 display.debug(h)
                 # FUTURE: add direct VM filtering by tag here (performance optimization)?
-                self._hosts.append(AzureHost(h, self, vmss=vmss, arcvm=arcvm, legacy_name=self._legacy_hostnames))
+                self._hosts.append(AzureHost(h, self, vmss=vmss, archcivm=archcivm, legacy_name=self._legacy_hostnames))
 
     def _on_arc_page_response(self, response):
         next_link = response.get('nextLink')
@@ -536,16 +536,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             display.debug(arcvm)
             self._hosts.append(ArcHost(arcvm, self, legacy_name=self._legacy_hostnames))
 
-    def _on_arcvm_page_response(self, response):
+    def _on_archcivm_page_response(self, response):
         next_link = response.get('nextLink')
 
         if next_link:
-            self._enqueue_get(url=next_link, api_version=self._hybridcompute_api_version, handler=self._on_arcvm_page_response)
+            self._enqueue_get(url=next_link, api_version=self._hybridcompute_api_version, handler=self._on_archcivm_page_response)
 
-        for arcvm in response['value']:
-            url = '{0}/providers/Microsoft.AzureStackHCI/virtualMachineInstances'.format(arcvm['id'])
+        for archcivm in response['value']:
+            url = '{0}/providers/Microsoft.AzureStackHCI/virtualMachineInstances'.format(archcivm['id'])
             # Stack HCI instances look close enough to regular VMs that we can share the handler impl...
-            self._enqueue_get(url=url, api_version=self._stackhci_api_version, handler=self._on_vm_page_response, handler_args=dict(arcvm=arcvm))
+            self._enqueue_get(url=url, api_version=self._stackhci_api_version, handler=self._on_vm_page_response, handler_args=dict(archcivm=archcivm))
 
     def _on_vmss_page_response(self, response):
         next_link = response.get('nextLink')
@@ -768,11 +768,11 @@ class ArcHost(object):
 class AzureHost(object):
     _powerstate_regex = re.compile('^PowerState/(?P<powerstate>.+)$')
 
-    def __init__(self, vm_model, inventory_client, vmss=None, arcvm=None, legacy_name=False):
+    def __init__(self, vm_model, inventory_client, vmss=None, archcivm=None, legacy_name=False):
         self._inventory_client = inventory_client
         self._vm_model = vm_model
         self._vmss = vmss
-        self._arcvm = arcvm
+        self._archcivm = archcivm
         self._type = vm_model['type'].lower()
 
         self._instanceview = None
@@ -780,7 +780,7 @@ class AzureHost(object):
         self._powerstate = "unknown"
         self.nics = []
 
-        vm_name = self._arcvm['name'] if self._arcvm else self._vm_model['name']
+        vm_name = self._archcivm['name'] if self._archcivm else self._vm_model['name']
 
         if legacy_name:
             self.default_inventory_hostname = vm_name
@@ -790,7 +790,7 @@ class AzureHost(object):
 
         self._hostvars = {}
 
-        if self._arcvm:
+        if self._archcivm:
             self._instanceview = self._vm_model
             self._powerstate = self._vm_model['properties'].get('status', {}).get('powerState', '').lower()  # 'Running'
         else:
@@ -804,7 +804,7 @@ class AzureHost(object):
             is_primary = nic.get('properties', {}).get('primary', len(nic_refs) == 1)
 
             api_version = self._inventory_client._network_api_version
-            if self._arcvm:
+            if self._archcivm:
                 api_version = self._inventory_client._stackhci_api_version
             elif self._type == 'microsoft.compute/virtualmachinescalesets/virtualmachines':
                 api_version = self._inventory_client._scaleSet_network_api_version
@@ -820,8 +820,8 @@ class AzureHost(object):
             return self._hostvars
 
         system = "unknown"
-        if self._arcvm and self._arcvm['properties'].get('osType'):  # osType unavailable with disabled guest agent
-            system = self._arcvm['properties']['osType']
+        if self._archcivm and self._archcivm['properties'].get('osType'):  # osType unavailable with disabled guest agent
+            system = self._archcivm['properties']['osType']
         elif 'osProfile' in self._vm_model['properties']:
             if 'linuxConfiguration' in self._vm_model['properties']['osProfile']:
                 system = 'linux'
@@ -857,13 +857,13 @@ class AzureHost(object):
             private_ipv4_addresses=[],
             subnet=[],
             id=self._vm_model['id'],
-            location=self._arcvm['location'] if self._arcvm else self._vm_model['location'],
-            name=self._arcvm['name'] if self._arcvm else self._vm_model['name'],
+            location=self._archcivm['location'] if self._archcivm else self._vm_model['location'],
+            name=self._archcivm['name'] if self._archcivm else self._vm_model['name'],
             computer_name=computer_name,
             availability_zone=av_zone,
             powerstate=self._powerstate,
             provisioning_state=self._vm_model['properties']['provisioningState'].lower(),
-            tags=self._arcvm.get('tags', {}) if self._arcvm else self._vm_model.get('tags', {}),
+            tags=self._archcivm.get('tags', {}) if self._archcivm else self._vm_model.get('tags', {}),
             resource_type=self._vm_model.get('type', "unknown"),
             vmid=self._vm_model['properties']['vmId'],
             os_profile=dict(
@@ -956,10 +956,10 @@ class AzureHost(object):
             new_hostvars['os_disk'] = dict(
                 name=osDisk.get('name'),
                 operating_system_type=osDisk.get('osType').lower() if osDisk.get('osType') else None,
-                id=storageProfile.get('vmConfigStoragePathId') if self._arcvm else osDisk.get('managedDisk', {}).get('id')
+                id=storageProfile.get('vmConfigStoragePathId') if self._archcivm else osDisk.get('managedDisk', {}).get('id')
             )
 
-            if self._arcvm:
+            if self._archcivm:
                 new_hostvars['data_disks'] = [
                     dict(
                         name=dataDisk.get('id').split('/')[-1],


### PR DESCRIPTION
##### SUMMARY
Following #2077 
Prevents useless call if object is only Arc but not HCI

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory azure_rm.py

##### ADDITIONAL INFORMATION
Splitted in 2 commits for readability (one with rename, one with the fix)

Happens if you use `include_hcivm_resource_groups` and you also have non HCI arc objects in targetted scope.
Without this PR, it causes requests to this handler, despite not being an `Microsoft.AzureStackHCI/virtualMachineInstances`:
`https://management.azure.com/subscriptions/<subscription_id>/resourceGroups/<rg>/providers/Microsoft.HybridCompute/machines/<arc name>/providers/Microsoft.AzureStackHCI/virtualMachineInstances?api-version=2024-01-01`
