### PR TITLE
Fix 1511: Temporary fix on dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ azure-containerregistry==1.2.0
 azure-core==1.38.0
 azure-eventhub==5.15.0
 azure-identity==1.19.0
-azure-iot-hub==2.6.1
+azure-iot-hub==2.6.1;platform_machine=="x86_64"
 azure-keyvault==4.2.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-apimanagement==4.0.1


### PR DESCRIPTION
##### SUMMARY
Fix #1511. The `uamqp` dependency failing to build on macOS ARM (and in some Linux ARM / newer Python versions), which then blocks installation of `azure-iot-hub`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt

##### ADDITIONAL INFORMATION
Temporary workaround only. A follow-up PR will be required once we get confirmation from `azure-iot-hub` maintainers.
[WIP] Currently coordinating with the relevant Azure SDK team to understand the status and recommended path forward for ARM support.
