### PR TITLE
Fix #1568: Support OIDC/Workload Identity federation

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -45,6 +45,24 @@ options:
         description:
             - Azure tenant ID. Use when authenticating with a Service Principal.
         type: str
+    oidc_token:
+        description:
+            - Direct OpenID Connect (OIDC) token (JWT) used for workload identity authentication.
+            - This token is exchanged with Azure AD using OIDC federated identity.
+            - Useful in CI systems (for example GitHub Actions, Azure DevOps) where an OIDC token is provided directly by the platform.
+            - Can also be set via the C(AZURE_FEDERATED_TOKEN) environment variable.
+        type: str
+        no_log: true
+        version_added: '3.17.0'
+    oidc_token_file_path:
+        description:
+            - Path to a file containing an OpenID Connect (OIDC) token (JWT) used for workload identity authentication.
+            - The file must contain only raw token.
+            - This method is commonly used in platforms that materialize OIDC tokens as files
+            - Can also be set via the C(AZURE_FEDERATED_TOKEN_FILE) environment variable.
+        type: path
+        no_log: true
+        version_added: '3.17.0'
     cloud_environment:
         description:
             - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),
@@ -84,7 +102,7 @@ options:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
             - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
-            - When set to C(env), the credentials will be read from the environment variables
+            - When set to C(env), the credentials will be read from the environment variables.
             - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable
               C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if more than one is present otherwise the default
@@ -141,6 +159,8 @@ notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
       in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login).
     - Authentication is also possible using a service principal or Active Directory user.
+    - To authenticate via OIDC, pass client_id, tenant and oidc_token or oidc_token_file_path, or set environment
+      variables AZURE_CLIENT_ID, AZURE_TENANT and AZURE_FEDERATED_TOKEN or AZURE_FEDERATED_TOKEN_FILE.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -99,9 +99,7 @@ options:
         description:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
-            - By default (C(auth_source=auto)), credentials are resolved by first reading module parameters,
-              then filling missing values from environment variables, and finally falling back to C(~/.azure/credentials)
-              or the Azure CLI if no identity is found.
+            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
             - When set to C(env), the credentials will be read from the environment variables.
             - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -99,7 +99,9 @@ options:
         description:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
-            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
+            - By default (C(auth_source=auto)), credentials are resolved by first reading module parameters,
+              then filling missing values from environment variables, and finally falling back to C(~/.azure/credentials)
+              or the Azure CLI if no identity is found.
             - When set to C(env), the credentials will be read from the environment variables.
             - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -52,7 +52,6 @@ options:
             - Useful in CI systems (for example GitHub Actions, Azure DevOps) where an OIDC token is provided directly by the platform.
             - Can also be set via the C(AZURE_FEDERATED_TOKEN) environment variable.
         type: str
-        no_log: true
         version_added: '3.17.0'
     oidc_token_file_path:
         description:
@@ -61,7 +60,6 @@ options:
             - This method is commonly used in platforms that materialize OIDC tokens as files
             - Can also be set via the C(AZURE_FEDERATED_TOKEN_FILE) environment variable.
         type: path
-        no_log: true
         version_added: '3.17.0'
     cloud_environment:
         description:

--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -39,6 +39,18 @@ options:
         type: str
         env:
           - name: AZURE_TENANT
+    oidc_token:
+        description:
+            - Direct OpenID Connect (OIDC) token (JWT) used for workload identity authentication.
+        type: str
+        env:
+          - name: AZURE_FEDERATED_TOKEN
+    oidc_token_file_path:
+        description:
+            - Path to a file containing an OpenID Connect (OIDC) token (JWT) used for workload identity authentication.
+        type: path
+        env:
+          - name: AZURE_FEDERATED_TOKEN_FILE
     cloud_environment:
         description:
             - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),
@@ -82,6 +94,8 @@ notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
       in ~/.azure/credentials, or log in before you run your tasks or playbook with C(az login).
     - Authentication is also possible using a service principal.
+    - To authenticate via OIDC, pass client_id, tenant and oidc_token or oidc_token_file_path, or set environment
+      variables AZURE_CLIENT_ID, AZURE_TENANT and AZURE_FEDERATED_TOKEN or AZURE_FEDERATED_TOKEN_FILE.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - "Alternatively, credentials can be stored in ~/.azure/credentials. This is an ini file containing

--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -66,11 +66,8 @@ options:
         description:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
-            - By default (C(auth_source=auto)), credentials are resolved by first reading module parameters,
-              then filling missing values from environment variables, and finally falling back to C(~/.azure/credentials)
-              or the Azure CLI if no identity is found.
-            - When set to C(env), the credentials will be read from the environment variables.
-            - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
+            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
+            - When set to C(env), the credentials will be read from the environment variables
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable
               C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if more than one is present otherwise the default
               az cli subscription is used.
@@ -82,10 +79,9 @@ options:
         default: auto
         choices:
         - auto
-        - msi
-        - env
-        - credential_file
         - cli
+        - env
+        - msi
         env:
           - name: ANSIBLE_AZURE_AUTH_SOURCE
 requirements:

--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -66,8 +66,11 @@ options:
         description:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
-            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
-            - When set to C(env), the credentials will be read from the environment variables
+            - By default (C(auth_source=auto)), credentials are resolved by first reading module parameters,
+              then filling missing values from environment variables, and finally falling back to C(~/.azure/credentials)
+              or the Azure CLI if no identity is found.
+            - When set to C(env), the credentials will be read from the environment variables.
+            - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable
               C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if more than one is present otherwise the default
               az cli subscription is used.
@@ -79,9 +82,10 @@ options:
         default: auto
         choices:
         - auto
-        - cli
-        - env
         - msi
+        - env
+        - credential_file
+        - cli
         env:
           - name: ANSIBLE_AZURE_AUTH_SOURCE
 requirements:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1799,7 +1799,8 @@ class AzureRMAuth(object):
             return None
 
         has_sp_secret = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('secret')
-        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('thumbprint') and env_credentials.get('x509_certificate_path')
+        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('thumbprint') \
+            and env_credentials.get('x509_certificate_path')
         has_oidc = env_credentials.get('client_id') and env_credentials.get('tenant') and os.environ.get('AZURE_FEDERATED_TOKEN_FILE')
         has_userpass = env_credentials.get('ad_user') and env_credentials.get('password')
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1840,21 +1840,22 @@ class AzureRMAuth(object):
             credentials = self._get_profile(env_credentials['profile'])
             return credentials
 
