### PR TITLE
Fix #2171: Remove azure-cli mentions

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1871,7 +1871,7 @@ class AzureRMAuth(object):
 
         if auth_source == 'cli':
             if not HAS_AZURE_CLI_CORE:
-                self.fail(msg=missing_required_lib('azure-cli', reason='for `cli` auth_source'),
+                self.fail(msg=missing_required_lib('azure-cli-core', reason='for `cli` auth_source'),
                           exception=HAS_AZURE_CLI_CORE_EXC)
             try:
                 self.log('Retrieving credentials from Azure CLI profile')

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -220,8 +220,8 @@ AZURE_FAILED_STATE = "Failed"
 
 HAS_AZURE = True
 HAS_AZURE_EXC = None
-HAS_AZURE_CLI_CORE = True
-HAS_AZURE_CLI_CORE_EXC = None
+HAS_AZURE_CLI = True
+HAS_AZURE_CLI_EXC = None
 
 try:
     import importlib
@@ -295,7 +295,6 @@ try:
     from azure.mgmt.batch import models as BatchManagementModel
     from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
     from azure.mgmt.cdn import CdnManagementClient
-
 except ImportError as exc:
     Authentication = object
     HAS_AZURE_EXC = traceback.format_exc()
@@ -316,8 +315,8 @@ try:
     from azure.cli.core.util import CLIError
     from azure.cli.core import cloud as azure_cloud
 except ImportError:
-    HAS_AZURE_CLI_CORE = False
-    HAS_AZURE_CLI_CORE_EXC = None
+    HAS_AZURE_CLI = False
+    HAS_AZURE_CLI_EXC = traceback.format_exc()
     CLIError = Exception
 
 
@@ -1635,7 +1634,7 @@ class AzureRMAuth(object):
             disable_instance_discovery=disable_instance_discovery)
 
         if not self.credentials:
-            if HAS_AZURE_CLI_CORE:
+            if HAS_AZURE_CLI:
                 self.fail("Failed to get credentials. Either pass as parameters, set environment variables, "
                           "define a profile in ~/.azure/credentials, or log in with Azure CLI (`az login`).")
             else:
@@ -1870,9 +1869,9 @@ class AzureRMAuth(object):
                                              _cloud_environment=params.get('cloud_environment'))
 
         if auth_source == 'cli':
-            if not HAS_AZURE_CLI_CORE:
+            if not HAS_AZURE_CLI:
                 self.fail(msg=missing_required_lib('azure-cli-core', reason='for `cli` auth_source'),
-                          exception=HAS_AZURE_CLI_CORE_EXC)
+                          exception=HAS_AZURE_CLI_EXC)
             try:
                 self.log('Retrieving credentials from Azure CLI profile')
                 cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
@@ -1915,7 +1914,7 @@ class AzureRMAuth(object):
             return default_credentials
 
         try:
-            if HAS_AZURE_CLI_CORE:
+            if HAS_AZURE_CLI:
                 self.log('Retrieving credentials from AzureCLI profile')
             cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
             return cli_credentials

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -220,8 +220,6 @@ AZURE_FAILED_STATE = "Failed"
 
 HAS_AZURE = True
 HAS_AZURE_EXC = None
-HAS_AZURE_CLI = True
-HAS_AZURE_CLI_EXC = None
 
 try:
     import importlib
@@ -315,8 +313,6 @@ try:
     from azure.cli.core.util import CLIError
     from azure.cli.core import cloud as azure_cloud
 except ImportError:
-    HAS_AZURE_CLI = False
-    HAS_AZURE_CLI_EXC = traceback.format_exc()
     CLIError = Exception
 
 
@@ -1634,12 +1630,8 @@ class AzureRMAuth(object):
             disable_instance_discovery=disable_instance_discovery)
 
         if not self.credentials:
-            if HAS_AZURE_CLI:
-                self.fail("Failed to get credentials. Either pass as parameters, set environment variables, "
-                          "define a profile in ~/.azure/credentials, or log in with Azure CLI (`az login`).")
-            else:
-                self.fail("Failed to get credentials. Either pass as parameters, set environment variables, "
-                          "define a profile in ~/.azure/credentials, or install Azure CLI and log in (`az login`).")
+            self.fail("Failed to get credentials. Either pass as parameters, set environment variables, "
+                      "define a profile in ~/.azure/credentials, or log in with Azure CLI (`az login`).")
 
         # cert validation mode precedence: module-arg, credential profile, env, "validate"
         self._cert_validation_mode = cert_validation_mode or \
