### PR TITLE
Fix #2178: Point-in-Time Restore for MySQL Flexible Server

### DIFF
--- a/plugins/modules/azure_rm_mysqlflexibleserver.py
+++ b/plugins/modules/azure_rm_mysqlflexibleserver.py
@@ -93,10 +93,12 @@ options:
     restore_point_in_time:
         description:
             - Restore point creation time (ISO8601 format), specifying the time to restore from.
+            - Required when C(source_server_resource_id) is specified.
         type: str
     source_server_resource_id:
         description:
             - The source MySQL server id.
+            - Required when C(restore_point_in_time) is specified.
         type: str
     backup:
         description:
@@ -195,6 +197,13 @@ EXAMPLES = '''
       backup_retention_days: 7
       geo_redundant_backup: Disabled
     availability_zone: 1
+
+- name: Restore MySQL flexible server from a point-in-time backup
+  azure_rm_mysqlflexibleserver:
+    resource_group: "{{ resource_group }}"
+    name: postflexible-restore{{ rpfx }}
+    source_server_resource_id: "{{ mysql_flexible_server_id }}"
+    restore_point_in_time: "2026-02-26T02:27:14Z"
 '''
 
 RETURN = '''
@@ -517,8 +526,11 @@ class AzureRMMySqlFlexibleServers(AzureRMModuleBaseExt):
         self.state = None
         self.to_do = Actions.NoAction
 
+        required_together = [['restore_point_in_time', 'source_server_resource_id']]
+
         super(AzureRMMySqlFlexibleServers, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                           supports_check_mode=True,
+                                                          required_together=required_together,
                                                           supports_tags=True)
 
     def exec_module(self, **kwargs):
@@ -558,6 +570,10 @@ class AzureRMMySqlFlexibleServers(AzureRMModuleBaseExt):
                     self.parameters['network'] = kwargs[key]
 
         self.parameters['tags'] = self.tags
+
+        # If this is a PointInTimeRestore, set create_mode to PointInTimeRestore
+        if self.parameters.get('source_server_resource_id') and self.parameters.get('restore_point_in_time'):
+            self.parameters['create_mode'] = 'PointInTimeRestore'
 
         old_response = None
         response = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ azure-mgmt-managedservices==7.0.0b2
 azure-mgmt-managementgroups==1.1.0b2
 azure-mgmt-marketplaceordering==1.2.0b2
 azure-mgmt-monitor==6.0.2
-azure-mgmt-mysqlflexibleservers==1.0.0b3
+azure-mgmt-mysqlflexibleservers==1.0.0
 azure-mgmt-network==28.0.0
 azure-mgmt-notificationhubs==8.1.0b1
 azure-mgmt-nspkg==3.0.2

--- a/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
@@ -147,7 +147,7 @@
       azure.azcollection.azure_rm_mysqlflexibleserver:
         resource_group: "{{ resource_group }}-mysqlflexibleserver"
         location: "{{ location }}"
-        name: postflexible-restore{{ rpfx }}
+        name: mysqlflexible-restore{{ rpfx }}
         source_server_resource_id: "{{ output.servers[0].id }}"
         restore_point_in_time: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}"  # set current time
       check_mode: true
@@ -314,6 +314,18 @@
       register: output
 
     - name: Assert the flexible server deleted
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Delete the restored mysql flexible server
+      azure.azcollection.azure_rm_mysqlflexibleserver:
+        resource_group: "{{ resource_group }}-mysqlflexibleserver"
+        name: mysqlflexible-restore{{ rpfx }}
+        state: absent
+      register: output
+
+    - name: Assert the restored flexible server deleted
       ansible.builtin.assert:
         that:
           - output is changed

--- a/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
@@ -95,7 +95,7 @@
         that:
           - output is not changed
 
-    - name: Create mysql flexible server again(Idempotent Test)
+    - name: Update mysql flexible server
       azure.azcollection.azure_rm_mysqlflexibleserver:
         resource_group: "{{ resource_group }}-mysqlflexibleserver"
         name: mysqlflexible{{ rpfx }}
@@ -138,6 +138,24 @@
           - output.servers[0].backup.geo_redundant_backup == 'Disabled'
           - output.servers[0].availability_zone == "1"
           - output.servers[0].tags | length == 2
+
+    - name: Wait 10 minutes to allow PITR backup pipeline to initialize
+      ansible.builtin.pause:
+        minutes: 10  # earliest restore date is 10 minutes after server creation
+
+    - name: Restore MySQL flexible server from a point-in-time backup
+      azure.azcollection.azure_rm_mysqlflexibleserver:
+        resource_group: "{{ resource_group }}-mysqlflexibleserver"
+        location: "{{ location }}"
+        name: postflexible-restore{{ rpfx }}
+        source_server_resource_id: "{{ output.servers[0].id }}"
+        restore_point_in_time: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}"  # set current time
+      check_mode: true
+
+    - name: Assert the resource is updated
+      ansible.builtin.assert:
+        that:
+          - output is changed
 
     - name: Create a MySQL flexible database
       azure.azcollection.azure_rm_mysqlflexibledatabase:

--- a/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
@@ -149,12 +149,12 @@
         name: mysqlflexible-restore{{ rpfx }}
         source_server_resource_id: "{{ output.servers[0].id }}"
         restore_point_in_time: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}"  # set current time
-      check_mode: true
+      register: restore_output
 
-    - name: Assert the resource is updated
+    - name: Assert the MySQL flexible server is restored
       ansible.builtin.assert:
         that:
-          - output is changed
+          - restore_output is changed
 
     - name: Create a MySQL flexible database
       azure.azcollection.azure_rm_mysqlflexibledatabase:

--- a/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
@@ -146,7 +146,6 @@
     - name: Restore MySQL flexible server from a point-in-time backup
       azure.azcollection.azure_rm_mysqlflexibleserver:
         resource_group: "{{ resource_group }}-mysqlflexibleserver"
-        location: "{{ location }}"
         name: mysqlflexible-restore{{ rpfx }}
         source_server_resource_id: "{{ output.servers[0].id }}"
         restore_point_in_time: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}"  # set current time


### PR DESCRIPTION
##### SUMMARY
Fix #2178. 
- Enforce restore_point_in_time and source_server_resource_id provided together
- Automatically set create_mode for PITR restore requests
- Update docs and examples

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_mysqlflexibleserver.py
requirements.txt
tests/integration/targets/azure_rm_mysqlflexibleserver/tasks/main.yml