+        # Detech env auth shapes
+        has_sp_secret = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('secret')
+        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('thumbprint') \
+            and env_credentials.get('x509_certificate_path')
+        has_oidc_direct = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('oidc_token')
+        has_oidc_file = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('oidc_token_file_path')
+        has_userpass = env_credentials.get('ad_user') and env_credentials.get('password')
+
+        if not (has_sp_secret or has_sp_cert or has_oidc_direct or has_oidc_file or has_userpass):
+            return None
+
         # Must have subscription_id for ARM resources
         if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
             return None
 
-        has_sp_secret = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('secret')
-        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('thumbprint') \
-            and env_credentials.get('x509_certificate_path')
-        has_oidc = env_credentials.get('client_id') and env_credentials.get('tenant') and os.environ.get('AZURE_FEDERATED_TOKEN_FILE')
-        has_userpass = env_credentials.get('ad_user') and env_credentials.get('password')
-
-        if has_sp_secret or has_sp_cert or has_oidc or has_userpass:
-            return env_credentials
-
-        # Otherwise, let auto fall through to credential_file/cli
-        return None
+        return env_credentials
 
     def _get_credentials(self, auth_source=None, **params):
         # Get authentication credentials.
@@ -1895,7 +1896,8 @@ class AzureRMAuth(object):
             credentials = self._get_profile(arg_credentials['profile'])
             return credentials
 
-        if arg_credentials['client_id'] or arg_credentials['ad_user']:
+        if arg_credentials['client_id'] or arg_credentials['ad_user'] or \
+            arg_credentials['oidc_token'] or arg_credentials['oidc_token_file_path']:
             self.log('Received credentials from parameters.')
             return arg_credentials
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1686,10 +1686,12 @@ class AzureRMAuth(object):
                                                                                     disable_instance_discovery=self._disable_instance_discovery)
 
         else:
-            self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
-                      "Credentials must include client_id, secret and tenant or ad_user and password, or "
-                      "ad_user, password, client_id, tenant and adfs_authority_url(optional) for ADFS authentication, or "
-                      "be logged in using AzureCLI.")
+            self.fail("Failed to authenticate with provided credentials. Some attributes were missing. \n\n"
+                      "Supported authentication methods: \n"
+                      "- Workload identity (OIDC): client_id, tenant, and AZURE_FEDERATED_TOKEN_FILE\n"
+                      "- Service principal with client secret: client_id, tenant, secret\n"
+                      "- Service principal with certificate: client_id, tenant, thumbprint, x509_certificate_path\n"
+                      "- Username/password authentication: ad_user, password\n")
 
     def fail(self, msg, exception=None, **kwargs):
         self._fail_impl(msg)

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1547,7 +1547,7 @@ class AzureRMAuth(object):
     def __init__(self, auth_source=None, profile=None, subscription_id=None, client_id=None, secret=None,
                  tenant=None, ad_user=None, password=None, cloud_environment='AzureCloud', cert_validation_mode='validate',
                  api_profile='latest', adfs_authority_url=None, fail_impl=None, is_ad_resource=False,
-                 x509_certificate_path=None, thumbprint=None, track1_cred=False,
+                 x509_certificate_path=None, thumbprint=None, oidc_token=None, oidc_token_file_path=None, track1_cred=False,
                  disable_instance_discovery=False , **kwargs):
 
         if fail_impl:
@@ -1577,7 +1577,9 @@ class AzureRMAuth(object):
             adfs_authority_url=adfs_authority_url,
             x509_certificate_path=x509_certificate_path,
             thumbprint=thumbprint,
-            disable_instance_discovery=disable_instance_discovery)
+            disable_instance_discovery=disable_instance_discovery,
+            oidc_token=oidc_token,
+            oidc_token_file_path=oidc_token_file_path)
 
         if not self.credentials:
             self.fail("Failed to get credentials. Either pass as parameters, set environment variables, "
@@ -1632,10 +1634,6 @@ class AzureRMAuth(object):
             self._adfs_authority_url = self._cloud_environment.endpoints.active_directory
         else:
             self._adfs_authority_url = self.credentials.get('adfs_authority_url')
-
-        # OIDC PATH
-        self.oidc_token = self.credentials.get('oidc_token') or self._get_env('oidc_token')
-        self.oidc_token_file_path = self.credentials.get('oidc_token_file_path') or self._get_env('oidc_token_file_path')
 
         # auth_source if-elif precedence: MSI, Azure CLI, OIDC direct token, OIDC token file, SP secret, SP cert, userpass
         if self.credentials.get('auth_source') == 'msi':

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1633,11 +1633,11 @@ class AzureRMAuth(object):
                 self.credentials.get('tenant') is not None and \
                 os.environ.get('AZURE_FEDERATED_TOKEN_FILE') is not None:
             token_file = os.environ["AZURE_FEDERATED_TOKEN_FILE"]
-            
+
             def _load_assertion():
                 with open(token_file, "r") as f:
                     return f.read()
-            
+
             self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
                                                                      client_id=self.credentials['client_id'],
                                                                      client_assertion=_load_assertion,
@@ -1789,18 +1789,25 @@ class AzureRMAuth(object):
         return cli_credentials
 
     def _get_env_credentials(self):
-        env_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            env_credentials[attribute] = os.environ.get(env_variable, None)
+        env_credentials = {attr: os.environ.get(env_var) for attr, env_var in AZURE_CREDENTIAL_ENV_MAPPING.items()}
 
-        if env_credentials['profile']:
-            credentials = self._get_profile(env_credentials['profile'])
-            return credentials
+        if env_credentials.get('profile'):
+            return self._get_profile(env_credentials['profile'])
 
+        # Must have subscription_id for ARM resources
         if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
             return None
-        else:
+
+        has_sp_secret = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('secret')
+        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('thumbprint') and env_credentials.get('x509_certificate_path')
+        has_oidc = env_credentials.get('client_id') and env_credentials.get('tenant') and os.environ.get('AZURE_FEDERATED_TOKEN_FILE')
+        has_userpass = env_credentials.get('ad_user') and env_credentials.get('password')
+
+        if has_sp_secret or has_sp_cert or has_oidc or has_userpass:
             return env_credentials
+
+        # Otherwise, let auto fall through to credential_file/cli
+        return None
 
     def _get_credentials(self, auth_source=None, **params):
         # Get authentication credentials.

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -292,6 +292,7 @@ from hashlib import sha256
 from hmac import HMAC
 from time import time
 import subprocess
+import logging  # oidcdebug
 
 try:
     from urllib import (urlencode, quote_plus)
@@ -1539,9 +1540,6 @@ class AzureRMAuthException(Exception):
     pass
 
 
-AZURE_SDK_HTTP_LOGGING = True  # oidcdebug
-
-
 class AzureRMAuth(object):
     _cloud_environment = None
     _adfs_authority_url = None
@@ -1559,11 +1557,8 @@ class AzureRMAuth(object):
         self.is_ad_resource = is_ad_resource
 
         # oidcdebug
-        self._enable_http_logging = (
-            os.environ.get("AZURE_SDK_HTTP_LOGGING", "False").lower() == "true"
-        )
-        if self._enable_http_logging:
-            self._enable_azure_sdk_http_logging()
+        logger = logging.getLogger('azure.identity')
+        logger.setLevel(logging.DEBUG)
 
         # authenticate
         self.credentials = self._get_credentials(
@@ -1662,7 +1657,7 @@ class AzureRMAuth(object):
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
                                                                      disable_instance_discovery=self._disable_instance_discovery,
-                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
+                                                                     logging_enable=True)  # oidcdebug
         # OIDC token file
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
@@ -1681,7 +1676,7 @@ class AzureRMAuth(object):
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
                                                                      disable_instance_discovery=self._disable_instance_discovery,
-                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
+                                                                     logging_enable=True)  # oidcdebug
 
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('secret') is not None and \
@@ -1934,35 +1929,3 @@ class AzureRMAuth(object):
         #         log_file.write(json.dumps(msg, indent=4, sort_keys=True))
         #     else:
         #         log_file.write(msg + u'\n')
