### PR TITLE
Support changing VM size in azure_rm_virtualmachinescaleset

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1062,6 +1062,13 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     changed = True
                     vmss_dict['sku']['capacity'] = self.capacity
 
+                if self.vm_size and \
+                   self.vm_size != vmss_dict['sku']['name']:
+                    self.log('CHANGED: virtual machine scale set {0} - VM Size'.format(self.name))
+                    differences.append('VM Size')
+                    changed = True
+                    vmss_dict['sku']['name'] = self.vm_size
+
                 if self.data_disks and \
                    len(self.data_disks) != len(vmss_dict['virtual_machine_profile']['storage_profile'].get('data_disks', [])):
                     self.log('CHANGED: virtual machine scale set {0} - Data Disks'.format(self.name))
@@ -1439,6 +1446,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     vmss_resource = self.get_vmss()
                     vmss_resource.virtual_machine_profile.storage_profile.os_disk.caching = self.os_disk_caching
                     vmss_resource.sku.capacity = self.capacity
+                    vmss_resource.sku.name = self.vm_size
                     vmss_resource.orchestration_mode = self.orchestration_mode
                     vmss_resource.platform_fault_domain_count = self.platform_fault_domain_count
                     vmss_resource.overprovision = self.overprovision


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The azure_rm_virtualmachinescaleset module allows specifying a "vm_size" parameter for an Azure VM Compute SKU name. Currently the module does not handle changes to vm_size on updating a scale set. The module reports "changed" but does not change the SKU. This PR adds support to allow the SKU name to change on updates. With the PR it now successfully changes the SKU and reports "ok" for idempotency runs. Half bug fix, half new feature?

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachinescaleset

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I wasn't sure if adding a test case was possible in your test environment so I didn't add one. I didn't know if a SKU besides 'Standard_D2s_v3' was available.
