### PR TITLE
Fix crashes when processing VMs in failed or creating states

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -808,7 +808,7 @@ class AzureHost(object):
                                           api_version=self._inventory_client._compute_api_version,
                                           handler=self._on_instanceview_response)
 
-        nic_refs = vm_model['properties']['networkProfile']['networkInterfaces']
+        nic_refs = vm_model['properties'].get('networkProfile', dict()).get('networkInterfaces', [])
         for nic in nic_refs:
             # single-nic instances don't set primary, so figure it out...
             is_primary = nic.get('properties', {}).get('primary', len(nic_refs) == 1)
@@ -849,7 +849,7 @@ class AzureHost(object):
 
         createdAt = self._vm_model.get('systemData', {}).get('createdAt')  # hci specific
 
-        if self._instanceview.get('computerName'):
+        if self._instanceview and self._instanceview.get('computerName'):
             computer_name = self._instanceview['computerName']
         else:
             computer_name = self._vm_model['properties'].get('osProfile', {}).get('computerName')
@@ -892,12 +892,13 @@ class AzureHost(object):
         )
 
         # Instance view
-        if self._instanceview.get('osName'):
-            new_hostvars['os_name'] = self._instanceview['osName']
-        if self._instanceview.get('osVersion'):
-            new_hostvars['os_version'] = self._instanceview['osVersion']
-        if self._instanceview.get('hyperVGeneration'):
-            new_hostvars['hyper_v_generation'] = self._instanceview['hyperVGeneration']
+        if self._instanceview:
+            if self._instanceview.get('osName'):
+                new_hostvars['os_name'] = self._instanceview['osName']
+            if self._instanceview.get('osVersion'):
+                new_hostvars['os_version'] = self._instanceview['osVersion']
+            if self._instanceview.get('hyperVGeneration'):
+                new_hostvars['hyper_v_generation'] = self._instanceview['hyperVGeneration']
 
         if self._type == 'microsoft.azurestackhci/virtualmachineinstances':
             new_hostvars['customLocation'] = self._vm_model.get('extendedLocation', {}).get('name', '').split('/')[-1]


### PR DESCRIPTION
##### SUMMARY
This PR fixes two critical crashes in the `azure_rm` inventory plugin that occur when processing Azure VMs in `Failed`, `Creating`, or other transient states.

In these states, the Azure SDK may return `None` for `instanceView` or omit the `networkProfile` key entirely from the VM model. The current code assumes these keys and objects always exist, leading to immediate inventory sync failures that prevent the plugin from processing the rest of the valid hosts.

Changes made:
1.  Added a check for `if self._instanceview` before attempting to access its attributes to prevent `AttributeError`.
2.  Switched to safe `.get()` calls when retrieving `networkInterfaces` from `networkProfile` to prevent `KeyError`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION
When an Azure subscription contains a VM in a broken state (e.g., "ProvisioningState/failed/NoRegisteredProviderFound"), the inventory plugin crashes with an unhandled exception, stopping the entire sync process.

The crash happens in two locations depending on the specific missing data:
1.  **AttributeError:** When `instanceView` is `None`, the code fails at `self._instanceview.get('computerName')`.
2.  **KeyError:** When the VM model lacks a `networkProfile`, the code fails when accessing `['networkInterfaces']`.

This fix ensures the plugin skips these missing attributes gracefully rather than crashing.

[WARNING]:  * Failed to parse /runner/inventory/azure_rm.yml with auto plugin: 'NoneType' object has no attribute 'get'
  File "/usr/share/ansible/collections/ansible_collections/azure/azcollection/plugins/inventory/azure_rm.py", line 852, in hostvars
    if self._instanceview.get('computerName'):
AttributeError: 'NoneType' object has no attribute 'get'

[WARNING]:  * Failed to parse /runner/inventory/azure_rm.yml with auto plugin: 'networkProfile'
  File "/usr/share/ansible/collections/ansible_collections/azure/azcollection/plugins/inventory/azure_rm.py", line 811, in hostvars
    nic_refs = vm_model['properties']['networkProfile']['networkInterfaces']
KeyError: 'networkProfile'