-
-    # oidcdebug
-    def _enable_azure_sdk_http_logging(self):
-        import logging
-        import sys
-
-        handler = logging.StreamHandler(sys.stderr)
-        handler.setLevel(logging.DEBUG)
-        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
-
-        handler._azcollection_oidc_http_logging = True
-
-        azure_logger_names = [
-            "azure",
-            "azure.identity",
-            "azure.core",
-            "azure.core.pipeline",
-            "azure.core.pipeline.policies",
-            "azure.core.pipeline.policies.http_logging_policy",
-            "azure.core.pipeline.policies._universal",
-        ]
-
-        for name in azure_logger_names:
-            logger = logging.getLogger(name)
-            logger.setLevel(logging.DEBUG)
-
-            logger.propagate = True
-
-            if not any(getattr(h, "_azcollection_oidc_http_logging", False) for h in logger.handlers):
-                logger.addHandler(handler)
-
-        logging.getLogger("azure").setLevel(logging.DEBUG)

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -293,6 +293,7 @@ from hmac import HMAC
 from time import time
 import subprocess
 import logging  # oidcdebug
+import sys  # oidcdebug
 
 try:
     from urllib import (urlencode, quote_plus)
@@ -1559,6 +1560,8 @@ class AzureRMAuth(object):
         # oidcdebug
         logger = logging.getLogger('azure.identity')
         logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler(stream=sys.stdout)
+        logger.addHandler(handler)
 
         # authenticate
         self.credentials = self._get_credentials(

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1688,9 +1688,12 @@ class AzureRMAuth(object):
                                                                                 authority=self._adfs_authority_url,
                                                                                 disable_instance_discovery=self._disable_instance_discovery)
 
+        # Removed thumbprint as a requirement for cert auth as Azure SDK for Python's CertificateCredential does not require thumbprint to authenticate
+        # Reference: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.certificatecredential?view=azure-python
+        # Reference: https://docs.azure.cn/en-us/entra/identity-platform/certificate-credentials
+        # Create SP with certificate using az cli: `az ad app credential reset --id 00000000-0000-0000-0000-000000000000 --create-cert`
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
-                self.credentials.get('thumbprint') is not None and \
                 self.credentials.get('x509_certificate_path') is not None:
             self.azure_credential_track2 = certificate.CertificateCredential(tenant_id=self.credentials['tenant'],
                                                                              client_id=self.credentials['client_id'],
@@ -1726,7 +1729,7 @@ class AzureRMAuth(object):
                       "- Workload identity (OIDC) token: client_id, tenant, and oidc_token\n"
                       "- Workload identity (OIDC) token file: client_id, tenant, and oidc_token_file_path\n"
                       "- Service principal with client secret: client_id, tenant, secret\n"
-                      "- Service principal with certificate: client_id, tenant, thumbprint, x509_certificate_path\n"
+                      "- Service principal with certificate: client_id, tenant, x509_certificate_path\n"
                       "- Username/password authentication: ad_user, password\n"
                       "- Azure CLI authentication: run `az_login`.\n")
 
@@ -1838,8 +1841,7 @@ class AzureRMAuth(object):
 
         # Detech env auth shapes
         has_sp_secret = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('secret')
-        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('thumbprint') \
-            and env_credentials.get('x509_certificate_path')
+        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('x509_certificate_path')
         has_oidc_direct = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('oidc_token')
         has_oidc_file = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('oidc_token_file_path')
         has_userpass = env_credentials.get('ad_user') and env_credentials.get('password')

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1791,10 +1791,13 @@ class AzureRMAuth(object):
         return cli_credentials
 
     def _get_env_credentials(self):
-        env_credentials = {attr: os.environ.get(env_var) for attr, env_var in AZURE_CREDENTIAL_ENV_MAPPING.items()}
+        env_credentials = dict()
+        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
+            env_credentials[attribute] = os.environ.get(env_variable, None)
 
-        if env_credentials.get('profile'):
-            return self._get_profile(env_credentials['profile'])
+        if env_credentials['profile']:
+            credentials = self._get_profile(env_credentials['profile'])
+            return credentials
 
         # Must have subscription_id for ARM resources
         if env_credentials.get('subscription_id') is None and not self.is_ad_resource:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1816,29 +1816,28 @@ class AzureRMAuth(object):
         }
         return cli_credentials
 
