### PR TITLE
Dependencies Fix: Skip azure-iot-hub on Python 3.14+ uamqp build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ azure-containerregistry==1.2.0
 azure-core==1.38.0
 azure-eventhub==5.15.0
 azure-identity==1.25.2
-azure-iot-hub==2.6.1;platform_machine=="x86_64"
+azure-iot-hub==2.6.1; platform_machine == "x86_64" and python_version < "3.14"
 azure-keyvault==4.2.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-apimanagement==4.0.1


### PR DESCRIPTION
##### SUMMARY
This PR adds an environment marker to the `azure-iot-hub` dependency to prevent installation on Python 3.14+ on top of existing constraint on x86_64 platforms.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt

##### ADDITIONAL INFORMATION
This issue reproduces consistently on Python 3.14.x (x86_64) and does **not** occur on Python 3.13 and below. 

Related issue: #1511, https://github.com/Azure/azure-iot-hub-python/issues/14