@@ -1869,9 +1861,6 @@ class AzureRMAuth(object):
                                              _cloud_environment=params.get('cloud_environment'))
 
         if auth_source == 'cli':
-            if not HAS_AZURE_CLI:
-                self.fail(msg=missing_required_lib('azure-cli-core', reason='for `cli` auth_source'),
-                          exception=HAS_AZURE_CLI_EXC)
             try:
                 self.log('Retrieving credentials from Azure CLI profile')
                 cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
@@ -1914,8 +1903,7 @@ class AzureRMAuth(object):
             return default_credentials
 
         try:
-            if HAS_AZURE_CLI:
-                self.log('Retrieving credentials from AzureCLI profile')
+            self.log('Retrieving credentials from AzureCLI profile')
             cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
             return cli_credentials
         except CLIError as ce:

--- a/plugins/modules/azure_rm_keyvaultsecuritydomain.py
+++ b/plugins/modules/azure_rm_keyvaultsecuritydomain.py
@@ -111,14 +111,14 @@ except ImportError:
 try:
     from azure.keyvault.securitydomain import SecurityDomainClient
     from azure.keyvault.securitydomain.models import CertificateInfo, SecurityDomainJsonWebKey
-    HAS_AZURE_CLI = True
-    HAS_AZURE_CLI_EXC = None
+    HAS_AZURE_CLI_CORE = True
+    HAS_AZURE_CLI_CORE_EXC = None
 except ImportError:
     CertificateInfo = None
     SecurityDomainJsonWebKey = None
     SecurityDomainClient = None
-    HAS_AZURE_CLI = False
-    HAS_AZURE_CLI_EXC = traceback.format_exc()
+    HAS_AZURE_CLI_CORE = False
+    HAS_AZURE_CLI_CORE_EXC = traceback.format_exc()
 
 
 class AzureRMVaultSecurityDomain(AzureRMModuleBaseExt):
@@ -178,9 +178,9 @@ class AzureRMVaultSecurityDomain(AzureRMModuleBaseExt):
             self.fail(msg=missing_required_lib('cryptography'),
                       exception=HAS_CRYPTO_EXC)
 
-        if not HAS_AZURE_CLI:
-            self.fail(msg=missing_required_lib('azure-cli'),
-                      exception=HAS_AZURE_CLI_EXC)
+        if not HAS_AZURE_CLI_CORE:
+            self.fail(msg=missing_required_lib('azure-cli-core'),
+                      exception=HAS_AZURE_CLI_CORE_EXC)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""

--- a/plugins/modules/azure_rm_keyvaultsecuritydomain.py
+++ b/plugins/modules/azure_rm_keyvaultsecuritydomain.py
@@ -111,14 +111,10 @@ except ImportError:
 try:
     from azure.keyvault.securitydomain import SecurityDomainClient
     from azure.keyvault.securitydomain.models import CertificateInfo, SecurityDomainJsonWebKey
-    HAS_AZURE_CLI_CORE = True
-    HAS_AZURE_CLI_CORE_EXC = None
 except ImportError:
     CertificateInfo = None
     SecurityDomainJsonWebKey = None
     SecurityDomainClient = None
-    HAS_AZURE_CLI_CORE = False
-    HAS_AZURE_CLI_CORE_EXC = traceback.format_exc()
 
 
 class AzureRMVaultSecurityDomain(AzureRMModuleBaseExt):
@@ -145,7 +141,7 @@ class AzureRMVaultSecurityDomain(AzureRMModuleBaseExt):
             ),
             no_wait=dict(
                 type='bool',
-                default='False'
+                default=False
             ),
             action=dict(
                 type='str',
@@ -177,10 +173,6 @@ class AzureRMVaultSecurityDomain(AzureRMModuleBaseExt):
         if not HAS_CRYPTO:
             self.fail(msg=missing_required_lib('cryptography'),
                       exception=HAS_CRYPTO_EXC)
-
-        if not HAS_AZURE_CLI_CORE:
-            self.fail(msg=missing_required_lib('azure-cli-core'),
-                      exception=HAS_AZURE_CLI_CORE_EXC)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""


### PR DESCRIPTION
##### SUMMARY
Fix #2171. Remove `azure-cli`, `HAS_AZURE_CLI_CORE` and `HAS_AZURE_CLI_CORE_EXC` mentions from code logic.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py
plugins/modules/azure_rm_keyvaultsecuritydomain.py
