### PR TITLE
Adding data plane support for azure app configuration key

### DIFF
--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -1,0 +1,411 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_appconfigurationkey
+version_added: "3.15.0"
+short_description: Manage key-values (and Key Vault reference) in Azure App Configuration.
+description:
+    - Create, update, lock/unlock, or delete a key in an Azure App Configuration store.
+    - Supports both simple key-values (type=kv) and Key Vault reference (type=vault).
+    - For C(type=vault), the module writes the reference value and content-type required by App Configuration.
+
+options:
+    endpoint:
+        description:
+            - The App Configuration data-plane endpoint, for example C(https://myappconf.azconfig.io).
+        type: str
+        required: true
+    key:
+        description:
+            - Name of the configuration key.
+            - Together with I(label), identifies a single setting.
+        type: str
+        required: true
+    label:
+        description:
+            - Optional label to disambiguate settings with the same key.
+        type: str
+    type:
+        description:
+            - The setting type to manage.
+            - C(kv) creates/updates a plain key-value.
+            - C(vault) creates/updates a Key Vault reference entry.
+        type: str
+        choices:
+            - kv
+            - vault
+        default: kv
+    value:
+        description:
+            - The value for C(type=kv). Required when creating a new C(kv) setting.
+            - Ignored on updates if you only want to change I(content_type), or I(read_only).
+        type: str
+    content_type:
+        description:
+            - Content type metadata for the setting.
+            - Ignored for C(type=vault), the KV-reference content-type is fixed by the service.
+        type: str
+    vault_key_reference:
+        description:
+            - The versionless Key Vault Secret ID for a Key Vault reference C(type=vault).
+        type: str
+    read_only:
+        description:
+            - Whether the setting should be read-only in App Configuration.
+        type: bool
+    state:
+        description:
+            - Assert the state of the configuration setting. Use C(present) to create or update the setting and C(absent) to delete.
+        type: str
+        default: present
+        choices:
+            - absent
+            - present
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+
+'''
+
+EXAMPLES = '''
+- name: Create/Update a plain key-value
+  azure.azcollection.azure_rm_appconfigurationkey:
+    endpoint: https://myappconf.azconfig.io
+    key: "Payments:TimeoutSeconds"
+    label: "prod"
+    type: kv
+    value: "30"
+    content_type: "text/plain"
+    read_only: true
+    state: present
+
+- name: Create/Update a Key Vault reference (versionless secret ID)
+  azure.azcollection.azure_rm_appconfigurationkey:
+    endpoint: https://myappconf.azconfig.io
+    key: "Payments:ApiKey"
+    label: "prod"
+    type: vault
+    vault_key_reference: "https://myvault.vault.azure.net/secrets/my-secret/xxxx"
+    read_only: false
+    state: present
+
+- name: Delete a key
+  azure.azcollection.azure_rm_appconfigurationkey:
+    endpoint: https://myappconf.azconfig.io
+    key: "Legacy:Flag"
+    label: "prod"
+    state: absent
+
+'''
+
+RETURN = '''
+id:
+    description:
+        - Identifier of the configuration setting (data-plane URL form).
+    returned: always
+    type: str
+    example: https://myappconf.azconfig.io/kv/Payments:TimeoutSeconds?label=prod
+'''  # NOQA
+
+import json
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.appconfiguration import AzureAppConfigurationClient, ConfigurationSetting
+except ImportError:
+    # Handled in azure_rm_common_ext
+    pass
+
+
+VAULT_CT = "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8"
+
+
+class Actions:
+    NoAction, Create, Update, Delete = range(4)
+
+
+class AzureRMAppConfigurationKey(AzureRMModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            endpoint=dict(type='str', required=True),
+            key=dict(
+                type='str',
+                required=True,
+                no_log=False
+            ),
+            label=dict(type='str'),
+            type=dict(
+                type='str',
+                choices=['kv', 'vault'],
+                default='kv'
+            ),
+            value=dict(
+                type='str',
+                no_log=True
+            ),
+            content_type=dict(type='str'),
+            vault_key_reference=dict(type='str', no_log=True),
+            read_only=dict(type='bool'),
+
+            state=dict(
+                type='str',
+                default='present',
+                choices=['absent', 'present']
+            )
+        )
+
+        self.endpoint = None
+        self.key = None
+        self.label = None
+        self.type = None
+        self.value = None
+        self.content_type = None
+        self.vault_key_reference = None
+        self.read_only = None
+
+        self.dataplane_client = None
+        self.mgmt_client = None
+        self.state = None
+        self.parameters = dict()
+        self.results = dict(changed=False)
+        self.to_do = Actions.NoAction
+
+        super(AzureRMAppConfigurationKey, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                         supports_tags=False,
+                                                         supports_check_mode=True)
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+
+        for key in list(self.module_arg_spec.keys()):
+            if key in kwargs:
+                setattr(self, key, kwargs[key])
+            if key in kwargs and kwargs.get(key) is not None:
+                if key == 'type':
+                    self.parameters['type'] = kwargs[key]
+                elif key == 'content_type':
+                    self.parameters['content_type'] = kwargs[key]
+                elif key == 'value':
+                    self.parameters['value'] = kwargs[key]
+                elif key == 'vault_key_reference':
+                    self.parameters['vault_key_reference'] = kwargs[key]
+                elif key == 'read_only':
+                    self.parameters['read_only'] = bool(kwargs[key])
+
+        # Resolve endpoint if needed (from ARM ID)
+        self.mgmt_client = None
+
+        # Build data-plane client
+        self.dataplane_client = AzureAppConfigurationClient(self.endpoint,
+                                                            credential=self.azure_auth.azure_credential_track2)
+
+        # Read current
+        old_response = self.get_setting()
+        response = None
+
+        # Validation: kv vs value
+        if self.state == 'present' and old_response is None:
+            # default type if not provided
+            if self.type == 'kv' and self.value is None:
+                self.fail("Parameter 'value' is required when creating a type='kv' setting.")
+            if self.type == 'vault' and not self.vault_key_reference:
+                self.fail("Parameter 'vault_key_reference' is required when creating a type='vault' setting.")
+
+        # Decide action
+        if not old_response:
+            if self.state == 'absent':
+                self.log("Settings did not exist")
+                self.to_do = Actions.NoAction
+            else:
+                self.to_do = Actions.Create
+        else:
+            if self.state == 'absent':
+                self.to_do = Actions.Delete
+            else:
+                self.to_do = self._needs_update(old_response, self.parameters)
+
+        # unlock-first, upsert/delete, lock-finally
+        if self.to_do in (Actions.Create, Actions.Update):
+            # If the existing setting is locked, unlock BEFORE upsert.
+            original_ro = bool(old_response.get('read_only')) if old_response else False
+            if old_response and original_ro and not self.check_mode:
+                self.ensure_lock_state(False)
+
+            # Perform the upsert
+            self.results['changed'] = True
+            if not self.check_mode:
+                response = self.upsert_setting()
+
+            # Decide final lock state:
+            # If caller explicitly set read_only, honor it.
+            # Otherwise, restore the original lock (for updates).
+            final_ro = bool(self.read_only) if self.read_only is not None else original_ro
+            if not self.check_mode:
+                self.ensure_lock_state(final_ro)
+
+            if response is None:
+                response = self.get_setting()
+
+        elif self.to_do == Actions.Delete:
+            # If the existing setting is locked, unlock BEFORE delete.
+            original_ro = bool(old_response.get('read_only')) if old_response else False
+            if old_response and original_ro and not self.check_mode:
+                self.ensure_lock_state(False)
+
+            self.results['changed'] = True
+            if not self.check_mode:
+                self.delete_setting()
+            self.results['id'] = self._compose_id(self.endpoint, self.key, self.label)
+            return self.results
+
+        else:
+            # No data changes; converge lock ONLY if the user explicitly asked.
+            self.log("No action needed on the setting.")
+            self.results['changed'] = False
+            response = old_response
+
+            if response and self.read_only is not None:
+                current_ro = bool(response.get('read_only'))
+                desired_ro = bool(self.read_only)
+                if current_ro != desired_ro:
+                    self.results['changed'] = True
+                    if not self.check_mode:
+                        self.ensure_lock_state(desired_ro)
+                    response = self.get_setting()
+
+        if response:
+            self.results['id'] = self._compose_id(self.endpoint, self.key, self.label)
+
+        return self.results
+
+    def get_setting(self):
+        '''
+        Retrieve the current configuration setting from the data plane.
+
+        :return: The configuration setting as a dictionary, or False if not found.
+        '''
+        try:
+            response = self.dataplane_client.get_configuration_setting(key=self.key,
+                                                                       label=self.label)
+            return response.as_dict()
+        except ResourceNotFoundError:
+            return False
+
+    def upsert_setting(self):
+        '''
+        Upsert (create or update) the configuration setting in the data plane.
+
+        :return: The updated configuration setting as a dictionary.
+        '''
+        try:
+            if self.type == 'kv':
+                if self.value is not None:
+                    desired_value = self.value
+                else:
+                    cur = self.get_setting() or {}
+                    desired_value = cur.get('value', '')
+
+                cs = ConfigurationSetting(key=self.key,
+                                          label=self.label,
+                                          value=desired_value,
+                                          content_type=self.content_type)
+
+                response = self.dataplane_client.set_configuration_setting(configuration_setting=cs)
+            else:
+                # vault
+                payload = json.dumps({"uri": self.vault_key_reference})
+
+                cs = ConfigurationSetting(key=self.key,
+                                          label=self.label,
+                                          value=payload,
+                                          content_type=VAULT_CT)  # official KV-ref MIME
+
+                response = self.dataplane_client.set_configuration_setting(configuration_setting=cs)
+            return response.as_dict()
+        except Exception as exc:
+            self.fail("Error creating/updating the Configuration Setting '{}': {}".format(self.key, str(exc)))
+
+    def delete_setting(self):
+        '''
+        Delete the configuration setting from the data plane.
+
+        :return: The deleted configuration setting as a dictionary.
+        '''
+        try:
+            response = self.dataplane_client.delete_configuration_setting(key=self.key,
+                                                                          label=self.label)
+            return response.as_dict()
+        except Exception as exc:
+            self.fail("Error deleting the Configuration Setting '{}': {}".format(self.key, str(exc)))
+
+    def ensure_lock_state(self, read_only):
+        '''
+        Converge the read-only (lock) state of the setting.
+
+        :return: The updated configuration setting as a dictionary.
+        '''
+        try:
+            cs = ConfigurationSetting(key=self.key, label=self.label)
+            response = self.dataplane_client.set_read_only(configuration_setting=cs,
+                                                           read_only=bool(read_only))
+            return response.as_dict()
+        except Exception as exc:
+            self.fail("Error setting read_only={} on Configuration Setting '{}': {}".format(read_only, self.key, str(exc)))
+
+    def _needs_update(self, old, new_params):
+        '''
+        Determine whether an update is required by comparing fields, honoring user intent.
+
+        :return: Actions.Update or Actions.NoAction
+        '''
+        to_do = Actions.NoAction
+        # type
+        if (old.get('type') or 'kv') != (new_params.get('type') or 'kv'):
+            to_do = Actions.Update
+
+        if (new_params.get('type') or 'kv') == 'kv':
+            if self.value is not None and old.get('value') != self.value:
+                to_do = Actions.Update
+            if self.content_type is not None and (self.content_type or None) != (old.get('content_type') or None):
+                to_do = Actions.Update
+        else:
+            if self.vault_key_reference is not None and old.get('vault_key_reference') != self.vault_key_reference:
+                to_do = Actions.Update
+
+        return to_do
+
+    @staticmethod
+    def _compose_id(endpoint, key, label):
+        '''
+        Compose a deterministic data-plane identifier for the setting.
+        - With label: "<endpoint>/kv/<key>?label=<label>"
+        - Without label: "<endpoint>/kv/<key>"
+
+        :return: The composed identifier string.
+        '''
+        base = endpoint.rstrip('/')
+        if label:
+            return f"{base}/kv/{key}?label={label}"
+        return f"{base}/kv/{key}"
+
+
+def main():
+    """Main execution"""
+    AzureRMAppConfigurationKey()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -298,11 +298,16 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
         :return: The configuration setting as a dictionary, or False if not found.
         '''
         try:
-            response = self.dataplane_client.get_configuration_setting(key=self.key,
-                                                                       label=self.label)
+            response = self.dataplane_client.get_configuration_setting(
+                key=self.key,
+                label=self.label
+            )
             return response.as_dict()
         except ResourceNotFoundError:
             return False
+        except Exception as e:
+            # Catch SDK bug: empty response causes JSONDecodeError
+            self.fail("Failed to retrieve setting '{}': {}\n{}".format(self.key, str(e), traceback.format_exc()))
 
     def upsert_setting(self):
         '''
@@ -402,17 +407,9 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
         return f"{base}/kv/{key}"
 
 
-# def main():
-#     """Main execution"""
-#     AzureRMAppConfigurationKey()
-
 def main():
     """Main execution"""
-    try:
-        AzureRMAppConfigurationKey()
-    except Exception as e:
-        import traceback
-        raise Exception("Module failed during initialisation: {}\n{}".format(str(e), traceback.format_exc()))   
+    AzureRMAppConfigurationKey()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -107,7 +107,6 @@ EXAMPLES = '''
     key: "Legacy:Flag"
     label: "prod"
     state: absent
-
 '''
 
 RETURN = '''
@@ -120,7 +119,7 @@ id:
 '''  # NOQA
 
 import json
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
@@ -137,7 +136,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMAppConfigurationKey(AzureRMModuleBase):
+class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
     def __init__(self):
         self.module_arg_spec = dict(
             endpoint=dict(type='str', required=True),

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -5,7 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-import traceback
 __metaclass__ = type
 
 
@@ -120,6 +119,7 @@ id:
 '''  # NOQA
 
 import json
+import traceback
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
 try:

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -118,6 +118,7 @@ id:
     example: https://myappconf.azconfig.io/kv/Payments:TimeoutSeconds?label=prod
 '''  # NOQA
 
+import traceback
 import json
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
@@ -288,7 +289,10 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
         if response:
             self.results['id'] = self._compose_id(self.endpoint, self.key, self.label)
 
-        return self.results
+        try:
+            return self.results
+        except Exception as e:
+            self.fail("Module crashed during return: {}\n{}".format(str(e), traceback.format_exc()))    
 
     def get_setting(self):
         '''

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -412,8 +412,7 @@ def main():
         AzureRMAppConfigurationKey()
     except Exception as e:
         import traceback
-        from ansible.module_utils.basic import AnsibleModule
-        AnsibleModule(argument_spec={}).fail_json(msg="Module failed during initialisation: {}\n{}".format(str(e), traceback.format_exc()))
+        raise Exception("Module failed during initialisation: {}\n{}".format(str(e), traceback.format_exc()))   
 
 
 if __name__ == '__main__':

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+import traceback
 __metaclass__ = type
 
 
@@ -118,7 +119,6 @@ id:
     example: https://myappconf.azconfig.io/kv/Payments:TimeoutSeconds?label=prod
 '''  # NOQA
 
-import traceback
 import json
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
@@ -289,10 +289,7 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
         if response:
             self.results['id'] = self._compose_id(self.endpoint, self.key, self.label)
 
-        try:
-            return self.results
-        except Exception as e:
-            self.fail("Module crashed during return: {}\n{}".format(str(e), traceback.format_exc()))    
+        return self.results
 
     def get_setting(self):
         '''
@@ -405,9 +402,18 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
         return f"{base}/kv/{key}"
 
 
+# def main():
+#     """Main execution"""
+#     AzureRMAppConfigurationKey()
+
 def main():
     """Main execution"""
-    AzureRMAppConfigurationKey()
+    try:
+        AzureRMAppConfigurationKey()
+    except Exception as e:
+        import traceback
+        from ansible.module_utils.basic import AnsibleModule
+        AnsibleModule(argument_spec={}).fail_json(msg="Module failed during initialisation: {}\n{}".format(str(e), traceback.format_exc()))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/azure_rm_appconfigurationkey_info.py
+++ b/plugins/modules/azure_rm_appconfigurationkey_info.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_appconfigurationkey_info
+version_added: "3.15.0"
+short_description: Get key-values (and Key Vault references) from Azure App Configuration.
+description:
+    - Read configuration settings (key-values or Key Vault references) from an Azure App Configuration store.
+    - Supports lookup by key, by label, or by full listing.
+
+options:
+    endpoint:
+        description:
+            - The App Configuration data-plane endpoint, e.g. C(https://myappconf.azconfig.io).
+        required: true
+        type: str
+    key:
+        description:
+            - Optional key filter. Supports exact key.
+        type: str
+    label:
+        description:
+            - Optional label filter.
+        type: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: List all settings via endpoint
+  azure.azcollection.azure_rm_appconfigurationkey_info:
+    endpoint: https://myappconf.azconfig.io
+
+- name: Get settings with a specific key + label
+  azure.azcollection.azure_rm_appconfigurationkey_info:
+    endpoint: https://myappconf.azconfig.io
+    key: "Payments:TimeoutSeconds"
+    label: "prod"
+'''
+
+RETURN = '''
+settings:
+    description:
+        - List of configuration settings returned from the store.
+    returned: always
+    type: list
+    contains:
+        key:
+            description:
+                - The key of the configuration setting.
+            type: str
+            returned: always
+            sample: "Payments:TimeoutSeconds"
+        label:
+            description:
+                - The label of the configuration setting.
+            type: str
+            returned: always
+            sample: "prod"
+        value:
+            description:
+                - The value for C(type=kv).
+            type: str
+            returned: always
+            sample: "30"
+        content_type:
+            description:
+                - Content type metadata for the setting.
+            type: str
+            returned: always
+            sample: "application/json"
+        read_only:
+            description:
+                - Whether the setting is read-only in App Configuration.
+            type: bool
+            returned: always
+            sample: false
+        type:
+            description:
+                - The type of the configuration setting. Possible values are C(kv) and C(vault).
+            type: str
+            returned: always
+            sample: "kv"
+        vault_key_reference:
+            description:
+                - The Key Vault reference details for C(type=vault).
+            type: str
+            returned: when applicable
+            sample: "https://myvault.vault.azure.net/secrets/mysecret/xxxx"
+        id:
+            description:
+                - The unique identifier of the configuration setting.
+            type: str
+            returned: always
+            sample: "https://myappconf.azconfig.io/kv/Payments:TimeoutSeconds?label=prod"
+'''
+
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.appconfiguration import AzureAppConfigurationClient
+except ImportError:
+    pass
+
+
+def normalize_setting(s, endpoint):
+    d = s.as_dict()
+    # infer type
+    ct = (d.get("content_type") or "").lower()
+    if ct.startswith("application/vnd.microsoft.appconfig.keyvaultref"):
+        d["type"] = "vault"
+        try:
+            import json
+            body = json.loads(d.get("value") or "{}")
+            d["vault_key_reference"] = body.get("uri")
+        except Exception:
+            d["vault_key_reference"] = None
+    else:
+        d["type"] = "kv"
+        d["vault_key_reference"] = None
+
+    # add composed id
+    base = endpoint.rstrip('/')
+    key = d.get("key")
+    label = d.get("label")
+    if label:
+        d["id"] = f"{base}/kv/{key}?label={label}"
+    else:
+        d["id"] = f"{base}/kv/{key}"
+    return d
+
+
+class AzureRMAppConfigurationKeyInfo(AzureRMModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            endpoint=dict(type='str', required=True),
+            key=dict(type='str', no_log=False),
+            label=dict(type='str')
+        )
+
+        self.endpoint = None
+        self.key = None
+        self.label = None
+
+        self.dataplane_client = None
+        self.mgmt_client = None
+        self.results = dict(changed=False)
+
+        super(AzureRMAppConfigurationKeyInfo, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                             supports_tags=False,
+                                                             supports_check_mode=True)
+
+    def exec_module(self, **kwargs):
+        for k in self.module_arg_spec.keys():
+            setattr(self, k, kwargs.get(k))
+
+        self.dataplane_client = AzureAppConfigurationClient(self.endpoint,
+                                                            credential=self.azure_auth.azure_credential_track2)
+
+        out = []
+        items = self.dataplane_client.list_configuration_settings(key_filter=self.key, label_filter=self.label)
+
+        for s in items:
+            nd = normalize_setting(s, self.endpoint)
+            out.append(nd)
+
+        self.results["settings"] = out
+        return self.results
+
+
+def main():
+    AzureRMAppConfigurationKeyInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -37,6 +37,7 @@ parameters:
       - "azure_rm_aksagentpool"
       - "azure_rm_apimanagement"
       - "azure_rm_appconfiguration"
+      - "azure_rm_appconfigurationkey"
       - "azure_rm_appgateway"
       - "azure_rm_appserviceplan"
       - "azure_rm_automationaccount"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp>=3.13.0
+azure-appconfiguration==1.8.0
 azure-cli-core==2.75.0
 azure-common==1.1.28
 azure-containerregistry==1.2.0

--- a/tests/integration/targets/azure_rm_appconfigurationkey/aliases
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+destructive
+shippable/azure/group13

--- a/tests/integration/targets/azure_rm_appconfigurationkey/meta/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -43,29 +43,6 @@
       ansible.builtin.set_fact:
         endpoint: "{{ store_info.appconfigurations[0].endpoint }}"
 
-    - name: Set AppConfig principalId
-      ansible.builtin.set_fact:
-        appconfig_principal_id: "{{ store_info.appconfigurations[0].identity.principal_id }}"
-
-    - name: Lookup service principal object id
-      ansible.builtin.set_fact:
-        object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
-                       azure_client_id=azure_client_id,
-                       azure_secret=azure_secret,
-                       azure_tenant=tenant_id) }}"
-      register: object_id_facts
-
-    - name: Assign App Configuration Data Owner role to managed identity
-      azure.azcollection.azure_rm_roleassignment:
-        scope: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-appconfigkey/providers/Microsoft.AppConfiguration/configurationStores/appconfig{{ rpfx }}"
-        role_definition_id: "/subscriptions/{{ azure_subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b"  # App Configuration Data Owner
-        assignee_object_id: "{{ object_id }}"
-        state: present
-
-    - name: Wait for data-plane RBAC to propagate
-      ansible.builtin.pause:
-        seconds: 120
-
     - name: Create KV setting
       azure.azcollection.azure_rm_appconfigurationkey:
         endpoint: "{{ endpoint }}"

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -23,7 +23,7 @@
         sku: standard
         identity:
           type: SystemAssigned
-        disable_local_auth: true
+        disable_local_auth: false
         public_network_access: Enabled
         state: present
       register: create_result
@@ -47,11 +47,19 @@
       ansible.builtin.set_fact:
         appconfig_principal_id: "{{ store_info.appconfigurations[0].identity.principal_id }}"
 
+    - name: Lookup service principal object id
+      ansible.builtin.set_fact:
+        object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
+                       azure_client_id=azure_client_id,
+                       azure_secret=azure_secret,
+                       azure_tenant=tenant_id) }}"
+      register: object_id_facts
+
     - name: Assign App Configuration Data Owner role to managed identity
       azure.azcollection.azure_rm_roleassignment:
         scope: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-appconfigkey/providers/Microsoft.AppConfiguration/configurationStores/appconfig{{ rpfx }}"
         role_definition_id: "/subscriptions/{{ azure_subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b"  # App Configuration Data Owner
-        assignee_object_id: "{{ appconfig_principal_id }}"
+        assignee_object_id: "{{ object_id }}"
         state: present
 
     - name: Create KV setting

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -1,0 +1,219 @@
+- name: Create a new resource group for app configuration key test
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}-appconfigkey"
+    location: eastus
+
+- name: For App Configuration key test
+  block:
+    - name: Prepare random prefix
+      ansible.builtin.set_fact:
+        rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+        tenant_id: "{{ azure_tenant }}"
+      run_once: true
+
+    - name: Gather Resource Group info
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ resource_group }}-appconfigkey"
+      register: __rg_info
+
+    - name: Create App Configuration Store
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfigkey"
+        appconfig_name: "appconfig{{ rpfx }}"
+        sku: standard
+        identity:
+          type: SystemAssigned
+        disable_local_auth: false
+        public_network_access: Enabled
+        state: present
+      register: create_result
+    - name: Assert the resource instance is created
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+
+    - name: Get existing AppConfig store
+      azure.azcollection.azure_rm_appconfiguration_info:
+        resource_group: "{{ resource_group }}-appconfigkey"
+        appconfig_name: "appconfig{{ rpfx }}"
+        include_replicas: false
+      register: store_info
+
+    - name: Extract endpoint
+      ansible.builtin.set_fact:
+        endpoint: "{{ store_info.appconfigurations[0].endpoint }}"
+
+    - name: Create KV setting
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+        type: kv
+        value: "45"
+        content_type: "text/plain"
+        read_only: false
+        state: present
+      register: kv_create
+    - name: Assert KV created
+      ansible.builtin.assert:
+        that:
+          - kv_create is changed
+
+    - name: Recreate KV setting (idempotent)
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+        type: kv
+        value: "45"
+        content_type: "text/plain"
+        read_only: false
+        state: present
+      register: kv_idem
+    - name: Assert KV setting is idempotent
+      ansible.builtin.assert:
+        that:
+          - kv_idem is not changed
+
+    - name: Get KV setting facts
+      azure.azcollection.azure_rm_appconfigurationkey_info:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+      register: kv_info
+    - name: Assert info module returns KV
+      ansible.builtin.assert:
+        that:
+          - kv_info.settings | length == 1
+          - kv_info.settings[0].type == 'kv'
+          - kv_info.settings[0].value == '45'
+
+    - name: Update KV value and content_type
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+        type: kv
+        value: "60"
+        content_type: "application/json"
+        read_only: true
+        state: present
+      register: kv_update
+    - name: Assert KV updated
+      ansible.builtin.assert:
+        that:
+          - kv_update is changed
+
+    - name: Get KV info after update
+      azure.azcollection.azure_rm_appconfigurationkey_info:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+      register: kv_info_after
+    - name: Assert KV updated facts
+      ansible.builtin.assert:
+        that:
+          - kv_info_after.settings[0].value == '60'
+          - kv_info_after.settings[0].content_type == 'application/json'
+          - kv_info_after.settings[0].read_only == true
+
+    - name: Create Vault reference setting (dummy URI)
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:ApiKey"
+        label: "vault-prod"
+        type: vault
+        vault_key_reference: "https://dummyvault.vault.azure.net/secrets/mysecret/1234567890abcdef"
+        read_only: false
+        state: present
+      register: vault_create
+    - name: Assert vault reference is created
+      ansible.builtin.assert:
+        that:
+          - vault_create is changed
+
+    - name: Get vault reference info
+      azure.azcollection.azure_rm_appconfigurationkey_info:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:ApiKey"
+        label: "vault-prod"
+      register: vault_info
+    - name: Assert vault info
+      ansible.builtin.assert:
+        that:
+          - vault_info.settings | length == 1
+          - vault_info.settings[0].type == 'vault'
+          - vault_info.settings[0].vault_key_reference is not none
+
+    - name: Unlock KV setting
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+        read_only: false
+        state: present
+      register: kv_unlock
+
+    - name: Assert KV unlocked
+      ansible.builtin.assert:
+        that:
+          - kv_unlock is changed
+
+    - name: Delete KV setting
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:TimeoutSeconds"
+        label: "dev"
+        state: absent
+      register: kv_delete
+
+    - name: Assert KV deleted
+      ansible.builtin.assert:
+        that:
+          - kv_delete is changed
+
+    - name: Delete vault reference
+      azure.azcollection.azure_rm_appconfigurationkey:
+        endpoint: "{{ endpoint }}"
+        key: "Payments:ApiKey"
+        label: "vault-prod"
+        state: absent
+      register: vault_delete
+
+    - name: Assert vault reference deleted
+      ansible.builtin.assert:
+        that:
+          - vault_delete is changed
+
+    - name: Delete App Configuration store (soft delete)
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfigkey"
+        appconfig_name: "appconfig{{ rpfx }}"
+        state: absent
+      register: appconf_delete
+
+    - name: Assert AppConfig is deleted
+      ansible.builtin.assert:
+        that:
+          - appconf_delete is changed
+
+    - name: Purge deleted App Configuration
+      azure.azcollection.azure_rm_appconfiguration:
+        resource_group: "{{ resource_group }}-appconfigkey"
+        appconfig_name: "appconfig{{ rpfx }}"
+        is_purge_deleted: true
+        location: eastus
+        state: absent
+      register: appconf_purge
+
+    - name: Assert purge done
+      ansible.builtin.assert:
+        that:
+          - appconf_purge is changed
+
+  always:
+    - name: Force delete the resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ resource_group }}-appconfigkey"
+        force_delete_nonempty: true
+        state: absent

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -229,11 +229,6 @@
         state: absent
       register: appconf_purge
 
-    - name: Assert purge done
-      ansible.builtin.assert:
-        that:
-          - appconf_purge is changed
-
   always:
     - name: Force delete the resource group
       azure.azcollection.azure_rm_resourcegroup:

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -24,7 +24,7 @@
         identity:
           type: SystemAssigned
         disable_local_auth: true
-        public_network_access: Disabled
+        public_network_access: Enabled
         state: present
       register: create_result
     - name: Assert the resource instance is created
@@ -43,7 +43,7 @@
       ansible.builtin.set_fact:
         endpoint: "{{ store_info.appconfigurations[0].endpoint }}"
 
-    - name:  Set AppConfig principalId
+    - name: Set AppConfig principalId
       ansible.builtin.set_fact:
         appconfig_principal_id: "{{ store_info.appconfigurations[0].identity.principal_id }}"
 

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -47,6 +47,25 @@
       ansible.builtin.set_fact:
         appconfig_principal_id: "{{ store_info.appconfigurations[0].identity.principal_id }}"
 
+    - name: Lookup service principal object id
+      ansible.builtin.set_fact:
+        object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
+                       azure_client_id=azure_client_id,
+                       azure_secret=azure_secret,
+                       azure_tenant=tenant_id) }}"
+      register: object_id_facts
+
+    - name: Assign App Configuration Data Owner role to managed identity
+      azure.azcollection.azure_rm_roleassignment:
+        scope: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-appconfigkey/providers/Microsoft.AppConfiguration/configurationStores/appconfig{{ rpfx }}"
+        role_definition_id: "/subscriptions/{{ azure_subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b"  # App Configuration Data Owner
+        assignee_object_id: "{{ object_id }}"
+        state: present
+
+    - name: Wait for data-plane RBAC to propagate
+      ansible.builtin.pause:
+        seconds: 120
+
     - name: Create KV setting
       azure.azcollection.azure_rm_appconfigurationkey:
         endpoint: "{{ endpoint }}"

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -16,32 +16,13 @@
         name: "{{ resource_group }}-appconfigkey"
       register: __rg_info
 
-    - name: Set location and managed_identity_ids
-      ansible.builtin.set_fact:
-        location: "eastus"
-        managed_identity_ids: []
-        new_resource_group: "{{ resource_group }}-appconfigkey"
-
-    - name: Create user managed identities
-      ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
-      vars:
-        managed_identity_test_unique: 'AppConfig'
-        managed_identity_unique: "{{ item }}"
-        managed_identity_action: 'create'
-        managed_identity_location: "{{ location }}"
-        resource_group: "{{ new_resource_group }}"
-      with_items:
-        - '1'
-
     - name: Create App Configuration Store
       azure.azcollection.azure_rm_appconfiguration:
         resource_group: "{{ resource_group }}-appconfigkey"
         appconfig_name: "appconfig{{ rpfx }}"
         sku: standard
         identity:
-          type: UserAssigned
-        user_assigned_identity_ids:
-          - "{{ managed_identity_ids[0] }}"
+          type: SystemAssigned
         disable_local_auth: true
         public_network_access: Disabled
         state: present
@@ -61,6 +42,17 @@
     - name: Extract endpoint
       ansible.builtin.set_fact:
         endpoint: "{{ store_info.appconfigurations[0].endpoint }}"
+
+    - name:  Set AppConfig principalId
+      ansible.builtin.set_fact:
+        appconfig_principal_id: "{{ store_info.appconfigurations[0].identity.principal_id }}"
+
+    - name: Assign App Configuration Data Owner role to managed identity
+      azure.azcollection.azure_rm_roleassignment:
+        scope: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-appconfigkey/providers/Microsoft.AppConfiguration/configurationStores/appconfig{{ rpfx }}"
+        role_definition_id: "/subscriptions/{{ azure_subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b"  # App Configuration Data Owner
+        assignee_object_id: "{{ appconfig_principal_id }}"
+        state: present
 
     - name: Create KV setting
       azure.azcollection.azure_rm_appconfigurationkey:

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -47,21 +47,6 @@
       ansible.builtin.set_fact:
         appconfig_principal_id: "{{ store_info.appconfigurations[0].identity.principal_id }}"
 
-    - name: Lookup service principal object id
-      ansible.builtin.set_fact:
-        object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
-                       azure_client_id=azure_client_id,
-                       azure_secret=azure_secret,
-                       azure_tenant=tenant_id) }}"
-      register: object_id_facts
-
-    - name: Assign App Configuration Data Owner role to managed identity
-      azure.azcollection.azure_rm_roleassignment:
-        scope: "/subscriptions/{{ azure_subscription_id }}/resourceGroups/{{ resource_group }}-appconfigkey/providers/Microsoft.AppConfiguration/configurationStores/appconfig{{ rpfx }}"
-        role_definition_id: "/subscriptions/{{ azure_subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b"  # App Configuration Data Owner
-        assignee_object_id: "{{ object_id }}"
-        state: present
-
     - name: Create KV setting
       azure.azcollection.azure_rm_appconfigurationkey:
         endpoint: "{{ endpoint }}"

--- a/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml
@@ -16,15 +16,34 @@
         name: "{{ resource_group }}-appconfigkey"
       register: __rg_info
 
+    - name: Set location and managed_identity_ids
+      ansible.builtin.set_fact:
+        location: "eastus"
+        managed_identity_ids: []
+        new_resource_group: "{{ resource_group }}-appconfigkey"
+
+    - name: Create user managed identities
+      ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
+      vars:
+        managed_identity_test_unique: 'AppConfig'
+        managed_identity_unique: "{{ item }}"
+        managed_identity_action: 'create'
+        managed_identity_location: "{{ location }}"
+        resource_group: "{{ new_resource_group }}"
+      with_items:
+        - '1'
+
     - name: Create App Configuration Store
       azure.azcollection.azure_rm_appconfiguration:
         resource_group: "{{ resource_group }}-appconfigkey"
         appconfig_name: "appconfig{{ rpfx }}"
         sku: standard
         identity:
-          type: SystemAssigned
-        disable_local_auth: false
-        public_network_access: Enabled
+          type: UserAssigned
+        user_assigned_identity_ids:
+          - "{{ managed_identity_ids[0] }}"
+        disable_local_auth: true
+        public_network_access: Disabled
         state: present
       register: create_result
     - name: Assert the resource instance is created


### PR DESCRIPTION
##### SUMMARY
Introduces **Azure App Configuration Key data-plane support**.
- `azure_rm_appconfigurationkey` - Create, update, lock/unlock, and delete configuration settings (type=kv or vault) in an App Configuration store. Supports Endpoint-first auth with Entra ID and deterministic data‑plane IDs (`<endpoint>/kv/<key>?label=<label>`).
- `azure_rm_appconfigurationkey_info` -Read configuration settings from the data plane with key/label filtering and normalization (reports type=kv|vault, extracts vault_key_reference, returns composed id).

Module request: #330 
Management plane refer #2156 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_appconfigurationkey.py
plugins/modules/azure_rm_appconfigurationkey_info.py
pr-pipelines.yml
requirements.txt
tests/integration/targets/azure_rm_appconfigurationkey/aliases
tests/integration/targets/azure_rm_appconfigurationkey/tasks/main.yml

##### ADDITIONAL INFORMATION
References: 
- https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview
- https://pypi.org/project/azure-appconfiguration/#create-a-configuration-setting