### PR TITLE
Adding management plane support for azure app configuration

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -135,6 +135,7 @@ AZURE_API_PROFILES = {
         'CdnManagementClient': '2017-04-02',
         'BatchManagementClient': 'latest',
         'EventGridManagementClient': '2025-02-15',
+        'AppConfigurationManagementClient': '2024-05-01'
     },
     '2019-03-01-hybrid': {
         'StorageManagementClient': '2017-10-01',

--- a/plugins/modules/azure_rm_appconfiguration.py
+++ b/plugins/modules/azure_rm_appconfiguration.py
@@ -1,0 +1,633 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_appconfiguration
+version_added: "3.15.0"
+short_description: Manage Azure App Configuration stores.
+description:
+    - Create, update and delete Azure App Configuration stores.
+
+options:
+    resource_group:
+        description:
+            - The name of the Resource Group to which the App Configuration store belongs.
+        required: True
+        type: str
+    appconfig_name:
+        description:
+            - Name of the app configuration store.
+        required: True
+        type: str
+    identity:
+        description:
+            - Managed identity configuration for the store.
+        type: dict
+        suboptions:
+            type:
+                description:
+                    - Type of the managed identity
+                required: true
+                choices:
+                    - SystemAssigned
+                    - UserAssigned
+                    - SystemAssigned, UserAssigned
+                type: str
+            user_assigned_identity_ids:
+                description:
+                    - List of user-assigned identity resource IDs (required when type includes UserAssigned).
+                required: false
+                type: list
+                elements: str
+    location:
+        description:
+            - Resource location. If not set, location from the resource group will be used as default.
+        type: str
+    sku:
+        description:
+            - SKU tier of the store.
+        type: str
+        choices:
+            - 'free'
+            - 'developer'
+            - 'standard'
+            - 'premium'
+    enable_purge_protection:
+        description:
+            - Property specifying whether protection against purge is enabled for this store.
+        type: bool
+        default: False
+    soft_delete_retention_in_days:
+        description:
+            - Property specifying the number of days to retain deleted store.
+        type: int
+    public_network_access:
+        description:
+            - Public network access setting for the store.
+            - If omitted at creation, Azure treats it as C(Automatic). Once set to C(Enabled) or C(Disabled), it cannot be returned to C(Automatic);
+              omit the property in updates to leave unchanged.
+        type: str
+        choices:
+            - Disabled
+            - Enabled
+    disable_local_auth:
+        description:
+            - Property specifying whether local authentication (access keys) is enabled for the store.
+        type: bool
+        default: False
+    replicas:
+        description:
+            - List of replicas to manage for this store.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description:
+                    - Name of the replica.
+                required: true
+                type: str
+            location:
+                description:
+                    - Location of the replica.
+                required: true
+                type: str
+    is_purge_deleted:
+        description:
+            - Whether permanently deletes the specified store. aka Purges the deleted Azure App Configuration store
+            - When I(is_purge_deleted) is specified, the I(location) has to be configured.
+            - If not configured, the default location of the resource group will be used.
+        type: bool
+        default: False
+    state:
+        description:
+            - Assert the state of the App Configuration store. Use C(present) to create or update an App Configuration store and C(absent) to delete it.
+        default: present
+        type: str
+        choices:
+            - absent
+            - present
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+    - azure.azcollection.azure_tags
+
+author:
+    - Zun Yang (@zunyangc)
+
+'''
+
+EXAMPLES = '''
+- name: Create a Standard App Configuration store with system-assigned identity
+  azure.azcollection.azure_rm_appconfiguration:
+    resource_group: myResourceGroup
+    appconfig_name: myAppConfigStore
+    location: eastus
+    sku: standard
+    identity:
+      type: SystemAssigned
+    enable_local_auth: true
+    tags:
+      env: prod
+    state: present
+
+- name: Assign a user-assigned identity and enable purge protection
+  azure.azcollection.azure_rm_appconfiguration:
+    resource_group: myResourceGroup
+    appconfig_name: myAppConfigStore
+    identity:
+      type: UserAssigned
+      user_assigned_identity_ids:
+        - /subscriptions/xxxx/resourceGroups/myResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myIdentity
+    enable_purge_protection: true
+    soft_delete_retention_in_days: 7
+    state: present
+
+- name: Delete an App Configuration store
+  azure.azcollection.azure_rm_appconfiguration:
+    resource_group: myRG
+    appconfig_name: my-appconf-legacy
+    state: absent
+
+- name: Purge a soft-deleted App Configuration store (subscription-level permission required)
+  azure.azcollection.azure_rm_appconfiguration:
+    resource_group: myRG
+    appconfig_name: my-appconf-legacy
+    location: eastus
+    is_purge_deleted: true
+    state: absent
+
+- name: Create store with two replicas
+  azure.azcollection.azure_rm_appconfiguration:
+    resource_group: myRG
+    appconfig_name: myappconf
+    location: eastus
+    sku: standard
+    replicas:
+      - name: r1
+        location: westus
+      - name: r2
+        location: northeurope
+    state: present
+'''
+
+RETURN = '''
+id:
+    description:
+        - The Azure Resource Manager resource ID for the App Configuration store.
+    returned: always
+    type: str
+    sample: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.AppConfiguration/configurationStores/myAppConfigStore
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+
+try:
+    from azure.core.polling import LROPoller
+    from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
+    from azure.mgmt.appconfiguration import AppConfigurationManagementClient
+except ImportError:
+    # Handled in azure_rm_common_ext
+    pass
+
+
+class Actions:
+    NoAction, Create, Update, Delete = range(4)
+
+
+class AzureRMAppConfiguration(AzureRMModuleBaseExt):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(
+                type='str',
+                required=True
+            ),
+            appconfig_name=dict(
+                type='str',
+                required=True
+            ),
+            identity=dict(
+                type='dict',
+                options=dict(
+                    type=dict(
+                        type='str',
+                        required=True,
+                        choices=['SystemAssigned', 'UserAssigned', 'SystemAssigned, UserAssigned']
+                    ),
+                    user_assigned_identity_ids=dict(
+                        type='list',
+                        elements='str'
+                    )
+                )
+            ),
+            location=dict(type='str'),
+            sku=dict(
+                type='str',
+                choices=['free', 'developer', 'standard', 'premium']
+            ),
+            enable_purge_protection=dict(
+                type='bool',
+                default=False
+            ),
+            soft_delete_retention_in_days=dict(
+                type='int'
+            ),
+            public_network_access=dict(
+                type='str',
+                choices=['Disabled', 'Enabled']
+            ),
+            disable_local_auth=dict(
+                type='bool',
+                default=False
+            ),
+            replicas=dict(
+                type='list',
+                elements='dict',
+                options=dict(
+                    name=dict(type='str', required=True),
+                    location=dict(type='str', required=True)
+                )
+            ),
+            # Administrative op: purge soft-deleted store
+            is_purge_deleted=dict(type='bool', default=False),
+
+            # Azure tags (provided by AzureRMModuleBaseExt)
+            # 'tags' is injected by base class when supports_tags=True
+
+            state=dict(
+                type='str',
+                default='present',
+                choices=['absent', 'present']
+            )
+        )
+
+        self.resource_group = None
+        self.appconfig_name = None
+        self.identity = None
+        self.is_purge_deleted = None
+
+        self.results = dict(changed=False)
+        self.mgmt_client = None
+        self.state = None
+        self.to_do = Actions.NoAction
+        self.parameters = dict()
+        self.tags = None
+
+        super(AzureRMAppConfiguration, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                      supports_tags=True,
+                                                      supports_check_mode=True)
+
+    @property
+    def managed_identity(self):
+        return {}
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+
+        # Bind known attributes and build parameters payload
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            if key in kwargs:
+                setattr(self, key, kwargs[key])
+            if key in kwargs and kwargs.get(key) is not None:
+                if key == 'location':
+                    self.parameters['location'] = kwargs[key]
+                elif key == 'sku':
+                    # ARM expects {"sku": {"name": "<tier>"}}
+                    self.parameters.setdefault('sku', {})['name'] = kwargs[key]
+                elif key == "public_network_access":
+                    self.parameters.setdefault("properties", {})["publicNetworkAccess"] = kwargs[key]
+                elif key == "disable_local_auth":
+                    self.parameters.setdefault("properties", {})["disableLocalAuth"] = kwargs[key]
+                elif key == "enable_purge_protection":
+                    self.parameters.setdefault("properties", {})["enablePurgeProtection"] = kwargs[key]
+                elif key == "soft_delete_retention_in_days":
+                    self.parameters.setdefault("properties", {})["softDeleteRetentionInDays"] = kwargs[key]
+
+        self.mgmt_client = self.get_mgmt_svc_client(AppConfigurationManagementClient,
+                                                    base_url=self._cloud_environment.endpoints.resource_manager)
+
+        # Resolve RG + default location
+        resource_group = self.get_resource_group(self.resource_group)
+        if "location" not in self.parameters:
+            self.parameters['location'] = resource_group.location
+
+        # Validation: SKU vs purge fields
+        if self.sku not in ('standard', 'premium'):
+            if self.enable_purge_protection:
+                self.fail("enable_purge_protection is only supported on 'standard' or 'premium' SKUs.")
+            if self.soft_delete_retention_in_days is not None:
+                self.fail("soft_delete_retention_in_days is only supported on 'standard' or 'premium' SKUs.")
+
+        # Normalize identity changes using base helper
+        identity_dict = None
+        if self.identity:
+            id_type = (self.identity.get("type") or "").strip()
+            ids = self.identity.get("user_assigned_identity_ids") or []
+            if "UserAssigned" in id_type and not ids:
+                self.fail("identity.user_assigned_identity_ids must be provided when identity.type includes 'UserAssigned'.")
+            if id_type == "SystemAssigned":
+                identity_dict = {"type": "SystemAssigned"}
+            elif id_type == "UserAssigned":
+                identity_dict = {"type": "UserAssigned",
+                                 "userAssignedIdentities": {uid: {} for uid in ids}}
+            elif id_type == "SystemAssigned, UserAssigned":
+                identity_dict = {"type": "SystemAssigned, UserAssigned",
+                                 "userAssignedIdentities": {uid: {} for uid in ids}}
+            else:
+                # If not provided or unrecognized, omit identity block altogether
+                identity_dict = None
+
+            if identity_dict:
+                self.parameters["identity"] = identity_dict
+
+        # Read current
+        old_response = self.get_instance()
+        response = None
+
+        # Compute identity_changed
+        identity_changed = False
+        if old_response and identity_dict:
+            old_ident = old_response.get('identity') or {}
+            old_type = (old_ident.get('type') or '').lower()
+            new_type = (identity_dict.get('type') or '').lower()
+            if old_type != new_type:
+                identity_changed = True
+            else:
+                # Compare UAMI sets if applicable
+                if 'userassigned' in new_type:
+                    old_ids = set(((old_ident.get('user_assigned_identities') or {}).keys()) or [])
+                    new_ids = set(((identity_dict.get('userAssignedIdentities') or {}).keys()) or [])
+                    if old_ids != new_ids:
+                        identity_changed = True
+
+        # Decide action
+        if not old_response:
+            if self.state == 'absent':
+                self.log("Old instance didn't exist")
+                self.to_do = Actions.NoAction
+            else:
+                self.to_do = Actions.Create
+        else:
+            if self.state == 'absent':
+                self.to_do = Actions.Delete
+            else:
+                # compute update deltas
+                self.to_do = self._needs_update(old_response, self.parameters, identity_changed)
+
+        # Execute
+        if self.to_do in (Actions.Create, Actions.Update):
+            self.results['changed'] = True
+            if not self.check_mode:
+                self.parameters["tags"] = self.tags
+                response = self.create_or_update_store()
+                if self.replicas is not None:
+                    self.reconcile_replicas(self.replicas)
+                if response is None:
+                    response = self.get_instance()
+        elif self.to_do == Actions.Delete:
+            self.results['changed'] = True
+            if not self.check_mode:
+                self.delete_store()
+        elif self.to_do == Actions.NoAction and self.replicas is not None:
+            self.reconcile_replicas(self.replicas)
+            if response is None:
+                response = old_response or self.get_instance()
+        else:
+            # NoAction
+            self.results['changed'] = False
+            response = old_response
+
+        # Purge soft-deleted if requested
+        if self.is_purge_deleted:
+            purge_response = self.get_deleted(self.parameters["location"])
+            if purge_response:
+                self.results['changed'] = True
+                if not self.check_mode:
+                    self.purge_deleted(self.parameters["location"])
+
+        if response is not None and hasattr(response, "as_dict"):
+            response = response.as_dict()
+
+        if response:
+            self.results["id"] = response["id"]
+
+        return self.results
+
+    def get_instance(self):
+        '''
+        Get the properties of the specified App Configuration store.
+
+        :return: deserialized App Configuration store instance state dictionary.
+        '''
+        try:
+            response = self.mgmt_client.configuration_stores.get(resource_group_name=self.resource_group,
+                                                                 config_store_name=self.appconfig_name)
+            return response.as_dict()
+        except ResourceNotFoundError:
+            return False
+
+    def create_or_update_store(self):
+        '''
+        Create or update (PUT) App Configuration store with the specified configuration.
+
+        :return: deserialized App Configuration store state dictionary.
+        '''
+        try:
+            poller = self.mgmt_client.configuration_stores.begin_create(resource_group_name=self.resource_group,
+                                                                        config_store_name=self.appconfig_name,
+                                                                        config_store_creation_parameters=self.parameters)
+            if isinstance(poller, LROPoller):
+                return self.get_poller_result(poller)
+            return poller.as_dict() if hasattr(poller, "as_dict") else poller
+        except Exception as exc:
+            self.fail("Error creating/updating App Configuration store '{}': {}".format(self.appconfig_name, str(exc)))
+
+    def delete_store(self):
+        '''
+        Delete the specified App Configuration store.
+
+        :return: True.
+        '''
+        try:
+            poller = self.mgmt_client.configuration_stores.begin_delete(resource_group_name=self.resource_group,
+                                                                        config_store_name=self.appconfig_name)
+            if isinstance(poller, LROPoller):
+                return self.get_poller_result(poller)
+            return True
+        except Exception as exc:
+            self.fail("Error deleting the App Configuration store '{}': {}".format(self.appconfig_name, str(exc)))
+
+    def get_deleted(self, location):
+        '''
+        Get deleted store
+        :return: True or False
+        '''
+        try:
+            self.mgmt_client.configuration_stores.get_deleted(self.appconfig_name, location)
+        except Exception as e:
+            self.log('Error attempting to get the deleted store: {0}'.format(str(e)))
+            return False
+        return True
+
+    def purge_deleted(self, location):
+        '''
+        Purge the specified soft-deleted App Configuration store.
+        '''
+        try:
+            poller = self.mgmt_client.configuration_stores.begin_purge_deleted(location=location,
+                                                                               config_store_name=self.appconfig_name)
+            if isinstance(poller, LROPoller):
+                return self.get_poller_result(poller)
+            return True
+        except HttpResponseError as e:
+            # 404/NotFound => nothing to purge
+            status = getattr(e, 'status_code', None) or getattr(getattr(e, 'response', None), 'status_code', None)
+            if status == 404:
+                return False
+            self.fail("Error purging deleted App Configuration store '{0}' in '{1}': {2}".format(
+                self.appconfig_name, location, str(e)))
+        except Exception as exc:
+            self.fail("Error purging deleted App Configuration store '{0}' in '{1}': {2}".format(
+                self.appconfig_name, location, str(exc)))
+
+    def _list_replicas(self):
+        '''
+        List replicas for the specified App Configuration store.
+
+        :return: Dictionary of replicas.
+        '''
+        found = {}
+        pager = self.mgmt_client.replicas.list_by_configuration_store(
+            resource_group_name=self.resource_group,
+            config_store_name=self.appconfig_name
+        )
+        for r in pager:
+            rd = r.as_dict()
+            found[rd['name']] = {'location': rd.get('location'), 'id': rd.get('id')}
+        return found
+
+    def _create_replica(self, name, location):
+        '''
+        Create a replica for the specified App Configuration store.
+
+        :return: deserialized replica instance state dictionary.
+        '''
+        poller = self.mgmt_client.replicas.begin_create(
+            resource_group_name=self.resource_group,
+            config_store_name=self.appconfig_name,
+            replica_name=name,
+            replica_creation_parameters={'location': location, 'properties': {}}
+        )
+        return self.get_poller_result(poller)
+
+    def _delete_replica(self, name):
+        '''
+        Delete a replica for the specified App Configuration store.
+
+        :return: True.
+        '''
+        poller = self.mgmt_client.replicas.begin_delete(
+            resource_group_name=self.resource_group,
+            config_store_name=self.appconfig_name,
+            replica_name=name
+        )
+        return self.get_poller_result(poller)
+
+    def reconcile_replicas(self, desired):
+        '''
+        Reconcile replicas to match desired state.
+        Authoritative: create missing, delete extras, recreate on location change.
+        '''
+        # desired: list[{'name': ..., 'location': ...}]
+        # authoritative behavior: create missing, delete extras, (re)create on location change
+        desired_index = {x['name']: x['location'] for x in (desired or [])}
+        current = self._list_replicas()
+
+        # create or recreate when location changed
+        for name, loc in desired_index.items():
+            if name not in current:
+                self.results['changed'] = True
+                if not self.check_mode:
+                    self._create_replica(name, loc)
+            else:
+                if loc and (loc.lower() != (current[name].get('location') or '').lower()):
+                    self.results['changed'] = True
+                    if not self.check_mode:
+                        self._delete_replica(name)
+                        self._create_replica(name, loc)
+
+        # delete extras (authoritative)
+        extra = set(current.keys()) - set(desired_index.keys())
+        for name in sorted(extra):
+            self.results['changed'] = True
+            if not self.check_mode:
+                self._delete_replica(name)
+
+    def _needs_update(self, old, new_params, identity_changed):
+        '''
+        Determine whether an update is required by comparing fields.
+        Explicitly manage. Keep parity with Azure defaults where possible.
+
+        :return: Action Required.
+        '''
+        to_do = Actions.NoAction
+        props_new = new_params.get('properties') or {}
+
+        # sku
+        sku_old = ((old.get('sku') or {}).get('name') or '').lower()
+        sku_new = ((new_params.get('sku') or {}).get('name') or '').lower()
+        if sku_new and sku_new != sku_old:
+            # Note: provider/API might restrict downgrades; PUT will handle errors.
+            to_do = Actions.Update
+
+        # publicNetworkAccess
+        if 'publicNetworkAccess' in props_new:
+            if (props_new.get('publicNetworkAccess') or '').lower() != (old.get('public_network_access') or '').lower():
+                to_do = Actions.Update
+
+        # disableLocalAuth
+        if 'disableLocalAuth' in props_new:
+            if bool(props_new.get('disableLocalAuth')) != bool(old.get('disable_local_auth')):
+                to_do = Actions.Update
+
+        # enablePurgeProtection
+        if 'enablePurgeProtection' in props_new:
+            if bool(props_new.get('enablePurgeProtection')) != bool(old.get('enable_purge_protection')):
+                to_do = Actions.Update
+
+        # softDeleteRetentionInDays
+        if 'softDeleteRetentionInDays' in props_new:
+            if props_new.get('softDeleteRetentionInDays') != old.get('soft_delete_retention_in_days'):
+                to_do = Actions.Update
+
+        # tags
+        update_tags, newtags = self.update_tags(old.get('tags', {}) or {})
+        if update_tags:
+            self.tags = newtags
+            to_do = Actions.Update
+
+        # identity
+        if identity_changed:
+            to_do = Actions.Update
+
+        # Write back potentially adjusted props
+        if props_new:
+            new_params['properties'] = props_new
+
+        return to_do
+
+
+def main():
+    """Main execution"""
+    AzureRMAppConfiguration()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_appconfiguration_info.py
+++ b/plugins/modules/azure_rm_appconfiguration_info.py
@@ -1,0 +1,346 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_appconfiguration_info
+version_added: "3.15.0"
+short_description: Get Azure App Configuration store facts
+description:
+    - Get facts for Azure App Configuration stores (Microsoft.AppConfiguration/configurationStores).
+    - Supports get by name, list by resource group and list by subscription.
+    - Optionally includes store replicas when fetching by name.
+
+options:
+    resource_group:
+        description:
+            - The name of the resource group to which the App Configuration store belongs.
+        type: str
+    appconfig_name:
+        description:
+            - The name of the App Configuration store.
+        type: str
+    include_replicas:
+        description:
+            - When C(appconfig_name) is specified, indicates whether to include the store replicas in the response.
+            - Disabled for list operations to avoid extra calls by default.
+        type: bool
+        default: false
+    tags:
+        description:
+            - Limit results by a list of tags. Format tags as C(key) or C(key:value).
+        type: list
+        elements: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Get App Configuration store
+  azure_rm_appconfiguration_info:
+    resource_group: myRG
+    appconfig_name: myAGS
+
+- name: Get App Configuration store with replicas
+  azure_rm_appconfiguration_info:
+    resource_group: myRG
+    appconfig_name: myAGS
+    include_replicas: true
+
+- name: List stores in RG
+  azure_rm_appconfiguration_info:
+    resource_group: myRG
+
+- name: List stores in subscription
+  azure_rm_appconfiguration_info:
+'''
+
+RETURN = '''
+appconfigurations:
+    description: List of App Configuration stores.
+    returned: always
+    type: list
+    contains:
+        appconfig_name:
+            description:
+                - Name of the App Configuration store.
+            returned: always
+            type: str
+            sample: myAGS
+        id:
+            description:
+                - Resource ID of the App Configuration store.
+            returned: always
+            type: str
+            sample: /subscriptions/xxxx/resourceGroups/myRG/providers/Microsoft.AppConfiguration/configurationStores/myAGS
+        location:
+            description:
+                - Azure location of the App Configuration store.
+            returned: always
+            type: str
+            sample: eastus
+        tags:
+            description:
+                - List of tags.
+            type: dict
+            sample: "{'env': 'prod', 'department': 'finance'}"
+        sku:
+            description:
+                - SKU of the App Configuration store.
+            returned: always
+            type: dict
+            contains:
+                name:
+                    description: SKU name.
+                    type: str
+                    returned: always
+                    sample: Standard
+        public_network_access:
+            description:
+                - Whether public network access is enabled.
+            returned: always
+            type: str
+            sample: Enabled
+        disable_local_auth:
+            description:
+                - Whether local authentication is disabled.
+            returned: always
+            type: bool
+            sample: false
+        replicas:
+            description:
+                - List of replicas for the App Configuration store.
+            returned: when include_replicas is true and appconfig_name is specified
+            type: list
+            elements: dict
+            contains:
+                name:
+                    description:
+                        - Name of the replica.
+                    returned: always
+                    type: str
+                    sample: myAGSrep
+                location:
+                    description:
+                        - Azure location of the replica.
+                    returned: always
+                    type: str
+                    sample: westus
+                id:
+                    description:
+                        - Resource ID of the replica.
+                    returned: always
+                    type: str
+                    sample: /subscriptions/xxxx/resourceGroups/myrg/providers/Microsoft.AppConfiguration/configurationStores/myAGS/replicas/myAGSrep
+        soft_delete_retention_in_days:
+            description:
+                - Number of days to retain soft-deleted items.
+            returned: always
+            type: int
+            sample: 7
+        enable_purge_protection:
+            description:
+                - Whether purge protection is enabled.
+            returned: always
+            type: bool
+            sample: true
+        identity:
+            description:
+                - Managed identity information.
+            returned: always
+            type: dict
+            contains:
+                type:
+                    description: Type of managed identity.
+                    type: str
+                    returned: always
+                    sample: SystemAssigned
+                principal_id:
+                    description: Principal ID of the managed identity.
+                    type: str
+                    returned: always
+                    sample: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                tenant_id:
+                    description: Tenant ID of the managed identity.
+                    type: str
+                    returned: always
+                    sample: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+'''
+
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.mgmt.appconfiguration import AppConfigurationManagementClient
+    from azure.core.exceptions import ResourceNotFoundError
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+
+def appconfig_to_dict(appconfig, replicas=None, include_replicas=False):
+    s = appconfig.as_dict()
+
+    data = dict(
+        id=s.get("id"),
+        appconfig_name=s.get("name"),
+        location=s.get("location"),
+        tags=s.get("tags"),
+        sku=dict(name=s.get("sku", {}).get("name")),
+
+        endpoint=s.get("endpoint"),
+        public_network_access=s.get("public_network_access"),
+        disable_local_auth=s.get("disable_local_auth"),
+        enable_purge_protection=s.get("enable_purge_protection"),
+        soft_delete_retention_in_days=s.get("soft_delete_retention_in_days"),
+        identity=s.get("identity")
+    )
+
+    # Only include replicas when explicitly requested
+    if include_replicas:
+        data["replicas"] = replicas or []
+
+    return data
+
+
+class AzureRMAppConfigurationInfo(AzureRMModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str'),
+            appconfig_name=dict(type='str'),
+            include_replicas=dict(type='bool', default=False),
+            tags=dict(type='list', elements='str'),
+        )
+
+        self.resource_group = None
+        self.appconfig_name = None
+        self.include_replicas = None
+        self.tags = None
+        self.results = dict(changed=False)
+        self._client = None
+
+        super(AzureRMAppConfigurationInfo, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                          supports_check_mode=True,
+                                                          supports_tags=False,
+                                                          facts_module=True)
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            if hasattr(self, key):
+                setattr(self, key, kwargs[key])
+
+        self._client = self.get_mgmt_svc_client(AppConfigurationManagementClient,
+                                                base_url=self._cloud_environment.endpoints.resource_manager)
+
+        if self.appconfig_name:
+            if not self.resource_group:
+                self.fail("Parameter 'resource_group' is required when filtering by appconfig_name.")
+            self.results['appconfigurations'] = [self.get_by_appconfig_name()]
+
+        elif self.resource_group:
+            self.results['appconfigurations'] = self.list_appconfig_by_resource_group()
+
+        else:
+            self.results["appconfigurations"] = self.list_appconfig_by_subscription()
+
+        return self.results
+
+    def get_by_appconfig_name(self):
+        '''
+        Get the properties of this specified app configuration store.
+
+        :return: deserialized app configuration store state dictionary.
+        '''
+        try:
+            s = self._client.configuration_stores.get(resource_group_name=self.resource_group,
+                                                      config_store_name=self.appconfig_name)
+            replicas = self.list_appconfig_replicas(self.resource_group, self.appconfig_name) if self.include_replicas else []
+            if self.has_tags(s.tags, self.tags):
+                return appconfig_to_dict(s, replicas, self.include_replicas)
+        except ResourceNotFoundError as e:
+            self.log("Did not find the app configurations {0}: {1}".format(self.appconfig_name, str(e)))
+
+    def list_appconfig_by_resource_group(self):
+        '''
+        List the properties of app configuration store in specific resource group.
+
+        :return: deserialized app configuration store state dictionary.
+        '''
+        results = []
+        try:
+            stores = list(self._client.configuration_stores.list_by_resource_group(resource_group_name=self.resource_group))
+
+            if stores:
+                for s in stores:
+                    if not self.has_tags(s.tags, self.tags):
+                        continue
+
+                    replicas = self.list_appconfig_replicas(self.resource_group, s.name) if self.include_replicas else []
+                    results.append(appconfig_to_dict(s, replicas, self.include_replicas))
+        except Exception as e:
+            self.log("Did not find appconfig in resource group {0} : {1}.".format(self.resource_group, str(e)))
+
+        return results
+
+    def list_appconfig_by_subscription(self):
+        '''
+        List the properties of app configuration stores in specific subscription.
+
+        :return: deserialized app configuration stores state dictionary.
+        '''
+        results = []
+        try:
+            stores = list(self._client.configuration_stores.list())
+
+            for s in stores:
+                if not self.has_tags(s.tags, self.tags):
+                    continue
+
+                # parse ID to retrieve RG + name
+                parts = s.id.split("/")
+                rg = parts[4]
+                name = parts[8]
+
+                replicas = self.list_appconfig_replicas(rg, name) if self.include_replicas else []
+
+                store_obj = self._client.configuration_stores.get(rg, name)
+                results.append(appconfig_to_dict(store_obj, replicas, self.include_replicas))
+        except Exception as e:
+            self.log("Did not find appconfig in current subscription {0}.", format(str(e)))
+        return results
+
+    def list_appconfig_replicas(self, rg, name):
+        '''
+        List replicas of the specific app configuration stores
+
+        :return: name, id and location of the replicas
+        '''
+        rlist = []
+        pager = self._client.replicas.list_by_configuration_store(resource_group_name=rg,
+                                                                  config_store_name=name)
+        for r in pager:
+            rlist.append(dict(id=r.id,
+                              name=r.name,
+                              location=r.location))
+        return rlist
+
+
+def main():
+    """Main execution"""
+    AzureRMAppConfigurationInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -36,6 +36,7 @@ parameters:
       - "azure_rm_aks"
       - "azure_rm_aksagentpool"
       - "azure_rm_apimanagement"
+      - "azure_rm_appconfiguration"
       - "azure_rm_appgateway"
       - "azure_rm_appserviceplan"
       - "azure_rm_automationaccount"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ azure-iot-hub==2.6.1;platform_machine=="x86_64"
 azure-keyvault==4.2.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-apimanagement==4.0.1
+azure-mgmt-appconfiguration==5.0.0
 azure-mgmt-authorization==4.0.0
 azure-mgmt-automation==1.1.0b4
 azure-mgmt-batch==17.3.0

--- a/tests/integration/targets/azure_rm_appconfiguration/aliases
+++ b/tests/integration/targets/azure_rm_appconfiguration/aliases
@@ -1,0 +1,4 @@
+cloud/azure
+destructive
+shippable/azure/group13
+needs/file/tests/integration_common_tasks/managed_identity.yml

--- a/tests/integration/targets/azure_rm_appconfiguration/meta/main.yml
+++ b/tests/integration/targets/azure_rm_appconfiguration/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_appconfiguration/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfiguration/tasks/main.yml
@@ -1,0 +1,167 @@
+- name: Create a new resource group for app configuration test
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}-appconfig"
+    location: eastus
+
+- name: For App Configuration test
+  block:
+    - name: Prepare random number
+      ansible.builtin.set_fact:
+        rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+        tenant_id: "{{ azure_tenant }}"
+      run_once: true
+
+    - name: Gather Resource Group info
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ resource_group }}-appconfig"
+      register: __rg_info
+
+    - name: Set location and managed_identity_ids
+      ansible.builtin.set_fact:
+        location: "eastus2"
+        # location: "{{ __rg_info.resourcegroups.0.location }}"
+        managed_identity_ids: []
+        new_resource_group: "{{ resource_group }}-appconfig"
+
+    - name: Create user managed identities
+      ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
+      vars:
+        managed_identity_test_unique: 'AppConfig'
+        managed_identity_unique: "{{ item }}"
+        managed_identity_action: 'create'
+        managed_identity_location: "{{ location }}"
+        resource_group: "{{ new_resource_group }}"
+      with_items:
+        - '1'
+
+    - name: Create App Configuration Store
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        sku: standard
+        identity:
+          type: SystemAssigned
+        disable_local_auth: false
+        public_network_access: Enabled
+        replicas:
+          - name: replica1
+            location: westus
+          - name: replica2
+            location: eastus2
+        state: present
+      register: create_result
+    - name: Assert the resource instance is well created
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+
+    - name: Create instance of App Configuration Store again (idempotent)
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        sku: standard
+        identity:
+          type: SystemAssigned
+        disable_local_auth: false
+        public_network_access: Enabled
+        replicas:
+          - name: replica1
+            location: westus
+          - name: replica2
+            location: eastus2
+        state: present
+      register: create_again
+    - name: Assert state not changed on idempotent create
+      ansible.builtin.assert:
+        that:
+          - create_again is not changed
+
+    - name: Update existing App Configuration (attach UAMI; PNA Disabled; change replicas)
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        sku: standard
+        identity:
+          type: "SystemAssigned, UserAssigned"
+          user_assigned_identity_ids:
+          - "{{ managed_identity_ids[0] }}"
+        disable_local_auth: true
+        public_network_access: Disabled
+        replicas:
+          - name: replica1
+            location: westus
+          - name: replica3
+            location: westus2
+        state: present
+      register: update_result
+    - name: Assert the state has changed
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+
+    - name: Get App Configuration facts (single store, with replicas)
+      azure.azcollection.azure_rm_appconfiguration_info:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        include_replicas: true
+      register: facts_single
+
+    - name: Assert the facts are properly set (single + replicas)
+      ansible.builtin.assert:
+        that:
+          - facts_single.appconfigurations | length == 1
+          - facts_single.appconfigurations[0].appconfig_name == appconfig{{ rpfx }}
+          - facts_single.appconfigurations[0].public_network_access | lower == 'disabled'
+          - facts_single.appconfigurations[0].disable_local_auth | bool == true
+          - "'replica1' in (facts_single.appconfigurations[0].replicas | map(attribute='name') | list)"
+          - "'replica3' in (facts_single.appconfigurations[0].replicas | map(attribute='name') | list)"
+
+    - name: Delete App Configuration (soft delete)
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        state: absent
+      register: delete_result
+    - name: Assert the state has changed
+      ansible.builtin.assert:
+        that:
+          - delete_result is changed
+
+    - name: Delete unexisting App Configuration (no-op)
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        state: absent
+      register: delete_again
+    - name: Assert the state has no changed
+      ansible.builtin.assert:
+        that:
+          - delete_again is not changed
+
+    - name: Purge the deleted vault
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfig"
+        appconfig_name: "appconfig{{ rpfx }}"
+        is_purge_deleted: true
+        state: absent
+      register: purge_result
+    - name: Show purge result
+      ansible.builtin.debug:
+        var: purge_result
+
+    - name: Delete user managed identities
+      ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
+      vars:
+        managed_identity_test_unique: 'AppConfig'
+        managed_identity_unique: "{{ item }}"
+        managed_identity_action: 'delete'
+        managed_identity_location: "{{ location }}"
+        resource_group: "{{ new_resource_group }}"
+      with_items:
+        - '1'
+  always:
+    - name: Force delete the resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ resource_group }}-appconfig"
+        force_delete_nonempty: true
+        state: absent

--- a/tests/integration/targets/azure_rm_appconfiguration/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfiguration/tasks/main.yml
@@ -84,7 +84,7 @@
         identity:
           type: "SystemAssigned, UserAssigned"
           user_assigned_identity_ids:
-          - "{{ managed_identity_ids[0] }}"
+            - "{{ managed_identity_ids[0] }}"
         disable_local_auth: true
         public_network_access: Disabled
         replicas:
@@ -110,7 +110,7 @@
       ansible.builtin.assert:
         that:
           - facts_single.appconfigurations | length == 1
-          - facts_single.appconfigurations[0].appconfig_name == appconfig{{ rpfx }}
+          - facts_single.appconfigurations[0].appconfig_name != None
           - facts_single.appconfigurations[0].public_network_access | lower == 'disabled'
           - facts_single.appconfigurations[0].disable_local_auth | bool == true
           - "'replica1' in (facts_single.appconfigurations[0].replicas | map(attribute='name') | list)"


### PR DESCRIPTION
##### SUMMARY
Introduces full **Azure App Configuration management-plane support**.
- `azure_rm_appconfiguration` - Create, update, delete, purge, and manage replicas of App Configuration Stores
- `azure_rm_appconfiguration_info` - Retrieve App Configuration Store facts (single, resource_group, subscription), with optional replica enumeration.

Module request: #330 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py
plugins/modules/azure_rm_appconfiguration.py
plugins/modules/azure_rm_appconfiguration_info.py
pr-pipelines.yml
requirements.txt
tests/integration/targets/azure_rm_appconfiguration/aliases
tests/integration/targets/azure_rm_appconfiguration/tasks/main.yml

##### ADDITIONAL INFORMATION
References: 
- https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview
- https://learn.microsoft.com/en-us/python/api/azure-mgmt-appconfiguration/azure.mgmt.appconfiguration.operations.configurationstoresoperations?view=azure-python#azure-mgmt-appconfiguration-operations-configurationstoresoperations-begin-create

##### FUTURE WORK:
- azure_rm_appconfigurationkey
- azure_rm_appconfigurationfeature