-    def _read_env_params(self):
-        env = {}
-        for attr, env_var in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            value = os.environ.get(env_var)
-            if value is not None:
-                env[attr] = value
-        return env
+    def _get_env_credentials(self):
+        env_credentials = dict()
+        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
+            env_credentials[attribute] = os.environ.get(env_variable, None)
+
+        if env_credentials['profile']:
+            credentials = self._get_profile(env_credentials['profile'])
+            return credentials
+
+        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
+            return None
+        else:
+            return env_credentials
 
     def _get_credentials(self, auth_source=None, **params):
-        """
-        Resolve authentication credentials as data.
-
-        Resolution order:
-        1. Explicit auth_source (msi / cli / env / credential_file)
-        2. Module params
-        3. ENV variables (fill missing params)
-        4. Credential profile (~/.azure/credentials)
-        5. AZ CLI
-        6. Validation of subscription_id
-        """
+        # Get authentication credentials.
         self.log('Getting credentials')
 
-        # 1. Explicit auth_source
+        arg_credentials = dict()
+        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
+            arg_credentials[attribute] = params.get(attribute, None)
+
         if auth_source == 'msi':
             self.log('Retrieving credentials from MSI')
             return self._get_msi_credentials(subscription_id=params.get('subscription_id'), client_id=params.get('client_id'),
@@ -1854,16 +1853,8 @@ class AzureRMAuth(object):
 
         if auth_source == 'env':
             self.log('Retrieving credentials from environment')
-            credentials = {}
-            for attr in AZURE_CREDENTIAL_ENV_MAPPING:
-                credentials[attr] = None
-            env = self._read_env_params()
-            credentials.update(env)
-
-            if credentials.get("profile"):
-                return self._get_profile(credentials["profile"])
-
-            return credentials
+            env_credentials = self._get_env_credentials()
+            return env_credentials
 
         if auth_source == 'credential_file':
             self.log("Retrieving credentials from credential file")
@@ -1872,35 +1863,36 @@ class AzureRMAuth(object):
             return default_credentials
 
         # auto, precedence: module parameters -> environment variables -> default profile in ~/.azure/credentials -> azure cli
-        # 2. Module Params
-        credentials = {}
-        for attr in AZURE_CREDENTIAL_ENV_MAPPING:
-            credentials[attr] = params.get(attr)
+        # try module params
+        if arg_credentials['profile'] is not None:
+            self.log('Retrieving credentials with profile parameter.')
+            credentials = self._get_profile(arg_credentials['profile'])
+            return credentials
 
-        # 3. Fill missing from ENV
-        env = self._read_env_params()
-        for key, value in env.items():
-            if credentials.get(key) is None:
-                credentials[key] = value
+        if arg_credentials['client_id'] or arg_credentials['ad_user']:
+            self.log('Received credentials from parameters.')
+            return arg_credentials
 
-        # Check if has identity
-        if credentials.get("client_id") or credentials.get("ad_user"):
-            return credentials  # return early to prevent overwrites
+        # try environment
+        env_credentials = self._get_env_credentials()
+        if env_credentials:
+            self.log('Received credentials from env.')
+            return env_credentials
 
-        # 4. Credential profile
-        profile = credentials.get("profile") or "default"
-        profile_credentials = self._get_profile(profile)
-        if profile_credentials:
-            self.log(f"Retrieved credentials from credential file profile '{profile}'")
-            return profile_credentials
+        # try default profile from ~./azure/credentials
+        default_credentials = self._get_profile()
+        if default_credentials:
+            self.log('Retrieved default profile credentials from ~/.azure/credentials.')
+            return default_credentials
 
-        # 5. AZ CLI
         try:
             self.log('Retrieving credentials from AzureCLI profile')
-            return self._get_azure_cli_credentials(subscription_id=None)
+            cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
+            return cli_credentials
         except CLIError as ce:
             self.log('Error getting AzureCLI profile credentials - {0}'.format(ce))
-            return None
+
+        return None
 
     def _get_cloud_from_metadata_endpoint(self, metadata_endpoint):
         _knownClouds = azure_cloud.KNOWN_CLOUDS

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1645,8 +1645,8 @@ class AzureRMAuth(object):
         # OIDC direct token
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
-                self.oidc_token:
-            token = self.oidc_token
+                self.credentials.get('oidc_token') is not None:
+            token = self.credentials['oidc_token']
 
             def _load_assertion():
                 return token
@@ -1660,8 +1660,8 @@ class AzureRMAuth(object):
         # OIDC token file
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
-                self.oidc_token_file_path:
-            token_file = self.oidc_token_file_path
+                self.credentials.get('oidc_token_file_path') is not None:
+            token_file = self.credentials['oidc_token_file_path']
 
             if not os.path.exists(token_file):
                 self.fail(f"The specified OIDC token file does not exist: {token_file}")

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1640,7 +1640,7 @@ class AzureRMAuth(object):
 
             self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
                                                                      client_id=self.credentials['client_id'],
-                                                                     client_assertion=_load_assertion,
+                                                                     func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
                                                                      disable_instance_discovery=self._disable_instance_discovery)
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1558,10 +1558,9 @@ class AzureRMAuth(object):
         self.is_ad_resource = is_ad_resource
 
         # oidcdebug
-        logger = logging.getLogger('azure.identity')
-        logger.setLevel(logging.DEBUG)
-        handler = logging.StreamHandler(stream=sys.stdout)
-        logger.addHandler(handler)
+        self._enable_http_logging = os.environ.get("AZURE_SDK_HTTP_LOGGING", "false").lower() == "true"
+        if self._enable_http_logging:
+            self._azsdk_log_file = self._enable_azsdk_file_logging()
 
         # authenticate
         self.credentials = self._get_credentials(
@@ -1660,7 +1659,7 @@ class AzureRMAuth(object):
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
                                                                      disable_instance_discovery=self._disable_instance_discovery,
-                                                                     logging_enable=True)  # oidcdebug
+                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
         # OIDC token file
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
@@ -1679,7 +1678,7 @@ class AzureRMAuth(object):
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
                                                                      disable_instance_discovery=self._disable_instance_discovery,
