### PR TITLE
fix:  ScaleSetPriority is immutable

### DIFF
--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -1046,6 +1046,9 @@ def create_agent_pool_profiles_dict(agentpoolprofiles):
         vm_size=profile.vm_size,
         name=profile.name,
         os_disk_size_gb=profile.os_disk_size_gb,
+        scale_set_priority=getattr(profile, 'scale_set_priority', None),
+        scale_set_eviction_policy=getattr(profile, 'scale_set_eviction_policy', None),
+        spot_max_price=getattr(profile, 'spot_max_price', None),
         vnet_subnet_id=profile.vnet_subnet_id,
         availability_zones=profile.availability_zones,
         os_type=profile.os_type,
@@ -1111,6 +1114,9 @@ agent_pool_profile_spec = dict(
     count=dict(type='int', required=True),
     vm_size=dict(type='str', required=True),
     os_disk_size_gb=dict(type='int'),
+    scale_set_priority=dict(type='str', choices=['Regular', 'Spot']),
+    scale_set_eviction_policy=dict(type='str', choices=['Delete', 'Deallocate']),
+    spot_max_price=dict(type='float'),
     dns_prefix=dict(type='str'),
     ports=dict(type='list', elements='int'),
     storage_profiles=dict(type='str', choices=[
@@ -1620,6 +1626,13 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                                        bool(security_profile['enable_vtpm']) != bool(profile_result['security_profile']['enable_vtpm']):
                                         self.log(("Agent Profile Diff - Origin {0} / Update {1}".format(str(profile_result), str(profile_self))))
                                         to_be_updated = True
+                                # Preserve immutable VMSS settings if not explicitly provided
+                                if profile_self.get('scale_set_priority') is None and profile_result.get('scale_set_priority') is not None:
+                                    profile_self['scale_set_priority'] = profile_result.get('scale_set_priority')
+                                if profile_self.get('scale_set_eviction_policy') is None and profile_result.get('scale_set_eviction_policy') is not None:
+                                    profile_self['scale_set_eviction_policy'] = profile_result.get('scale_set_eviction_policy')
+                                if profile_self.get('spot_max_price') is None and profile_result.get('spot_max_price') is not None:
+                                    profile_self['spot_max_price'] = profile_result.get('spot_max_price')
 
                         if not matched:
                             self.log("Agent Pool not found")
@@ -1824,6 +1837,9 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                     count=profile["count"],
                     vm_size=profile["vm_size"],
                     os_disk_size_gb=profile["os_disk_size_gb"],
+                    scale_set_priority=profile.get("scale_set_priority"),
+                    scale_set_eviction_policy=profile.get("scale_set_eviction_policy"),
+                    spot_max_price=profile.get("spot_max_price"),
                     max_count=profile["max_count"],
                     node_labels=profile["node_labels"],
                     min_count=profile["min_count"],

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -200,6 +200,34 @@ options:
                             - Whether to disable or enabled the secure boot.
                         default: false
                         type: bool
+            scale_set_priority:
+                description:
+                    - Virtual Vachine Scale Set priority for the agent pool.
+                    - C(Regular) uses standard on-demand VMs.
+                    - C(Spot) uses Azure Spot VMs which can be evicted at any time.
+                    - This property is immutable after the agent pool is created.
+                type: str
+                choices:
+                    - Regular
+                    - Spot
+            scale_set_eviction_policy:
+                description:
+                    - Eviction policy for Spot VM agent pools.
+                    - Only applicable when I(scale_set_priority=Spot).
+                    - C(Delete) removes the VM and its disk on eviction.
+                    - C(Deallocate) deallocates the VM, but retains the disk on eviction.
+                    - This property is immutable after the agent pool is created.
+                type: str
+                choices:
+                    - Delete
+                    - Deallocate
+            spot_max_price:
+                description:
+                    - The maximum price (in USD per hour) for Spot VMs in the agent pool.
+                    - Use C(-1) to indicate the on-demand price.
+                    - Only applicable when I(scale_set_priority=Spot).
+                    - This property is immutable after the agent pool is created.
+                type: float
     security_profile:
         description:
             - Security profile for the container service cluster.
@@ -813,6 +841,36 @@ EXAMPLES = '''
       load_balancer_sku: standard
       network_plugin: azure
       outbound_type: loadBalancer
+
+- name: Create an AKS instance with a Spot user node pool
+  azure_rm_aks:
+    name: myAKSWithSpot
+    resource_group: myResourceGroup
+    location: eastus
+    dns_prefix: aksspot
+    kubernetes_version: 1.28.5
+    linux_profile:
+      admin_username: azureuser
+      ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAA...
+    service_principal:
+      client_id: "cf72ca99-f6b9-4004-b0e0-bee10c521948"
+      client_secret: "Password1234!"
+    enable_rbac: true
+    agent_pool_profiles:
+      - name: systempool
+        count: 1
+        vm_size: Standard_B2s
+        mode: System
+      - name: spotpool
+        count: 2
+        vm_size: Standard_D2_v2
+        mode: User
+        scale_set_priority: Spot
+        scale_set_eviction_policy: Deallocate
+        spot_max_price: -1
+        enable_auto_scaling: true
+        min_count: 1
+        max_count: 5
 
 - name: Remove a managed Azure Container Services (AKS) instance
   azure_rm_aks:

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -706,10 +706,11 @@
             type: VirtualMachineScaleSets
             mode: System
           - name: spotpool
-            count: 2  # trigger update
+            count: 1
             vm_size: Standard_D2s_v3
             type: VirtualMachineScaleSets
             mode: User
+            node_labels: {"environment":"test"}  # trigger update
         network_profile:
           load_balancer_sku: standard
       register: spot_update
@@ -738,7 +739,7 @@
             type: VirtualMachineScaleSets
             mode: System
           - name: spotpool
-            count: 2
+            count: 1
             vm_size: Standard_D2s_v3
             type: VirtualMachineScaleSets
             mode: User

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -676,7 +676,7 @@
             scale_set_priority: Spot
             scale_set_eviction_policy: Delete
             spot_max_price: -1
-        node_resource_group: "node{{ noderpfx }}"
+        node_resource_group: "node{{ rpfx }}-spot"
         enable_rbac: true
         network_profile:
           load_balancer_sku: standard
@@ -725,7 +725,7 @@
         name: "aks{{ rpfx }}-spot"
         resource_group: "{{ resource_group }}-aks"
         location: "{{ location }}"
-        dns_prefix: "aks{{ rpfx }}spot"
+        dns_prefix: "aks{{ rpfx }}-spot"
         kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
         service_principal:
           client_id: "{{ azure_client_id }}"

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -676,7 +676,7 @@
             scale_set_priority: Spot
             scale_set_eviction_policy: Delete
             spot_max_price: -1
-        node_resource_group: "node{{ rpfx }}-spot"
+        node_resource_group: "node{{ noderpfx }}-spot"
         enable_rbac: true
         network_profile:
           load_balancer_sku: standard

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -648,6 +648,109 @@
           - "fact.aks | length == 1"
           - fact.aks[0].kube_config == output.kube_config
 
+    - name: Create AKS with Spot agent pool
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}-spot"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}-spot"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        agent_pool_profiles:
+          - name: systempool
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+          - name: spotpool
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: User
+            scale_set_priority: Spot
+            scale_set_eviction_policy: Delete
+            spot_max_price: -1
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+      register: spot_create
+
+    - name: Assert Spot AKS created
+      ansible.builtin.assert:
+        that:
+          - spot_create is changed
+          - spot_create.provisioning_state == 'Succeeded'
+
+    - name: Update AKS Spot pool WITHOUT specifying Spot fields
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}-spot"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}-spot"
+        kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        enable_rbac: true
+        agent_pool_profiles:
+          - name: systempool
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+          - name: spotpool
+            count: 2  # trigger update
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: User
+        network_profile:
+          load_balancer_sku: standard
+      register: spot_update
+
+    - name: Assert Spot pool update succeeded (no ScaleSetPriority immutable error)
+      ansible.builtin.assert:
+        that:
+          - spot_update is changed
+          - spot_update.provisioning_state == 'Succeeded'
+
+    - name: Update AKS Spot pool again (idempotent)
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}-spot"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}spot"
+        kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        enable_rbac: true
+        agent_pool_profiles:
+          - name: systempool
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+          - name: spotpool
+            count: 2
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: User
+        network_profile:
+          load_balancer_sku: standard
+      register: spot_update_idem
+
+    - name: Assert Spot pool update idempotent
+      ansible.builtin.assert:
+        that:
+          - spot_update_idem is not changed
+
     - name: Delete the AKS instance
       azure.azcollection.azure_rm_aks:
         name: "aks{{ rpfx }}"
@@ -659,6 +762,18 @@
       ansible.builtin.assert:
         that:
           - output is changed
+
+    - name: Delete the AKS Spot instance
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}-spot"
+        resource_group: "{{ resource_group }}-aks"
+        state: absent
+      register: output_spot_delete
+
+    - name: Assert the AKS Spot instance is well deleted
+      ansible.builtin.assert:
+        that:
+          - output_spot_delete is changed
 
     - name: Delete the AKS instance (idempotent)
       azure.azcollection.azure_rm_aks:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We have recently been hitting the following failure when using the `azure_rm_aks.py` module:
```
msg: >-
  Error creating the AKS instance: (BadRequest) ScaleSetPriority is immutable.
  Provided value is Regular, Please use current value .

  Code: BadRequest

  Message: ScaleSetPriority is immutable. Provided value is Regular, Please use
  current value .
```
Changes in this PR:

- Add support for VMSS Spot settings in agent_pool_profiles:
    - scale_set_priority (Regular | Spot)
    - scale_set_eviction_policy (Delete | Deallocate)
    - spot_max_price (float)
- Safely read these properties from existing node pools and include them in returned state.
- During updates, if these fields are omitted, preserve the current pool values (by name match) to avoid Azure’s “ScaleSetPriority is immutable” error.
- Forward the fields to AgentPool create/update calls.
- Backwards-compatible: optional fields default to None; safe access (getattr/.get) used to support older SDKs and existing playbooks.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_aks.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When we first ran into this issue it was while performing a Kubernetes upgrade to a existing AKS cluster. 
Sanitized task that failed:
```
    - name: Upgrade AKS to target kubernetes version
      azure.azcollection.azure_rm_aks:
        name: "{{ cluster_name }}"
        resource_group: "{{ resource_group }}"
        subscription_id: "{{ subscription_id }}"
        dns_prefix: "{{ aks_info.dns_prefix }}"
        kubernetes_version: "{{ target_cluster_version }}"
        agent_pool_profiles:
          - name: "{{ aks_info.agent_pool_profiles[0].name }}"
            count: "{{ aks_info.agent_pool_profiles[0].count }}"
            vm_size: "{{ aks_info.agent_pool_profiles[0].vm_size }}"
            mode: "{{ aks_info.agent_pool_profiles[0].mode }}"
            orchestrator_version: "{{ target_cluster_version }}"
        service_principal:
          client_id: "{{ aks_info.service_principal_profile.client_id }}"
        enable_rbac: "{{ aks_info.enable_rbac }}"
      register: kube_upgrade
      notify: Print the finished upgrade status
```
<!--- Paste verbatim command output below, e.g. before and after your change -->

