### PR TITLE
Fixing support for using Metadata Endpoint (Azure Stack and other clo…

### DIFF
--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -42,8 +42,9 @@ options:
     cloud_environment:
         description:
             - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),
-              C(AzureUSGovernment)), or a metadata discovery endpoint URL (required for Azure Stack). Can also be set via credential file profile or
-              the C(AZURE_CLOUD_ENVIRONMENT) environment variable.
+              C(AzureUSGovernment)), or a resource manager URL (required for Azure Stack). Can also be set via credential file profile or
+              the C(AZURE_CLOUD_ENVIRONMENT) environment variable. If setting to a URL, you must also set the ARM_CLOUD_METADATA_URL if the cloud
+              is not registered with azcli.
         type: str
         default: AzureCloud
         version_added: '0.0.1'

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1674,7 +1674,7 @@ class AzureRMAuth(object):
                 if not urlparse.urlparse(raw_cloud_env).scheme:
                     self.fail("cloud_environment must be an endpoint discovery URL or one of {0}".format([x.name for x in all_clouds]))
                 try:
-                    self._cloud_environment = azure_cloud.get_cloud_from_metadata_endpoint(raw_cloud_env)
+                    self._cloud_environment = self._get_cloud_from_metadata_endpoint(raw_cloud_env)
                 except Exception as e:
                     self.fail("cloud_environment {0} could not be resolved: {1}".format(raw_cloud_env, e.message), exception=traceback.format_exc())
 
@@ -1791,7 +1791,7 @@ class AzureRMAuth(object):
                 if not urlparse.urlparse(_cloud_environment).scheme:
                     self.fail("cloud_environment must be an endpoint discovery URL or one of {0}".format([x.name for x in all_clouds]))
                 try:
-                    cloud_environment = azure_cloud.get_cloud_from_metadata_endpoint(_cloud_environment)
+                    cloud_environment = self._get_cloud_from_metadata_endpoint(_cloud_environment)
                 except Exception as exc:
                     self.fail("cloud_environment {0} could not be resolved: {1}".format(_cloud_environment, str(exc)), exception=traceback.format_exc())
 
@@ -1922,6 +1922,10 @@ class AzureRMAuth(object):
             self.log('Error getting AzureCLI profile credentials - {0}'.format(ce))
 
         return None
+
+    def _get_cloud_from_metadata_endpoint(self, metadata_endpoint):
+        _knownClouds = azure_cloud.KNOWN_CLOUDS
+        return next(cloud for cloud in _knownClouds if cloud.endpoints.resource_manager.lower().rstrip('/') == metadata_endpoint.lower().rstrip('/'))
 
     def log(self, msg, pretty_print=False):
         pass


### PR DESCRIPTION
…uds)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The authentication to Azure using a metadata discovery URL (for Azure Stack or non-default supported Azure clouds) does not work as the "get_cloud_from_metadata_endpoint" function does not exist in the current auth library used by this project

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2157 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #2157 for more detail. This fixes an issue only found when using Azure Stack or clouds not supported by default in the Azure Python SDK