-                                                                     logging_enable=True)  # oidcdebug
+                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
 
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('secret') is not None and \
@@ -1932,3 +1931,27 @@ class AzureRMAuth(object):
         #         log_file.write(json.dumps(msg, indent=4, sort_keys=True))
         #     else:
         #         log_file.write(msg + u'\n')
+
+    # oidcdebug
+    def _enable_azsdk_file_logging(self):
+        log_file = os.environ.get("AZURE_SDK_HTTP_LOG_FILE", "/tmp/azsdk.log")
+
+        handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+
+        # Attach handler to the relevant Azure SDK loggers
+        for name in (
+            "azure",
+            "azure.identity",
+            "azure.core.pipeline.policies.http_logging_policy",
+            "azure.core.pipeline.policies._universal",
+        ):
+            logger = logging.getLogger(name)
+            logger.setLevel(logging.DEBUG)
+            # avoid duplicates
+            if not any(isinstance(h, logging.FileHandler) and getattr(h, "baseFilename", None) == handler.baseFilename
+                    for h in logger.handlers):
+                logger.addHandler(handler)
+
+        return log_file

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1635,7 +1635,6 @@ class AzureRMAuth(object):
         else:
             self._adfs_authority_url = self.credentials.get('adfs_authority_url')
 
-        # auth_source if-elif precedence: MSI, Azure CLI, OIDC direct token, OIDC token file, SP secret, SP cert, userpass
         if self.credentials.get('auth_source') == 'msi':
             # MSI Credentials
             self.azure_credential_track2 = self.credentials['credentials']
@@ -1871,9 +1870,6 @@ class AzureRMAuth(object):
 
             if credentials.get("profile"):
                 return self._get_profile(credentials["profile"])
-
-            if credentials.get("client_id") is None or credentials.get("ad_user") is None:
-                self.fail("auth_source=env was specified, but no credentials were found in environment variables")
 
             return credentials
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -272,7 +272,7 @@ try:
     from azure.mgmt.datafactory import DataFactoryManagementClient
     import azure.mgmt.datafactory.models as DataFactoryModel
     from azure.identity._credentials import client_secret, user_password, certificate, managed_identity
-    from azure.identity import AzureCliCredential
+    from azure.identity import AzureCliCredential, ClientAssertionCredential
     from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
     from msgraph_core import GraphClientFactory, NationalClouds
     from msgraph import GraphRequestAdapter, GraphServiceClient
@@ -1629,6 +1629,21 @@ class AzureRMAuth(object):
         elif self.credentials.get('credentials') is not None:
             # AzureCLI credentials
             self.azure_credential_track2 = self.credentials['credentials']
+        elif self.credentials.get('client_id') is not None and \
+                self.credentials.get('tenant') is not None and \
+                os.environ.get('AZURE_FEDERATED_TOKEN_FILE') is not None:
+            token_file = os.environ["AZURE_FEDERATED_TOKEN_FILE"]
+            
+            def _load_assertion():
+                with open(token_file, "r") as f:
+                    return f.read()
+            
+            self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
+                                                                     client_id=self.credentials['client_id'],
+                                                                     client_assertion=_load_assertion,
+                                                                     authority=self._adfs_authority_url,
+                                                                     disable_instance_discovery=self._disable_instance_discovery)
+
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('secret') is not None and \
                 self.credentials.get('tenant') is not None:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1686,12 +1686,9 @@ class AzureRMAuth(object):
                                                                                 authority=self._adfs_authority_url,
                                                                                 disable_instance_discovery=self._disable_instance_discovery)
 
