### PR TITLE
Follow-up #2187: Add integration test on vm_size upgrade for virtual machine scale set.

### DIFF
--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -963,6 +963,84 @@
       ansible.builtin.assert:
         that: results is changed
 
+    - name: Upgrade VMSS with disk encryption (change vm_size to D4s_v3)
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: testVMSS{{ rpfx }}des
+        vm_size: Standard_D4s_v3  # upgrade
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        image:
+          name: testimagea
+          resource_group: "{{ resource_group }}-vmss01"
+        os_disk_encryption_set: "{{ des_results.state.id }}"
+        data_disks:
+          - lun: 0
+            disk_size_gb: 64
+            caching: ReadWrite
+            managed_disk_type: Standard_LRS
+            disk_encryption_set: "{{ des_results.state.id }}"
+        upgrade_policy: Manual
+        single_placement_group: true
+        orchestration_mode: Uniform
+      register: upgrade_result
+
+    - name: Assert that vm_size can be upgraded
+      ansible.builtin.assert:
+        that: upgrade_result is changed
+
+    - name: Get VMSS facts after vm_size upgrade
+      azure.azcollection.azure_rm_virtualmachinescaleset_info:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: testVMSS{{ rpfx }}des
+      register: vmss_info
+
+    - name: Assert that VMSS sku.name reflects upgraded vm_size
+      ansible.builtin.assert:
+        that:
+          - vmss_info.vmss | length == 1
+          - vmss_info.vmss[0].sku.name == "Standard_D4s_v3"
+        fail_msg: >-
+          Expected VMSS sku.name to be Standard_D4s_v3, but got
+          {{ vmss_info.vmss[0].sku.name }}
+
+    - name: Upgrade VMSS with disk encryption (change vm_size to D4s_v3)(idempotency)
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: testVMSS{{ rpfx }}des
+        vm_size: Standard_D4s_v3
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        image:
+          name: testimagea
+          resource_group: "{{ resource_group }}-vmss01"
+        os_disk_encryption_set: "{{ des_results.state.id }}"
+        data_disks:
+          - lun: 0
+            disk_size_gb: 64
+            caching: ReadWrite
+            managed_disk_type: Standard_LRS
+            disk_encryption_set: "{{ des_results.state.id }}"
+        upgrade_policy: Manual
+        single_placement_group: true
+        orchestration_mode: Uniform
+      register: idem_result
+
+    - name: Assert idempotency after vm_size upgrade
+      ansible.builtin.assert:
+        that:
+          - idem_result is not changed
+
     - name: Delete VMSS
       azure.azcollection.azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}-vmss01"


### PR DESCRIPTION
##### SUMMARY
Follow-up #2187. This PR adds an integration test to cover `vm_size` upgrades for `azure_rm_virtualmachinescaleset`, validating that:
- the VMSS SKU is actually updated in Azure
- subsequent runs are idempotent

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachinescaleset.py
tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml