### PR TITLE
Migrate azure_rm_keyvault to support API 2026-02-01 default RBAC behaviour

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -128,7 +128,7 @@ AZURE_API_PROFILES = {
         'IotHubClient': 'latest',
         'RecoveryServicesBackupClient': 'latest',
         'DataFactoryManagementClient': 'latest',
-        'KeyVaultManagementClient': '2021-10-01',
+        'KeyVaultManagementClient': '2026-02-01',
         'HDInsightManagementClient': 'latest',
         'DevTestLabsClient': 'latest',
         'CosmosDBManagementClient': 'latest',

--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -210,6 +210,7 @@ options:
             - When I(enable_rbac_authorization=false), the key vault will use the access policies specified in vault properties,
               and any policy stored on Azure Resource Manager will be ignored.
             - If null or not specified, the value of this property will not change.
+            - Starting with API version 2026-02-01, Azure defaults this to true (RBAC) if not specified.
         type: bool
     soft_delete_retention_in_days:
         description:

--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -585,7 +585,7 @@ class AzureRMVaults(AzureRMModuleBaseExt):
 
         self.mgmt_client = self.get_mgmt_svc_client(KeyVaultManagementClient,
                                                     base_url=self._cloud_environment.endpoints.resource_manager,
-                                                    api_version="2023-07-01")
+                                                    api_version="2026-02-01")
 
         resource_group = self.get_resource_group(self.resource_group)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ azure-mgmt-dns==8.1.0
 azure-mgmt-eventhub==11.1.0
 azure-mgmt-hdinsight==9.1.0b1
 azure-mgmt-iothub==3.0.0
-azure-mgmt-keyvault==10.3.1
+azure-mgmt-keyvault==13.0.0
 azure-mgmt-loganalytics==13.0.0b7
 azure-mgmt-managedservices==7.0.0b2
 azure-mgmt-managementgroups==1.1.0b2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ azure-mgmt-dns==8.1.0
 azure-mgmt-eventhub==11.1.0
 azure-mgmt-hdinsight==9.1.0b1
 azure-mgmt-iothub==3.0.0
-azure-mgmt-keyvault==13.0.0
+azure-mgmt-keyvault==12.1.1
 azure-mgmt-loganalytics==13.0.0b7
 azure-mgmt-managedservices==7.0.0b2
 azure-mgmt-managementgroups==1.1.0b2

--- a/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -482,6 +482,17 @@
         that:
           - output is not changed
 
+    - name: Delete instance of Key Vault (RBAC Test)
+      azure.azcollection.azure_rm_keyvault:
+        resource_group: "{{ resource_group }}-keyvault"
+        vault_name: "vault{{ rpfx }}-rbac-default"
+        state: absent
+      register: output
+    - name: Assert the state has changed
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
     #
     # azure.azcollection.azure_rm_keyvault hsm setup and test
     #

--- a/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -319,7 +319,7 @@
     - name: Create Key Vault with no access_policies and no enable_rbac_authorization
       azure.azcollection.azure_rm_keyvault:
         resource_group: "{{ resource_group }}-keyvault"
-        vault_name: "vault{{ rpfx }}-rbac-default"
+        vault_name: "vault{{ rpfx }}-rbac"
         vault_tenant: "{{ tenant_id }}"
         sku:
           name: standard
@@ -328,7 +328,7 @@
     - name: Assert RBAC-default vault created
       azure.azcollection.azure_rm_keyvault_info:
         resource_group: "{{ resource_group }}-keyvault"
-        name: "vault{{ rpfx }}-rbac-default"
+        name: "vault{{ rpfx }}-rbac"
       register: facts
     - name: Assert RBAC is enabled by default
       ansible.builtin.assert:
@@ -338,7 +338,7 @@
     - name: Update Key Vault to use access_policies (switch from RBAC to legacy)
       azure.azcollection.azure_rm_keyvault:
         resource_group: "{{ resource_group }}-keyvault"
-        vault_name: "vault{{ rpfx }}-rbac-default"
+        vault_name: "vault{{ rpfx }}-rbac"
         vault_tenant: "{{ tenant_id }}"
         sku:
           name: standard
@@ -353,7 +353,7 @@
     - name: Assert RBAC was disabled
       azure.azcollection.azure_rm_keyvault_info:
         resource_group: "{{ resource_group }}-keyvault"
-        name: "vault{{ rpfx }}-rbac-default"
+        name: "vault{{ rpfx }}-rbac"
       register: facts
     - name: Assert RBAC is now disabled
       ansible.builtin.assert:
@@ -485,7 +485,7 @@
     - name: Delete instance of Key Vault (RBAC Test)
       azure.azcollection.azure_rm_keyvault:
         resource_group: "{{ resource_group }}-keyvault"
-        vault_name: "vault{{ rpfx }}-rbac-default"
+        vault_name: "vault{{ rpfx }}-rbac"
         state: absent
       register: output
     - name: Assert the state has changed

--- a/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -102,6 +102,7 @@
               - backup
               - restore
       register: output
