### PR TITLE
Clean up dependency handling and import logic across AzureRM common utilities and related modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ Documentation of individual modules is [available at the Ansible Galaxy](https:/
 
 ## Installation
 
-Before using this collection, you need to install it with the Ansible Galaxy command-line tool:
+Before using this collection, you need to install/force-install it with the Ansible Galaxy command-line tool:
 
 ```
 ansible-galaxy collection install azure.azcollection
+```
+
+or force-install
+```
+ansible-galaxy collection install azure.azcollection --force
 ```
 
 You can also include it in a requirements.yml file and install it with `ansible-galaxy collection install -r requirements.yml`, using the format:
@@ -45,7 +50,7 @@ See [using Ansible collections](https://docs.ansible.com/ansible/devel/user_guid
 
 ---
 
-After the collection is installed, please install the dependencies required by the collection (adjust path to collection if necessary):
+After the collection is installed, please install the dependencies ([requirements.txt](https://github.com/ansible-collections/azure/blob/dev/requirements.txt)) required by the collection (adjust path to collection if necessary):
 
 ```bash
 pip install -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements.txt

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -217,7 +217,6 @@ CIDR_PATTERN = re.compile(r"(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)
 
 AZURE_SUCCESS_STATE = "Succeeded"
 
-AZURE_IMPORT_ERROR = None
 
 try:
     import importlib
@@ -226,73 +225,56 @@ except ImportError:
     # Doing so would require catching Exception for all imports of Azure dependencies in modules and module_utils.
     importlib = None
 
-try:
-    HAS_PACKAGING_VERSION = True
-    HAS_PACKAGING_VERSION_EXC = None
-except ImportError:
-    Version = None
-    HAS_PACKAGING_VERSION = False
-    HAS_PACKAGING_VERSION_EXC = traceback.format_exc()
-
-try:
-    from enum import Enum
-    from azure.mgmt.core.tools import parse_resource_id, resource_id, is_valid_resource_id
-    from azure.mgmt.network import NetworkManagementClient
-    from azure.mgmt.network import models as NetworkModels
-    from azure.mgmt.resource.resources import ResourceManagementClient
-    from azure.mgmt.managementgroups import ManagementGroupsAPI as ManagementGroupsClient
-    from azure.mgmt.resource.subscriptions import SubscriptionClient
-    from azure.mgmt.storage import StorageManagementClient
-    from azure.mgmt.compute import ComputeManagementClient
-    from azure.mgmt.dns import DnsManagementClient
-    from azure.mgmt.privatedns import PrivateDnsManagementClient
-    import azure.mgmt.privatedns.models as PrivateDnsModels
-    from azure.mgmt.monitor import MonitorManagementClient
-    from azure.mgmt.web import WebSiteManagementClient
-    from azure.mgmt.containerservice import ContainerServiceClient
-    from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
-    from azure.mgmt.trafficmanager import TrafficManagerManagementClient
-    from azure.storage.blob import BlobServiceClient
-    from azure.mgmt.authorization import AuthorizationManagementClient
-    from azure.mgmt.sql import SqlManagementClient
-    from azure.mgmt.servicebus import ServiceBusManagementClient
-    from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
-    from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as PostgreSQLFlexibleManagementClient
-    from azure.mgmt.rdbms.mysql import MySQLManagementClient
-    from azure.mgmt.mysqlflexibleservers import MySQLManagementClient as MySQLFlexibleManagementClient
-    from azure.mgmt.rdbms.mariadb import MariaDBManagementClient
-    from azure.mgmt.containerregistry import ContainerRegistryManagementClient
-    from azure.mgmt.containerinstance import ContainerInstanceManagementClient
-    from azure.mgmt.loganalytics import LogAnalyticsManagementClient
-    import azure.mgmt.loganalytics.models as LogAnalyticsModels
-    from azure.mgmt.automation import AutomationClient
-    import azure.mgmt.automation.models as AutomationModel
-    from azure.mgmt.iothub import IotHubClient
-    from azure.mgmt.iothub import models as IoTHubModels
-    from azure.mgmt.resource.locks import ManagementLockClient
-    from azure.mgmt.recoveryservicesbackup import RecoveryServicesBackupClient
-    try:
-        #  Older versions of the library exposed the modules at the root of the package
-        import azure.mgmt.recoveryservicesbackup.models as RecoveryServicesBackupModels
-    except ImportError:
-        import azure.mgmt.recoveryservicesbackup.activestamp.models as RecoveryServicesBackupModels
-    from azure.mgmt.search import SearchManagementClient
-    from azure.mgmt.notificationhubs import NotificationHubsManagementClient
-    from azure.mgmt.eventhub import EventHubManagementClient
-    from azure.mgmt.datafactory import DataFactoryManagementClient
-    import azure.mgmt.datafactory.models as DataFactoryModel
-    from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
-    from azure.identity import AzureCliCredential
-    from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-    from msgraph_core import GraphClientFactory, NationalClouds
-    from msgraph import GraphRequestAdapter, GraphServiceClient
-    from azure.mgmt.batch import BatchManagementClient
-    from azure.mgmt.batch import models as BatchManagementModel
-    from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
-    from azure.mgmt.cdn import CdnManagementClient
-except ImportError as exc:
-    Authentication = object
-    AZURE_IMPORT_ERROR = traceback.format_exc()
+# Imports
+from enum import Enum
+from azure.mgmt.core.tools import parse_resource_id, resource_id, is_valid_resource_id
+from azure.mgmt.network import NetworkManagementClient
+from azure.mgmt.network import models as NetworkModels
+from azure.mgmt.resource.resources import ResourceManagementClient
+from azure.mgmt.managementgroups import ManagementGroupsAPI as ManagementGroupsClient
+from azure.mgmt.resource.subscriptions import SubscriptionClient
+from azure.mgmt.storage import StorageManagementClient
+from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.dns import DnsManagementClient
+from azure.mgmt.privatedns import PrivateDnsManagementClient
+import azure.mgmt.privatedns.models as PrivateDnsModels
+from azure.mgmt.monitor import MonitorManagementClient
+from azure.mgmt.web import WebSiteManagementClient
+from azure.mgmt.containerservice import ContainerServiceClient
+from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
+from azure.mgmt.trafficmanager import TrafficManagerManagementClient
+from azure.storage.blob import BlobServiceClient
+from azure.mgmt.authorization import AuthorizationManagementClient
+from azure.mgmt.sql import SqlManagementClient
+from azure.mgmt.servicebus import ServiceBusManagementClient
+from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
+from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as PostgreSQLFlexibleManagementClient
+from azure.mgmt.rdbms.mysql import MySQLManagementClient
+from azure.mgmt.mysqlflexibleservers import MySQLManagementClient as MySQLFlexibleManagementClient
+from azure.mgmt.rdbms.mariadb import MariaDBManagementClient
+from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from azure.mgmt.loganalytics import LogAnalyticsManagementClient
+import azure.mgmt.loganalytics.models as LogAnalyticsModels
+from azure.mgmt.automation import AutomationClient
+import azure.mgmt.automation.models as AutomationModel
+from azure.mgmt.resource.locks import ManagementLockClient
+from azure.mgmt.recoveryservicesbackup import RecoveryServicesBackupClient
+import azure.mgmt.recoveryservicesbackup.activestamp.models as RecoveryServicesBackupModels
+from azure.mgmt.search import SearchManagementClient
+from azure.mgmt.notificationhubs import NotificationHubsManagementClient
+from azure.mgmt.eventhub import EventHubManagementClient
+from azure.mgmt.datafactory import DataFactoryManagementClient
+import azure.mgmt.datafactory.models as DataFactoryModel
+from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
+from azure.identity import AzureCliCredential
+from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
+from msgraph_core import GraphClientFactory, NationalClouds
+from msgraph import GraphRequestAdapter, GraphServiceClient
+from azure.mgmt.batch import BatchManagementClient
+from azure.mgmt.batch import models as BatchManagementModel
+from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
+from azure.mgmt.cdn import CdnManagementClient
 
 from base64 import b64encode, b64decode
 from hashlib import sha256
@@ -369,14 +351,6 @@ class AzureRMModuleBase(object):
                                     supports_check_mode=supports_check_mode,
                                     required_if=merged_required_if,
                                     required_by=required_by)
-
-        if not HAS_PACKAGING_VERSION:
-            self.fail(msg=missing_required_lib('packaging'),
-                      exception=HAS_PACKAGING_VERSION_EXC)
-
-        if AZURE_IMPORT_ERROR:
-            self.fail(msg=missing_required_lib('ansible[azure] (azure >= {0})'.format(AZURE_MIN_RELEASE)),
-                      exception=AZURE_IMPORT_ERROR)
 
         self._authorization_client = None
         self._network_client = None
@@ -1420,6 +1394,13 @@ class AzureRMModuleBase(object):
     def IoThub_client(self):
         self.log('Getting iothub client')
         if not self._IoThub_client:
+            try:
+                from azure.mgmt.iothub import IotHubClient
+            except ImportError as exc:
+                self.fail(missing_required_lib('azure-mgmt-iothub',
+                                               reason="IoT Hub management requires azure-mgmt-iothub. "
+                                               "Installation may fail due to uamqp wheel build issues.",
+                                               exception=exc))
             self._IoThub_client = self.get_mgmt_svc_client(IotHubClient,
                                                            api_version='2023-06-30-preview',
                                                            base_url=self._cloud_environment.endpoints.resource_manager)
@@ -1427,6 +1408,13 @@ class AzureRMModuleBase(object):
 
     @property
     def IoThub_models(self):
+        try:
+            from azure.mgmt.iothub import models as IoTHubModels
+        except ImportError as exc:
+            self.fail(missing_required_lib('azure-mgmt-iothub',
+                                            reason="IoT Hub management requires azure-mgmt-iothub. "
+                                            "Installation may fail due to uamqp wheel build issues.",
+                                            exception=exc))
         return IoTHubModels
 
     @property

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -217,6 +217,8 @@ CIDR_PATTERN = re.compile(r"(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)
 
 AZURE_SUCCESS_STATE = "Succeeded"
 
+AZURE_IMPORT_ERROR = None
+
 
 try:
     import importlib
@@ -226,55 +228,58 @@ except ImportError:
     importlib = None
 
 # Imports
-from enum import Enum
-from azure.mgmt.core.tools import parse_resource_id, resource_id, is_valid_resource_id
-from azure.mgmt.network import NetworkManagementClient
-from azure.mgmt.network import models as NetworkModels
-from azure.mgmt.resource.resources import ResourceManagementClient
-from azure.mgmt.managementgroups import ManagementGroupsAPI as ManagementGroupsClient
-from azure.mgmt.resource.subscriptions import SubscriptionClient
-from azure.mgmt.storage import StorageManagementClient
-from azure.mgmt.compute import ComputeManagementClient
-from azure.mgmt.dns import DnsManagementClient
-from azure.mgmt.privatedns import PrivateDnsManagementClient
-import azure.mgmt.privatedns.models as PrivateDnsModels
-from azure.mgmt.monitor import MonitorManagementClient
-from azure.mgmt.web import WebSiteManagementClient
-from azure.mgmt.containerservice import ContainerServiceClient
-from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
-from azure.mgmt.trafficmanager import TrafficManagerManagementClient
-from azure.storage.blob import BlobServiceClient
-from azure.mgmt.authorization import AuthorizationManagementClient
-from azure.mgmt.sql import SqlManagementClient
-from azure.mgmt.servicebus import ServiceBusManagementClient
-from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
-from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as PostgreSQLFlexibleManagementClient
-from azure.mgmt.rdbms.mysql import MySQLManagementClient
-from azure.mgmt.mysqlflexibleservers import MySQLManagementClient as MySQLFlexibleManagementClient
-from azure.mgmt.rdbms.mariadb import MariaDBManagementClient
-from azure.mgmt.containerregistry import ContainerRegistryManagementClient
-from azure.mgmt.containerinstance import ContainerInstanceManagementClient
-from azure.mgmt.loganalytics import LogAnalyticsManagementClient
-import azure.mgmt.loganalytics.models as LogAnalyticsModels
-from azure.mgmt.automation import AutomationClient
-import azure.mgmt.automation.models as AutomationModel
-from azure.mgmt.resource.locks import ManagementLockClient
-from azure.mgmt.recoveryservicesbackup import RecoveryServicesBackupClient
-import azure.mgmt.recoveryservicesbackup.activestamp.models as RecoveryServicesBackupModels
-from azure.mgmt.search import SearchManagementClient
-from azure.mgmt.notificationhubs import NotificationHubsManagementClient
-from azure.mgmt.eventhub import EventHubManagementClient
-from azure.mgmt.datafactory import DataFactoryManagementClient
-import azure.mgmt.datafactory.models as DataFactoryModel
-from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
-from azure.identity import AzureCliCredential
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from msgraph_core import GraphClientFactory, NationalClouds
-from msgraph import GraphRequestAdapter, GraphServiceClient
-from azure.mgmt.batch import BatchManagementClient
-from azure.mgmt.batch import models as BatchManagementModel
-from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
-from azure.mgmt.cdn import CdnManagementClient
+try:
+    from enum import Enum
+    from azure.mgmt.core.tools import parse_resource_id, resource_id, is_valid_resource_id
+    from azure.mgmt.network import NetworkManagementClient
+    from azure.mgmt.network import models as NetworkModels
+    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.managementgroups import ManagementGroupsAPI as ManagementGroupsClient
+    from azure.mgmt.resource.subscriptions import SubscriptionClient
+    from azure.mgmt.storage import StorageManagementClient
+    from azure.mgmt.compute import ComputeManagementClient
+    from azure.mgmt.dns import DnsManagementClient
+    from azure.mgmt.privatedns import PrivateDnsManagementClient
+    import azure.mgmt.privatedns.models as PrivateDnsModels
+    from azure.mgmt.monitor import MonitorManagementClient
+    from azure.mgmt.web import WebSiteManagementClient
+    from azure.mgmt.containerservice import ContainerServiceClient
+    from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
+    from azure.mgmt.trafficmanager import TrafficManagerManagementClient
+    from azure.storage.blob import BlobServiceClient
+    from azure.mgmt.authorization import AuthorizationManagementClient
+    from azure.mgmt.sql import SqlManagementClient
+    from azure.mgmt.servicebus import ServiceBusManagementClient
+    from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
+    from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as PostgreSQLFlexibleManagementClient
+    from azure.mgmt.rdbms.mysql import MySQLManagementClient
+    from azure.mgmt.mysqlflexibleservers import MySQLManagementClient as MySQLFlexibleManagementClient
+    from azure.mgmt.rdbms.mariadb import MariaDBManagementClient
+    from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+    from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+    from azure.mgmt.loganalytics import LogAnalyticsManagementClient
+    import azure.mgmt.loganalytics.models as LogAnalyticsModels
+    from azure.mgmt.automation import AutomationClient
+    import azure.mgmt.automation.models as AutomationModel
+    from azure.mgmt.resource.locks import ManagementLockClient
+    from azure.mgmt.recoveryservicesbackup import RecoveryServicesBackupClient
+    import azure.mgmt.recoveryservicesbackup.activestamp.models as RecoveryServicesBackupModels
+    from azure.mgmt.search import SearchManagementClient
+    from azure.mgmt.notificationhubs import NotificationHubsManagementClient
+    from azure.mgmt.eventhub import EventHubManagementClient
+    from azure.mgmt.datafactory import DataFactoryManagementClient
+    import azure.mgmt.datafactory.models as DataFactoryModel
+    from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
+    from azure.identity import AzureCliCredential
+    from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
+    from msgraph_core import GraphClientFactory, NationalClouds
+    from msgraph import GraphRequestAdapter, GraphServiceClient
+    from azure.mgmt.batch import BatchManagementClient
+    from azure.mgmt.batch import models as BatchManagementModel
+    from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
+    from azure.mgmt.cdn import CdnManagementClient
+except ImportError as exc:
+    AZURE_IMPORT_ERROR = traceback.format_exc()
 
 from base64 import b64encode, b64decode
 from hashlib import sha256
@@ -351,6 +356,10 @@ class AzureRMModuleBase(object):
                                     supports_check_mode=supports_check_mode,
                                     required_if=merged_required_if,
                                     required_by=required_by)
+        
+        if AZURE_IMPORT_ERROR:
+            self.fail(msg=missing_required_lib('ansible[azure] (azure >= {0})'.format(AZURE_MIN_RELEASE)),
+                      exception=AZURE_IMPORT_ERROR)
 
         self._authorization_client = None
         self._network_client = None
@@ -419,10 +428,6 @@ class AzureRMModuleBase(object):
         if not skip_exec:
             res = self.exec_module(**self.module.params)
             self.module.exit_json(**res)
-
-    def check_client_version(self, client_type):
-        # Deprecated: dependency management handled by requirements/constraints.
-        return
 
     def exec_module(self, **kwargs):
         self.fail("Error: {0} failed to implement exec_module method.".format(self.__class__.__name__))
@@ -841,7 +846,6 @@ class AzureRMModuleBase(object):
 
     def get_mgmt_svc_client(self, client_type, base_url=None, api_version=None, suppress_subscription_id=False):
         self.log('Getting management service client {0}'.format(client_type.__name__))
-        self.check_client_version(client_type)
 
         client_argspec = inspect.signature(client_type.__init__)
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -261,6 +261,8 @@ try:
     import azure.mgmt.loganalytics.models as LogAnalyticsModels
     from azure.mgmt.automation import AutomationClient
     import azure.mgmt.automation.models as AutomationModel
+    from azure.mgmt.iothub import IotHubClient
+    from azure.mgmt.iothub import models as IoTHubModels
     from azure.mgmt.resource.locks import ManagementLockClient
     from azure.mgmt.recoveryservicesbackup import RecoveryServicesBackupClient
     import azure.mgmt.recoveryservicesbackup.activestamp.models as RecoveryServicesBackupModels
@@ -1398,13 +1400,6 @@ class AzureRMModuleBase(object):
     def IoThub_client(self):
         self.log('Getting iothub client')
         if not self._IoThub_client:
-            try:
-                from azure.mgmt.iothub import IotHubClient
-            except ImportError as exc:
-                self.fail(missing_required_lib('azure-mgmt-iothub',
-                                               reason="IoT Hub management requires azure-mgmt-iothub. "
-                                               "Installation may fail due to uamqp wheel build issues.",
-                                               exception=exc))
             self._IoThub_client = self.get_mgmt_svc_client(IotHubClient,
                                                            api_version='2023-06-30-preview',
                                                            base_url=self._cloud_environment.endpoints.resource_manager)
@@ -1412,13 +1407,6 @@ class AzureRMModuleBase(object):
 
     @property
     def IoThub_models(self):
-        try:
-            from azure.mgmt.iothub import models as IoTHubModels
-        except ImportError as exc:
-            self.fail(missing_required_lib('azure-mgmt-iothub',
-                                           reason="IoT Hub management requires azure-mgmt-iothub. "
-                                           "Installation may fail due to uamqp wheel build issues.",
-                                           exception=exc))
         return IoTHubModels
 
     @property

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -216,10 +216,8 @@ CIDR_PATTERN = re.compile(r"(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)
                           r"[0-9]{2}|2[0-4][0-9]|25[0-5])(/([0-9]|[1-2][0-9]|3[0-2]))")
 
 AZURE_SUCCESS_STATE = "Succeeded"
-AZURE_FAILED_STATE = "Failed"
 
-HAS_AZURE = True
-HAS_AZURE_EXC = None
+AZURE_IMPORT_ERROR = None
 
 try:
     import importlib
@@ -295,8 +293,7 @@ try:
     from azure.mgmt.cdn import CdnManagementClient
 except ImportError as exc:
     Authentication = object
-    HAS_AZURE_EXC = traceback.format_exc()
-    HAS_AZURE = False
+    AZURE_IMPORT_ERROR = traceback.format_exc()
 
 from base64 import b64encode, b64decode
 from hashlib import sha256
@@ -336,52 +333,6 @@ def format_resource_id(val, subscription_id, namespace, types, resource_group):
 
 def normalize_location_name(name):
     return name.replace(' ', '').lower()
-
-
-# FUTURE: either get this from the requirements file (if we can be sure it's always available at runtime)
-# or generate the requirements files from this so we only have one source of truth to maintain...
-AZURE_PKG_VERSIONS = {
-    'StorageManagementClient': {
-        'package_name': 'storage',
-        'expected_version': '19.0.0'
-    },
-    'ComputeManagementClient': {
-        'package_name': 'compute',
-        'expected_version': '4.4.0'
-    },
-    'ContainerInstanceManagementClient': {
-        'package_name': 'containerinstance',
-        'expected_version': '9.0.0'
-    },
-    'NetworkManagementClient': {
-        'package_name': 'network',
-        'expected_version': '26.0.0'
-    },
-    'ResourceManagementClient': {
-        'package_name': 'resource',
-        'expected_version': '2.1.0'
-    },
-    'DnsManagementClient': {
-        'package_name': 'dns',
-        'expected_version': '8.0.0'
-    },
-    'PrivateDnsManagementClient': {
-        'package_name': 'privatedns',
-        'expected_version': '1.0.0'
-    },
-    'WebSiteManagementClient': {
-        'package_name': 'web',
-        'expected_version': '6.1.0'
-    },
-    'TrafficManagerManagementClient': {
-        'package_name': 'trafficmanager',
-        'expected_version': '1.0.0'
-    },
-    'EventHubManagementClient': {
-        'package_name': 'azure-mgmt-eventhub',
-        'expected_version': '2.0.0'
-    },
-} if HAS_AZURE else {}
 
 
 AZURE_MIN_RELEASE = '2.0.0'
@@ -424,9 +375,9 @@ class AzureRMModuleBase(object):
             self.fail(msg=missing_required_lib('packaging'),
                       exception=HAS_PACKAGING_VERSION_EXC)
 
-        if not HAS_AZURE:
+        if AZURE_IMPORT_ERROR:
             self.fail(msg=missing_required_lib('ansible[azure] (azure >= {0})'.format(AZURE_MIN_RELEASE)),
-                      exception=HAS_AZURE_EXC)
+                      exception=AZURE_IMPORT_ERROR)
 
         self._authorization_client = None
         self._network_client = None
@@ -497,23 +448,8 @@ class AzureRMModuleBase(object):
             self.module.exit_json(**res)
 
     def check_client_version(self, client_type):
-        # Ensure Azure modules are at least 2.0.0rc5.
-        package_version = AZURE_PKG_VERSIONS.get(client_type.__name__, None)
-        if package_version is not None:
-            client_name = package_version.get('package_name')
-            try:
-                client_module = importlib.import_module(client_type.__module__)
-                client_version = client_module.VERSION
-            except (RuntimeError, AttributeError):
-                # can't get at the module version for some reason, just fail silently...
-                return
-            expected_version = package_version.get('expected_version')
-            if Version(client_version) < Version(expected_version):
-                self.fail("Installed azure-mgmt-{0} client version is {1}. The minimum supported version is {2}. Try "
-                          "`pip install ansible[azure]`".format(client_name, client_version, expected_version))
-            if Version(client_version) != Version(expected_version):
-                self.module.warn("Installed azure-mgmt-{0} client version is {1}. The expected version is {2}. Try "
-                                 "`pip install ansible[azure]`".format(client_name, client_version, expected_version))
+        # Deprecated: dependency management handled by requirements/constraints.
+        return
 
     def exec_module(self, **kwargs):
         self.fail("Error: {0} failed to implement exec_module method.".format(self.__class__.__name__))

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -227,7 +227,6 @@ except ImportError:
     importlib = None
 
 try:
-    from packaging.version import Version
     HAS_PACKAGING_VERSION = True
     HAS_PACKAGING_VERSION_EXC = None
 except ImportError:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -356,7 +356,7 @@ class AzureRMModuleBase(object):
                                     supports_check_mode=supports_check_mode,
                                     required_if=merged_required_if,
                                     required_by=required_by)
-        
+
         if AZURE_IMPORT_ERROR:
             self.fail(msg=missing_required_lib('ansible[azure] (azure >= {0})'.format(AZURE_MIN_RELEASE)),
                       exception=AZURE_IMPORT_ERROR)
@@ -1416,9 +1416,9 @@ class AzureRMModuleBase(object):
             from azure.mgmt.iothub import models as IoTHubModels
         except ImportError as exc:
             self.fail(missing_required_lib('azure-mgmt-iothub',
-                                            reason="IoT Hub management requires azure-mgmt-iothub. "
-                                            "Installation may fail due to uamqp wheel build issues.",
-                                            exception=exc))
+                                           reason="IoT Hub management requires azure-mgmt-iothub. "
+                                           "Installation may fail due to uamqp wheel build issues.",
+                                           exception=exc))
         return IoTHubModels
 
     @property

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -325,7 +325,7 @@ state:
 import copy
 
 from ansible.module_utils.basic import _load_params
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, AZURE_IMPORT_ERROR
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
@@ -392,7 +392,7 @@ RECORDSET_VALUE_MAP = dict(
     SOA=dict(attrname='soa_record', classobj='SoaRecord', is_list=False),
     CAA=dict(attrname='caa_records', classobj='CaaRecord', is_list=True)
     # FUTURE: add missing record types from https://github.com/Azure/azure-sdk-for-python/blob/master/azure-mgmt-dns/azure/mgmt/dns/models/record_set.py
-) if AZURE_IMPORT_ERROR is None else {}
+)
 
 
 class AzureRMRecordSet(AzureRMModuleBase):

--- a/plugins/modules/azure_rm_dnsrecordset.py
+++ b/plugins/modules/azure_rm_dnsrecordset.py
@@ -325,7 +325,7 @@ state:
 import copy
 
 from ansible.module_utils.basic import _load_params
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, HAS_AZURE
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, AZURE_IMPORT_ERROR
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
@@ -392,7 +392,7 @@ RECORDSET_VALUE_MAP = dict(
     SOA=dict(attrname='soa_record', classobj='SoaRecord', is_list=False),
     CAA=dict(attrname='caa_records', classobj='CaaRecord', is_list=True)
     # FUTURE: add missing record types from https://github.com/Azure/azure-sdk-for-python/blob/master/azure-mgmt-dns/azure/mgmt/dns/models/record_set.py
-) if HAS_AZURE else {}
+) if AZURE_IMPORT_ERROR is None else {}
 
 
 class AzureRMRecordSet(AzureRMModuleBase):

--- a/plugins/modules/azure_rm_iotdevice.py
+++ b/plugins/modules/azure_rm_iotdevice.py
@@ -243,6 +243,7 @@ except ImportError:
 else:
     AZURE_IOT_HUB_IMPORT_ERROR = None
 
+
 class AzureRMIoTDevice(AzureRMModuleBase):
 
     def __init__(self):
@@ -287,13 +288,9 @@ class AzureRMIoTDevice(AzureRMModuleBase):
         super(AzureRMIoTDevice, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
         if AZURE_IOT_HUB_IMPORT_ERROR:
-                self.fail(msg=missing_required_lib('azure-iot-hub',reason=(
-                    "This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
-                    "Installation may fail on some platforms due to uamqp wheel build issues."
-                    ),
-                    ),
-                    exception=AZURE_IOT_HUB_IMPORT_ERROR,
-                )
+                self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                                                                            "Installation may fail on some platforms due to uamqp wheel build issues.")),
+                                                                            exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice.py
+++ b/plugins/modules/azure_rm_iotdevice.py
@@ -231,15 +231,17 @@ device:
 '''  # NOQA
 
 import re
+import traceback
 
+from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.iot.hub import IoTHubRegistryManager
 except ImportError:
-    # This is handled in azure_rm_common
-    pass
-
+    AZURE_IOT_HUB_IMPORT_ERROR = traceback.format_exc()
+else:
+    AZURE_IOT_HUB_IMPORT_ERROR = None
 
 class AzureRMIoTDevice(AzureRMModuleBase):
 
@@ -283,6 +285,15 @@ class AzureRMIoTDevice(AzureRMModuleBase):
         self._base_url = None
         self.mgmt_client = None
         super(AzureRMIoTDevice, self).__init__(self.module_arg_spec, supports_check_mode=True)
+
+        if AZURE_IOT_HUB_IMPORT_ERROR:
+                self.fail(msg=missing_required_lib('azure-iot-hub',reason=(
+                    "This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                    "Installation may fail on some platforms due to uamqp wheel build issues."
+                    ),
+                    ),
+                    exception=AZURE_IOT_HUB_IMPORT_ERROR,
+                )
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice.py
+++ b/plugins/modules/azure_rm_iotdevice.py
@@ -290,7 +290,7 @@ class AzureRMIoTDevice(AzureRMModuleBase):
         if AZURE_IOT_HUB_IMPORT_ERROR:
             self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
                                                                         "Installation may fail on some platforms due to uamqp wheel build issues.")),
-                                                                        exception=AZURE_IOT_HUB_IMPORT_ERROR)
+                      exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice.py
+++ b/plugins/modules/azure_rm_iotdevice.py
@@ -288,9 +288,9 @@ class AzureRMIoTDevice(AzureRMModuleBase):
         super(AzureRMIoTDevice, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
         if AZURE_IOT_HUB_IMPORT_ERROR:
-                self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
-                                                                            "Installation may fail on some platforms due to uamqp wheel build issues.")),
-                                                                            exception=AZURE_IOT_HUB_IMPORT_ERROR)
+            self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                                                                        "Installation may fail on some platforms due to uamqp wheel build issues.")),
+                                                                        exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice_info.py
+++ b/plugins/modules/azure_rm_iotdevice_info.py
@@ -224,7 +224,7 @@ class AzureRMIoTDeviceFacts(AzureRMModuleBase):
         if AZURE_IOT_HUB_IMPORT_ERROR:
             self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
                                                                         "Installation may fail on some platforms due to uamqp wheel build issues.")),
-                                                                        exception=AZURE_IOT_HUB_IMPORT_ERROR)
+                      exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice_info.py
+++ b/plugins/modules/azure_rm_iotdevice_info.py
@@ -176,13 +176,18 @@ iot_devices:
     }
 '''  # NOQA
 
+import re
+import traceback
+
+from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.iot.hub import IoTHubRegistryManager
 except ImportError:
-    # This is handled in azure_rm_common
-    pass
+    AZURE_IOT_HUB_IMPORT_ERROR = traceback.format_exc()
+else:
+    AZURE_IOT_HUB_IMPORT_ERROR = None
 
 
 class AzureRMIoTDeviceFacts(AzureRMModuleBase):
@@ -216,6 +221,15 @@ class AzureRMIoTDeviceFacts(AzureRMModuleBase):
         self._base_url = None
 
         super(AzureRMIoTDeviceFacts, self).__init__(self.module_arg_spec, supports_check_mode=True)
+
+        if AZURE_IOT_HUB_IMPORT_ERROR:
+                self.fail(msg=missing_required_lib('azure-iot-hub',reason=(
+                    "This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                    "Installation may fail on some platforms due to uamqp wheel build issues."
+                    ),
+                    ),
+                    exception=AZURE_IOT_HUB_IMPORT_ERROR,
+                )
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice_info.py
+++ b/plugins/modules/azure_rm_iotdevice_info.py
@@ -176,7 +176,6 @@ iot_devices:
     }
 '''  # NOQA
 
-import re
 import traceback
 
 from ansible.module_utils.basic import missing_required_lib
@@ -223,13 +222,9 @@ class AzureRMIoTDeviceFacts(AzureRMModuleBase):
         super(AzureRMIoTDeviceFacts, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
         if AZURE_IOT_HUB_IMPORT_ERROR:
-                self.fail(msg=missing_required_lib('azure-iot-hub',reason=(
-                    "This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
-                    "Installation may fail on some platforms due to uamqp wheel build issues."
-                    ),
-                    ),
-                    exception=AZURE_IOT_HUB_IMPORT_ERROR,
-                )
+                self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                                                                            "Installation may fail on some platforms due to uamqp wheel build issues.")),
+                                                                            exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevice_info.py
+++ b/plugins/modules/azure_rm_iotdevice_info.py
@@ -222,9 +222,9 @@ class AzureRMIoTDeviceFacts(AzureRMModuleBase):
         super(AzureRMIoTDeviceFacts, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
         if AZURE_IOT_HUB_IMPORT_ERROR:
-                self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
-                                                                            "Installation may fail on some platforms due to uamqp wheel build issues.")),
-                                                                            exception=AZURE_IOT_HUB_IMPORT_ERROR)
+            self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                                                                        "Installation may fail on some platforms due to uamqp wheel build issues.")),
+                                                                        exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevicemodule.py
+++ b/plugins/modules/azure_rm_iotdevicemodule.py
@@ -221,13 +221,9 @@ class AzureRMIoTDeviceModule(AzureRMModuleBase):
         super(AzureRMIoTDeviceModule, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
         if AZURE_IOT_HUB_IMPORT_ERROR:
-                self.fail(msg=missing_required_lib('azure-iot-hub',reason=(
-                    "This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
-                    "Installation may fail on some platforms due to uamqp wheel build issues."
-                    ),
-                    ),
-                    exception=AZURE_IOT_HUB_IMPORT_ERROR,
-                )
+                self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                                                                            "Installation may fail on some platforms due to uamqp wheel build issues.")),
+                                                                            exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevicemodule.py
+++ b/plugins/modules/azure_rm_iotdevicemodule.py
@@ -223,7 +223,7 @@ class AzureRMIoTDeviceModule(AzureRMModuleBase):
         if AZURE_IOT_HUB_IMPORT_ERROR:
             self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
                                                                         "Installation may fail on some platforms due to uamqp wheel build issues.")),
-                                                                        exception=AZURE_IOT_HUB_IMPORT_ERROR)
+                      exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevicemodule.py
+++ b/plugins/modules/azure_rm_iotdevicemodule.py
@@ -221,9 +221,9 @@ class AzureRMIoTDeviceModule(AzureRMModuleBase):
         super(AzureRMIoTDeviceModule, self).__init__(self.module_arg_spec, supports_check_mode=True)
 
         if AZURE_IOT_HUB_IMPORT_ERROR:
-                self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
-                                                                            "Installation may fail on some platforms due to uamqp wheel build issues.")),
-                                                                            exception=AZURE_IOT_HUB_IMPORT_ERROR)
+            self.fail(msg=missing_required_lib('azure-iot-hub', reason=("This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                                                                        "Installation may fail on some platforms due to uamqp wheel build issues.")),
+                                                                        exception=AZURE_IOT_HUB_IMPORT_ERROR)
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_iotdevicemodule.py
+++ b/plugins/modules/azure_rm_iotdevicemodule.py
@@ -166,14 +166,17 @@ module:
 '''  # NOQA
 
 import re
+import traceback
 
+from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.iot.hub import IoTHubRegistryManager
 except ImportError:
-    # This is handled in azure_rm_common
-    pass
+    AZURE_IOT_HUB_IMPORT_ERROR = traceback.format_exc()
+else:
+    AZURE_IOT_HUB_IMPORT_ERROR = None
 
 
 class AzureRMIoTDeviceModule(AzureRMModuleBase):
@@ -216,6 +219,15 @@ class AzureRMIoTDeviceModule(AzureRMModuleBase):
         self._base_url = None
         self.mgmt_client = None
         super(AzureRMIoTDeviceModule, self).__init__(self.module_arg_spec, supports_check_mode=True)
+
+        if AZURE_IOT_HUB_IMPORT_ERROR:
+                self.fail(msg=missing_required_lib('azure-iot-hub',reason=(
+                    "This module requires the Azure IoT Hub data-plane SDK (azure-iot-hub). "
+                    "Installation may fail on some platforms due to uamqp wheel build issues."
+                    ),
+                    ),
+                    exception=AZURE_IOT_HUB_IMPORT_ERROR,
+                )
 
     def exec_module(self, **kwargs):
 

--- a/plugins/modules/azure_rm_privatednsrecordset.py
+++ b/plugins/modules/azure_rm_privatednsrecordset.py
@@ -313,6 +313,7 @@ RECORDSET_VALUE_MAP = dict(
     CAA=dict(attrname='caa_records', classobj='CaaRecord', is_list=True)
 )
 
+
 class AzureRMPrivateDNSRecordSet(AzureRMModuleBase):
 
     def __init__(self):

--- a/plugins/modules/azure_rm_privatednsrecordset.py
+++ b/plugins/modules/azure_rm_privatednsrecordset.py
@@ -254,7 +254,7 @@ state:
 '''
 
 from ansible.module_utils.basic import _load_params
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, HAS_AZURE
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, AZURE_IMPORT_ERROR
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
@@ -311,7 +311,7 @@ RECORDSET_VALUE_MAP = dict(
     TXT=dict(attrname='txt_records', classobj='TxtRecord', is_list=True),
     SOA=dict(attrname='soa_record', classobj='SoaRecord', is_list=False),
     CAA=dict(attrname='caa_records', classobj='CaaRecord', is_list=True)
-) if HAS_AZURE else {}
+) if AZURE_IMPORT_ERROR is None else {}
 
 
 class AzureRMPrivateDNSRecordSet(AzureRMModuleBase):

--- a/plugins/modules/azure_rm_privatednsrecordset.py
+++ b/plugins/modules/azure_rm_privatednsrecordset.py
@@ -254,7 +254,7 @@ state:
 '''
 
 from ansible.module_utils.basic import _load_params
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, AZURE_IMPORT_ERROR
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from azure.core.exceptions import ResourceNotFoundError
@@ -311,8 +311,7 @@ RECORDSET_VALUE_MAP = dict(
     TXT=dict(attrname='txt_records', classobj='TxtRecord', is_list=True),
     SOA=dict(attrname='soa_record', classobj='SoaRecord', is_list=False),
     CAA=dict(attrname='caa_records', classobj='CaaRecord', is_list=True)
-) if AZURE_IMPORT_ERROR is None else {}
-
+)
 
 class AzureRMPrivateDNSRecordSet(AzureRMModuleBase):
 


### PR DESCRIPTION
##### SUMMARY
Fix #2063 & #1884. This PR cleans up dependency handling and import logic across Azure RM common utilities and related modules.

Key changes include:
- Simplifying Azure SDK import detection by replacing legacy `HAS_AZURE` / version‑checking logic with a single `AZURE_IMPORT_ERROR` mechanism.
- Removing internal Azure SDK version enforcement and packaging checks in favor of explicit dependency management via `requirements.txt`.
- Updating DNS and Private DNS record set modules to remove conditional logic tied to `HAS_AZURE`.
- Improving Azure IoT Hub modules (`azure_rm_iotdevice*`) to explicitly and lazily validate the presence of the Azure IoT Hub data‑plane SDK (`azure-iot-hub`) using `missing_required_lib`, with clearer error messages.

There is **no functional behavior change** for users with correctly installed dependencies.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- plugins/module_utils/azure_rm_common.py
- plugins/modules/azure_rm_dnsrecordset.py
- plugins/modules/azure_rm_privatednsrecordset.py
- plugins/modules/azure_rm_iotdevice.py
- plugins/modules/azure_rm_iotdevice_info.py
- plugins/modules/azure_rm_iotdevicemodule.py
----
##### ADDITIONAL INFORMATION
This change addresses long‑standing issues around dependency handling, import‑time failures, and Ansible sanity/lint behavior when Azure SDK dependencies are missing.

**Requirements reminder**
To use this collection successfully, users **must install the Python dependencies listed in `requirements.txt`** in their execution environment.  
This PR intentionally does **not** install or manage dependencies at runtime, as this is explicitly against Ansible collection rules.

**Azure IoT Hub SDK note**
Modules interacting with Azure IoT Hub require the **Azure IoT Hub data‑plane SDK** ([`azure-iot-hub`](https://github.com/Azure/azure-iot-hub-python)).

Please note:
- Installation of `azure-iot-hub` may fail on some platforms due to upstream `uamqp` wheel build [issue](https://github.com/Azure/azure-iot-hub-python/issues/14).
- This is a known upstream problem and is outside the scope of this collection.
- Clear, actionable error messages are now provided when this dependency is missing.

**Azure CLI authentication clarification**
Azure CLI (`az`) is **not** a dependency of this collection.

However:
- Azure CLI **must be installed separately** if users choose to authenticate using the `azcli` authentication method.
- Azure CLI is only one of several supported authentication mechanisms and is not installed or managed by this collection.

This PR does not change authentication behavior; it clarifies expectations and avoids implicit dependency assumptions.