-        # Removed thumbprint as a requirement for cert auth as Azure SDK for Python's CertificateCredential does not require thumbprint to authenticate
-        # Reference: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.certificatecredential?view=azure-python
-        # Reference: https://docs.azure.cn/en-us/entra/identity-platform/certificate-credentials
-        # Create SP with certificate using az cli: `az ad app credential reset --id 00000000-0000-0000-0000-000000000000 --create-cert`
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
+                self.credentials.get('thumbprint') is not None and \
                 self.credentials.get('x509_certificate_path') is not None:
             self.azure_credential_track2 = certificate.CertificateCredential(tenant_id=self.credentials['tenant'],
                                                                              client_id=self.credentials['client_id'],
@@ -1837,21 +1834,10 @@ class AzureRMAuth(object):
             credentials = self._get_profile(env_credentials['profile'])
             return credentials
 
-        # Detech env auth shapes
-        has_sp_secret = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('secret')
-        has_sp_cert = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('x509_certificate_path')
-        has_oidc_direct = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('oidc_token')
-        has_oidc_file = env_credentials.get('client_id') and env_credentials.get('tenant') and env_credentials.get('oidc_token_file_path')
-        has_userpass = env_credentials.get('ad_user') and env_credentials.get('password')
-
-        if not (has_sp_secret or has_sp_cert or has_oidc_direct or has_oidc_file or has_userpass):
-            return None
-
-        # Must have subscription_id for ARM resources
         if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
             return None
-
-        return env_credentials
+        else:
+            return env_credentials
 
     def _get_credentials(self, auth_source=None, **params):
         # Get authentication credentials.
@@ -1892,7 +1878,7 @@ class AzureRMAuth(object):
             credentials = self._get_profile(arg_credentials['profile'])
             return credentials
 
-        if arg_credentials['client_id'] or arg_credentials['ad_user'] or arg_credentials['oidc_token'] or arg_credentials['oidc_token_file_path']:
+        if arg_credentials['client_id'] or arg_credentials['ad_user']:
             self.log('Received credentials from parameters.')
             return arg_credentials
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1896,8 +1896,7 @@ class AzureRMAuth(object):
             credentials = self._get_profile(arg_credentials['profile'])
             return credentials
 
-        if arg_credentials['client_id'] or arg_credentials['ad_user'] or \
-            arg_credentials['oidc_token'] or arg_credentials['oidc_token_file_path']:
+        if arg_credentials['client_id'] or arg_credentials['ad_user'] or arg_credentials['oidc_token'] or arg_credentials['oidc_token_file_path']:
             self.log('Received credentials from parameters.')
             return arg_credentials
 
@@ -1945,7 +1944,7 @@ class AzureRMAuth(object):
         root.setLevel(logging.DEBUG)
 
         # IMPORTANT: ensure logs go to stdout (ADO captures this)
-        handler = logging.StreamHandler(sys.stdout)
+        handler = logging.StreamHandler(sys.stderr)
         handler.setLevel(logging.DEBUG)
 
         formatter = logging.Formatter(

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1825,28 +1825,29 @@ class AzureRMAuth(object):
         }
         return cli_credentials
 
-    def _get_env_credentials(self):
-        env_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            env_credentials[attribute] = os.environ.get(env_variable, None)
-
-        if env_credentials['profile']:
-            credentials = self._get_profile(env_credentials['profile'])
-            return credentials
-
-        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
-            return None
-        else:
-            return env_credentials
+    def _read_env_params(self):
+        env = {}
+        for attr, env_var in AZURE_CREDENTIAL_ENV_MAPPING.items():
+            value = os.environ.get(env_var)
+            if value is not None:
+                env[attr] = value
+        return env
 
     def _get_credentials(self, auth_source=None, **params):
-        # Get authentication credentials.
+        """
+        Resolve authentication credentials as data.
+
+        Resolution order:
+        1. Explicit auth_source (msi / cli / env / credential_file)
+        2. Module params
+        3. ENV variables (fill missing params)
+        4. Credential profile (~/.azure/credentials)
+        5. AZ CLI
+        6. Validation of subscription_id
+        """
         self.log('Getting credentials')
 
-        arg_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            arg_credentials[attribute] = params.get(attribute, None)
-
+        # 1. Explicit auth_source
         if auth_source == 'msi':
             self.log('Retrieving credentials from MSI')
             return self._get_msi_credentials(subscription_id=params.get('subscription_id'), client_id=params.get('client_id'),
@@ -1862,8 +1863,19 @@ class AzureRMAuth(object):
 
         if auth_source == 'env':
             self.log('Retrieving credentials from environment')
-            env_credentials = self._get_env_credentials()
-            return env_credentials
+            credentials = {}
+            for attr in AZURE_CREDENTIAL_ENV_MAPPING:
+                credentials[attr] = None
+            env = self._read_env_params()
+            credentials.update(env)
+
+            if credentials.get("profile"):
+                return self._get_profile(credentials["profile"])
+
+            if credentials.get("client_id") is None or credentials.get("ad_user") is None:
+                self.fail("auth_source=env was specified, but no credentials were found in environment variables")
+
+            return credentials
 
         if auth_source == 'credential_file':
             self.log("Retrieving credentials from credential file")
@@ -1872,36 +1884,35 @@ class AzureRMAuth(object):
             return default_credentials
 
         # auto, precedence: module parameters -> environment variables -> default profile in ~/.azure/credentials -> azure cli
-        # try module params
-        if arg_credentials['profile'] is not None:
-            self.log('Retrieving credentials with profile parameter.')
-            credentials = self._get_profile(arg_credentials['profile'])
-            return credentials
+        # 2. Module Params
+        credentials = {}
+        for attr in AZURE_CREDENTIAL_ENV_MAPPING:
+            credentials[attr] = params.get(attr)
 
-        if arg_credentials['client_id'] or arg_credentials['ad_user']:
-            self.log('Received credentials from parameters.')
-            return arg_credentials
+        # 3. Fill missing from ENV
+        env = self._read_env_params()
+        for key, value in env.items():
+            if credentials.get(key) is None:
+                credentials[key] = value
 
-        # try environment
-        env_credentials = self._get_env_credentials()
-        if env_credentials:
-            self.log('Received credentials from env.')
-            return env_credentials
+        # Check if has identity
+        if credentials.get("client_id") or credentials.get("ad_user"):
+            return credentials  # return early to prevent overwrites
 
-        # try default profile from ~./azure/credentials
-        default_credentials = self._get_profile()
-        if default_credentials:
-            self.log('Retrieved default profile credentials from ~/.azure/credentials.')
-            return default_credentials
+        # 4. Credential profile
+        profile = credentials.get("profile") or "default"
+        profile_credentials = self._get_profile(profile)
+        if profile_credentials:
+            self.log(f"Retrieved credentials from credential file profile '{profile}'")
+            return profile_credentials
 
+        # 5. AZ CLI
         try:
             self.log('Retrieving credentials from AzureCLI profile')
-            cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
-            return cli_credentials
+            return self._get_azure_cli_credentials(subscription_id=None)
         except CLIError as ce:
             self.log('Error getting AzureCLI profile credentials - {0}'.format(ce))
-
-        return None
+            return None
 
     def _get_cloud_from_metadata_endpoint(self, metadata_endpoint):
         _knownClouds = azure_cloud.KNOWN_CLOUDS

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -292,7 +292,6 @@ from hashlib import sha256
 from hmac import HMAC
 from time import time
 import subprocess
-import logging  # oidcdebug
 
 try:
     from urllib import (urlencode, quote_plus)
@@ -1556,11 +1555,6 @@ class AzureRMAuth(object):
             self._fail_impl = self._default_fail_impl
         self.is_ad_resource = is_ad_resource
 
-        # oidcdebug
-        self._enable_http_logging = os.environ.get("AZURE_SDK_HTTP_LOGGING", "false").lower() == "true"
-        if self._enable_http_logging:
-            self._azsdk_log_file = self._enable_azsdk_file_logging()
-
         # authenticate
         self.credentials = self._get_credentials(
             auth_source=auth_source,
@@ -1654,8 +1648,7 @@ class AzureRMAuth(object):
                                                                      client_id=self.credentials['client_id'],
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
-                                                                     disable_instance_discovery=self._disable_instance_discovery,
-                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
+                                                                     disable_instance_discovery=self._disable_instance_discovery)
         # OIDC token file
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
@@ -1673,8 +1666,7 @@ class AzureRMAuth(object):
                                                                      client_id=self.credentials['client_id'],
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
-                                                                     disable_instance_discovery=self._disable_instance_discovery,
-                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
+                                                                     disable_instance_discovery=self._disable_instance_discovery)
 
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('secret') is not None and \
@@ -1923,24 +1915,3 @@ class AzureRMAuth(object):
         #         log_file.write(json.dumps(msg, indent=4, sort_keys=True))
         #     else:
         #         log_file.write(msg + u'\n')
-
-    # oidcdebug
-    def _enable_azsdk_file_logging(self):
-        log_file = os.environ.get("AZURE_SDK_HTTP_LOG_FILE", "/tmp/azsdk.log")
-
-        handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
-        handler.setLevel(logging.DEBUG)
-        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
-
-        for name in (
-            "azure",
-            "azure.identity",
-            "azure.core.pipeline.policies.http_logging_policy",
-            "azure.core.pipeline.policies._universal",
-        ):
-            logger = logging.getLogger(name)
-            logger.setLevel(logging.DEBUG)
-            if not any(isinstance(h, logging.FileHandler) and getattr(h, "baseFilename", None) == handler.baseFilename for h in logger.handlers):
-                logger.addHandler(handler)
-
-        return log_file

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1940,23 +1940,29 @@ class AzureRMAuth(object):
         import logging
         import sys
 
-        root = logging.getLogger()
-        root.setLevel(logging.DEBUG)
-
-        # IMPORTANT: ensure logs go to stdout (ADO captures this)
         handler = logging.StreamHandler(sys.stderr)
         handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
 
-        formatter = logging.Formatter(
-            "%(asctime)s %(levelname)s %(name)s %(message)s"
-        )
-        handler.setFormatter(formatter)
+        handler._azcollection_oidc_http_logging = True
 
-        # Avoid duplicate handlers
-        if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
-            root.addHandler(handler)
+        azure_logger_names = [
+            "azure",
+            "azure.identity",
+            "azure.core",
+            "azure.core.pipeline",
+            "azure.core.pipeline.policies",
+            "azure.core.pipeline.policies.http_logging_policy",
+            "azure.core.pipeline.policies._universal",
+        ]
 
-        logging.getLogger("azure.identity").setLevel(logging.DEBUG)
-        logging.getLogger(
-            "azure.core.pipeline.policies.http_logging_policy"
-        ).setLevel(logging.DEBUG)
+        for name in azure_logger_names:
+            logger = logging.getLogger(name)
+            logger.setLevel(logging.DEBUG)
+
+            logger.propagate = True
+
+            if not any(getattr(h, "_azcollection_oidc_http_logging", False) for h in logger.handlers):
+                logger.addHandler(handler)
+
+        logging.getLogger("azure").setLevel(logging.DEBUG)

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -293,7 +293,6 @@ from hmac import HMAC
 from time import time
 import subprocess
 import logging  # oidcdebug
-import sys  # oidcdebug
 
 try:
     from urllib import (urlencode, quote_plus)
@@ -1940,7 +1939,6 @@ class AzureRMAuth(object):
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
 
-        # Attach handler to the relevant Azure SDK loggers
         for name in (
             "azure",
             "azure.identity",
@@ -1949,9 +1947,7 @@ class AzureRMAuth(object):
         ):
             logger = logging.getLogger(name)
             logger.setLevel(logging.DEBUG)
-            # avoid duplicates
-            if not any(isinstance(h, logging.FileHandler) and getattr(h, "baseFilename", None) == handler.baseFilename
-                    for h in logger.handlers):
+            if not any(isinstance(h, logging.FileHandler) and getattr(h, "baseFilename", None) == handler.baseFilename for h in logger.handlers):
                 logger.addHandler(handler)
 
         return log_file

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1538,7 +1538,9 @@ class AzureRMModuleBase(object):
 class AzureRMAuthException(Exception):
     pass
 
+
 AZURE_SDK_HTTP_LOGGING = True  # oidcdebug
+
 
 class AzureRMAuth(object):
     _cloud_environment = None
@@ -1651,8 +1653,10 @@ class AzureRMAuth(object):
                 self.credentials.get('tenant') is not None and \
                 self.oidc_token:
             token = self.oidc_token
+
             def _load_assertion():
                 return token
+
             self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
                                                                      client_id=self.credentials['client_id'],
                                                                      func=_load_assertion,
@@ -1664,11 +1668,14 @@ class AzureRMAuth(object):
                 self.credentials.get('tenant') is not None and \
                 self.oidc_token_file_path:
             token_file = self.oidc_token_file_path
+
             if not os.path.exists(token_file):
                 self.fail(f"The specified OIDC token file does not exist: {token_file}")
+
             def _load_assertion():
                 with open(token_file) as f:
                     return f.read()
+
             self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
                                                                      client_id=self.credentials['client_id'],
                                                                      func=_load_assertion,
@@ -1930,6 +1937,25 @@ class AzureRMAuth(object):
     # oidcdebug
     def _enable_azure_sdk_http_logging(self):
         import logging
-        logging.basicConfig(level=logging.DEBUG)
-        logging.getLogger('azure.identity').setLevel(logging.DEBUG)
-        logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.DEBUG)
+        import sys
+
+        root = logging.getLogger()
+        root.setLevel(logging.DEBUG)
+
+        # IMPORTANT: ensure logs go to stdout (ADO captures this)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.DEBUG)
+
+        formatter = logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s %(message)s"
+        )
+        handler.setFormatter(formatter)
+
+        # Avoid duplicate handlers
+        if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+            root.addHandler(handler)
+
+        logging.getLogger("azure.identity").setLevel(logging.DEBUG)
+        logging.getLogger(
+            "azure.core.pipeline.policies.http_logging_policy"
+        ).setLevel(logging.DEBUG)

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -50,6 +50,8 @@ AZURE_COMMON_ARGS = dict(
     x509_certificate_path=dict(type='path', no_log=True),
     thumbprint=dict(type='str', no_log=True),
     disable_instance_discovery=dict(type='bool', default=False),
+    oidc_token=dict(type='str', no_log=True),  # direct JWT assertion
+    oidc_token_file_path=dict(type='path', no_log=True)  # path to JWT assertion file
 )
 
 AZURE_CREDENTIAL_ENV_MAPPING = dict(
@@ -65,7 +67,9 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
     adfs_authority_url='AZURE_ADFS_AUTHORITY_URL',
     x509_certificate_path='AZURE_X509_CERTIFICATE_PATH',
     thumbprint='AZURE_THUMBPRINT',
-    disable_instance_discovery='AZURE_DISABLE_INSTANCE_DISCOVERY'
+    disable_instance_discovery='AZURE_DISABLE_INSTANCE_DISCOVERY',
+    oidc_token='AZURE_FEDERATED_TOKEN',
+    oidc_token_file_path='AZURE_FEDERATED_TOKEN_FILE'
 )
 
 
