### PR TITLE
Migrate azure_rm_keyvault_info to support API 2026-02-01

### DIFF
--- a/plugins/modules/azure_rm_keyvault_info.py
+++ b/plugins/modules/azure_rm_keyvault_info.py
@@ -343,7 +343,7 @@ class AzureRMKeyVaultInfo(AzureRMModuleBase):
 
         self._client = self.get_mgmt_svc_client(KeyVaultManagementClient,
                                                 base_url=self._cloud_environment.endpoints.resource_manager,
-                                                api_version="2023-07-01")
+                                                api_version="2026-02-01")
 
         if self.name:
             if self.resource_group:


### PR DESCRIPTION
##### SUMMARY
This PR updates the `azure_rm_keyvault_info` module to use latest Azure Key Vault API version 2026-02-01

Follow-up: #2154 

##### COMPONENT NAME
plugins/modules/azure_rm_keyvaultinfo.py

Reference: https://learn.microsoft.com/en-us/azure/key-vault/general/access-control-default?tabs=azure-cli