+
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
@@ -315,50 +316,6 @@
         resource_group: "{{ resource_group }}-keyvault"
         vault_name: "vault{{ rpfx }}-sec"
         state: absent
-
-    - name: Create Key Vault with no access_policies and no enable_rbac_authorization
-      azure.azcollection.azure_rm_keyvault:
-        resource_group: "{{ resource_group }}-keyvault"
-        vault_name: "vault{{ rpfx }}-rbac"
-        vault_tenant: "{{ tenant_id }}"
-        sku:
-          name: standard
-          family: A
-      register: output
-    - name: Assert RBAC-default vault created
-      azure.azcollection.azure_rm_keyvault_info:
-        resource_group: "{{ resource_group }}-keyvault"
-        name: "vault{{ rpfx }}-rbac"
-      register: facts
-    - name: Assert RBAC is enabled by default
-      ansible.builtin.assert:
-        that:
-          - facts['keyvaults'][0]['enable_rbac_authorization'] == true
-
-    - name: Update Key Vault to use access_policies (switch from RBAC to legacy)
-      azure.azcollection.azure_rm_keyvault:
-        resource_group: "{{ resource_group }}-keyvault"
-        vault_name: "vault{{ rpfx }}-rbac"
-        vault_tenant: "{{ tenant_id }}"
-        sku:
-          name: standard
-          family: A
-        access_policies:
-          - tenant_id: "{{ tenant_id }}"
-            object_id: "{{ object_id }}"
-            secrets:
-              - get
-        enable_rbac_authorization: false
-      register: output
-    - name: Assert RBAC was disabled
-      azure.azcollection.azure_rm_keyvault_info:
-        resource_group: "{{ resource_group }}-keyvault"
-        name: "vault{{ rpfx }}-rbac"
-      register: facts
-    - name: Assert RBAC is now disabled
-      ansible.builtin.assert:
-        that:
-          - facts['keyvaults'][0]['enable_rbac_authorization'] == false
     #
     # azure.azcollection.azure_rm_keyvaultkey tests
     #
@@ -481,17 +438,6 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-
-    - name: Delete instance of Key Vault (RBAC Test)
-      azure.azcollection.azure_rm_keyvault:
-        resource_group: "{{ resource_group }}-keyvault"
-        vault_name: "vault{{ rpfx }}-rbac"
-        state: absent
-      register: output
-    - name: Assert the state has changed
-      ansible.builtin.assert:
-        that:
-          - output is changed
 
     #
     # azure.azcollection.azure_rm_keyvault hsm setup and test

--- a/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -102,7 +102,6 @@
               - backup
               - restore
       register: output
-
     - name: Assert the resource instance is well created
       ansible.builtin.assert:
         that:
@@ -316,6 +315,50 @@
         resource_group: "{{ resource_group }}-keyvault"
         vault_name: "vault{{ rpfx }}-sec"
         state: absent
+
+    - name: Create Key Vault with no access_policies and no enable_rbac_authorization
+      azure.azcollection.azure_rm_keyvault:
+        resource_group: "{{ resource_group }}-keyvault"
+        vault_name: "vault{{ rpfx }}-rbac-default"
+        vault_tenant: "{{ tenant_id }}"
+        sku:
+          name: standard
+          family: A
+      register: output
+    - name: Assert RBAC-default vault created
+      azure.azcollection.azure_rm_keyvault_info:
+        resource_group: "{{ resource_group }}-keyvault"
+        name: "vault{{ rpfx }}-rbac-default"
+      register: facts
+    - name: Assert RBAC is enabled by default
+      ansible.builtin.assert:
+        that:
+          - facts['keyvaults'][0]['enable_rbac_authorization'] == true
+
+    - name: Update Key Vault to use access_policies (switch from RBAC to legacy)
+      azure.azcollection.azure_rm_keyvault:
+        resource_group: "{{ resource_group }}-keyvault"
+        vault_name: "vault{{ rpfx }}-rbac-default"
+        vault_tenant: "{{ tenant_id }}"
+        sku:
+          name: standard
+          family: A
+        access_policies:
+          - tenant_id: "{{ tenant_id }}"
+            object_id: "{{ object_id }}"
+            secrets:
+              - get
+        enable_rbac_authorization: false
+      register: output
+    - name: Assert RBAC was disabled
+      azure.azcollection.azure_rm_keyvault_info:
+        resource_group: "{{ resource_group }}-keyvault"
+        name: "vault{{ rpfx }}-rbac-default"
+      register: facts
+    - name: Assert RBAC is now disabled
+      ansible.builtin.assert:
+        that:
+          - facts['keyvaults'][0]['enable_rbac_authorization'] == false
     #
     # azure.azcollection.azure_rm_keyvaultkey tests
     #


### PR DESCRIPTION
##### SUMMARY
This PR updates the `azure_rm_keyvault` module to use latest Azure Key Vault API version 2026-02-01, which introduces a breaking change: new vaults now default to Azure RBAC for data plane access unless explicitly configured otherwise.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py
plugins/modules/azure_rm_keyvault.py

Reference: https://learn.microsoft.com/en-us/azure/key-vault/general/access-control-default?tabs=azure-cli