@@ -1534,6 +1538,7 @@ class AzureRMModuleBase(object):
 class AzureRMAuthException(Exception):
     pass
 
+AZURE_SDK_HTTP_LOGGING = True  # oidcdebug
 
 class AzureRMAuth(object):
     _cloud_environment = None
@@ -1550,6 +1555,13 @@ class AzureRMAuth(object):
         else:
             self._fail_impl = self._default_fail_impl
         self.is_ad_resource = is_ad_resource
+
+        # oidcdebug
+        self._enable_http_logging = (
+            os.environ.get("AZURE_SDK_HTTP_LOGGING", "False").lower() == "true"
+        )
+        if self._enable_http_logging:
+            self._enable_azure_sdk_http_logging()
 
         # authenticate
         self.credentials = self._get_credentials(
@@ -1623,26 +1635,46 @@ class AzureRMAuth(object):
         else:
             self._adfs_authority_url = self.credentials.get('adfs_authority_url')
 
+        # OIDC PATH
+        self.oidc_token = self.credentials.get('oidc_token') or self._get_env('oidc_token')
+        self.oidc_token_file_path = self.credentials.get('oidc_token_file_path') or self._get_env('oidc_token_file_path')
+
+        # auth_source if-elif precedence: MSI, Azure CLI, OIDC direct token, OIDC token file, SP secret, SP cert, userpass
         if self.credentials.get('auth_source') == 'msi':
             # MSI Credentials
             self.azure_credential_track2 = self.credentials['credentials']
         elif self.credentials.get('credentials') is not None:
             # AzureCLI credentials
             self.azure_credential_track2 = self.credentials['credentials']
+        # OIDC direct token
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('tenant') is not None and \
-                os.environ.get('AZURE_FEDERATED_TOKEN_FILE') is not None:
-            token_file = os.environ["AZURE_FEDERATED_TOKEN_FILE"]
-
+                self.oidc_token:
+            token = self.oidc_token
             def _load_assertion():
-                with open(token_file, "r") as f:
-                    return f.read()
-
+                return token
             self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
                                                                      client_id=self.credentials['client_id'],
                                                                      func=_load_assertion,
                                                                      authority=self._adfs_authority_url,
-                                                                     disable_instance_discovery=self._disable_instance_discovery)
+                                                                     disable_instance_discovery=self._disable_instance_discovery,
+                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
+        # OIDC token file
+        elif self.credentials.get('client_id') is not None and \
+                self.credentials.get('tenant') is not None and \
+                self.oidc_token_file_path:
+            token_file = self.oidc_token_file_path
+            if not os.path.exists(token_file):
+                self.fail(f"The specified OIDC token file does not exist: {token_file}")
+            def _load_assertion():
+                with open(token_file) as f:
+                    return f.read()
+            self.azure_credential_track2 = ClientAssertionCredential(tenant_id=self.credentials['tenant'],
+                                                                     client_id=self.credentials['client_id'],
+                                                                     func=_load_assertion,
+                                                                     authority=self._adfs_authority_url,
+                                                                     disable_instance_discovery=self._disable_instance_discovery,
+                                                                     logging_enable=self._enable_http_logging)  # oidcdebug
 
         elif self.credentials.get('client_id') is not None and \
                 self.credentials.get('secret') is not None and \
