### PR TITLE
Follow up #2183: Adding helper function to extract missing lib from traceback log

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -323,7 +323,19 @@ def normalize_location_name(name):
     return name.replace(' ', '').lower()
 
 
-AZURE_MIN_RELEASE = '2.0.0'
+def _extract_missing_module(import_error):
+    """
+    Extract missing module name from ImportError traceback.
+    Returns None if not detectable.
+    """
+    if not import_error:
+        return None
+
+    match = re.search(r"No module named '([^']+)'", import_error)
+    if match:
+        return match.group(1)
+
+    return None
 
 
 class AzureRMModuleBase(object):
@@ -359,9 +371,22 @@ class AzureRMModuleBase(object):
                                     required_if=merged_required_if,
                                     required_by=required_by)
 
-        if AZURE_IMPORT_ERROR:
-            self.fail(msg=missing_required_lib('ansible[azure] (azure >= {0})'.format(AZURE_MIN_RELEASE)),
-                      exception=AZURE_IMPORT_ERROR)
+        
+        missing_mod = _extract_missing_module(AZURE_IMPORT_ERROR)
+
+        if missing_mod:
+            msg = (
+                "Failed to import the required Python library ({0}). "
+                "Please install them by running: "
+                "pip install -r requirements.txt. "
+                "If the required library is installed, but Ansible is using the wrong "
+                "Python interpreter, please consult the documentation on "
+                "ansible_python_interpreter."
+            ).format(missing_mod)
+        else:
+            msg = missing_required_lib("Azure SDK dependencies")
+
+        self.fail(msg=msg, exception=AZURE_IMPORT_ERROR)
 
         self._authorization_client = None
         self._network_client = None

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -371,7 +371,6 @@ class AzureRMModuleBase(object):
                                     required_if=merged_required_if,
                                     required_by=required_by)
 
-        
         missing_mod = _extract_missing_module(AZURE_IMPORT_ERROR)
 
         if missing_mod:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -371,21 +371,22 @@ class AzureRMModuleBase(object):
                                     required_if=merged_required_if,
                                     required_by=required_by)
 
-        missing_mod = _extract_missing_module(AZURE_IMPORT_ERROR)
+        if AZURE_IMPORT_ERROR:
+            missing_mod = _extract_missing_module(AZURE_IMPORT_ERROR)
 
-        if missing_mod:
-            msg = (
-                "Failed to import the required Python library ({0}). "
-                "Please install them by running: "
-                "pip install -r requirements.txt. "
-                "If the required library is installed, but Ansible is using the wrong "
-                "Python interpreter, please consult the documentation on "
-                "ansible_python_interpreter."
-            ).format(missing_mod)
-        else:
-            msg = missing_required_lib("Azure SDK dependencies")
+            if missing_mod:
+                msg = (
+                    "Failed to import the required Python library ({0}). "
+                    "Please install them by running: "
+                    "pip install -r requirements.txt. "
+                    "If the required library is installed, but Ansible is using the wrong "
+                    "Python interpreter, please consult the documentation on "
+                    "ansible_python_interpreter."
+                ).format(missing_mod)
+            else:
+                msg = missing_required_lib("Azure SDK dependencies")
 
-        self.fail(msg=msg, exception=AZURE_IMPORT_ERROR)
+            self.fail(msg=msg, exception=AZURE_IMPORT_ERROR)
 
         self._authorization_client = None
         self._network_client = None


### PR DESCRIPTION
##### SUMMARY
Follow up on PR #2183 & #2063 . This PR improves the end-user error experience when Azure SDK dependencies are missing. Collection now reports the specific Python module that failed to import.

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py

----
##### ADDITIONAL INFORMATION
Limitation:
- Due to Python's import semantics, only the first missing library reported per execution.
- When multiple Azure SDK libraries are missing, the import process stops at the first `ImportError`, so users may need to re‑run after installing dependencies to discover the next missing library.

Solution:
- **(User)** must ensure that all **Python dependencies** listed in the Azure collection's [`requirements.txt`](https://github.com/ansible-collections/azure/blob/dev/requirements.txt) are installed in the execution environment before running any Azure modules (Refer [README.md](https://github.com/ansible-collections/azure/blob/dev/README.md#:~:text=After%20the%20collection,azcollection/requirements.txt)). 
- **(Maintainer)** must continuously keep the dependency list in `requirements.txt` accurate and up to date with the Azure SDK libraries used by the collection. Update dependencies as Azure SDKs evolve to prevent version mismatches and remove deprecated or unused SDKs. 