@@ -1688,10 +1720,12 @@ class AzureRMAuth(object):
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. \n\n"
                       "Supported authentication methods: \n"
-                      "- Workload identity (OIDC): client_id, tenant, and AZURE_FEDERATED_TOKEN_FILE\n"
+                      "- Workload identity (OIDC) token: client_id, tenant, and oidc_token\n"
+                      "- Workload identity (OIDC) token file: client_id, tenant, and oidc_token_file_path\n"
                       "- Service principal with client secret: client_id, tenant, secret\n"
                       "- Service principal with certificate: client_id, tenant, thumbprint, x509_certificate_path\n"
-                      "- Username/password authentication: ad_user, password\n")
+                      "- Username/password authentication: ad_user, password\n"
+                      "- Azure CLI authentication: run `az_login`.\n")
 
     def fail(self, msg, exception=None, **kwargs):
         self._fail_impl(msg)
@@ -1892,3 +1926,10 @@ class AzureRMAuth(object):
         #         log_file.write(json.dumps(msg, indent=4, sort_keys=True))
         #     else:
         #         log_file.write(msg + u'\n')
+
+    # oidcdebug
+    def _enable_azure_sdk_http_logging(self):
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+        logging.getLogger('azure.identity').setLevel(logging.DEBUG)
+        logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.DEBUG)


### PR DESCRIPTION
##### SUMMARY
Fix #1568. This PR adds support for Azure federated credentials / OIDC (Workload Identity Federation) authentication in `azure_rm_common` via both module parameters and environment variables. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py

##### ADDITIONAL INFORMATION
1. OIDC/Workload Identity Federation
    - Introduced `oidc_token` (direct JWT assertion) and `oidc_token_file_path` (path to JWT assertion file)
    - Added corresponding env var mappings
      - `AZURE_FEDERATED_TOKEN` -> `oidc_token`
      - `AZURE_FEDERATED_TOKEN_FILE` -> `oidc_token_file_path`
    - Added OIDC credential handling using [`ClientAssertionCredential`](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.clientassertioncredential?view=azure-python)
    - Updating `auth_source=auto` behavior by extending env/param shape detection to include OIDC, while preserving existing precedence
2. Testing-related (private):
    - [GitHub Actions](https://github.com/[zunyangc/azcollection-oidc-auth-test](https://github.com/zunyangc/azcollection-oidc-auth-test))
    - [ADO pipelines](https://dev.azure.com/zy-ansible-test/2200-oidc/_build/results?buildId=34&view=results)

----
References:
- https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
- https://docs.azure.cn/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp

Future work:
- OIDC request token + OIDC request URL
