### PR TITLE
Credential Resolution Refactor

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -99,7 +99,9 @@ options:
         description:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
-            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
+            - By default (C(auth_source=auto)), credentials are resolved by first reading module parameters,
+              then filling missing values from environment variables, and finally falling back to C(~/.azure/credentials)
+              or the Azure CLI if no identity is found.
             - When set to C(env), the credentials will be read from the environment variables.
             - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable

--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -66,8 +66,11 @@ options:
         description:
             - Controls the source of the credentials to use for authentication.
             - Can also be set via the C(ANSIBLE_AZURE_AUTH_SOURCE) environment variable.
-            - When set to C(auto) (the default) the precedence is module parameters -> C(env) -> C(credential_file) -> C(cli).
-            - When set to C(env), the credentials will be read from the environment variables
+            - By default (C(auth_source=auto)), credentials are resolved by first reading module parameters,
+              then filling missing values from environment variables, and finally falling back to C(~/.azure/credentials)
+              or the Azure CLI if no identity is found.
+            - When set to C(env), the credentials will be read from the environment variables.
+            - When set to C(credential_file), it will read the profile from C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the Azure CLI profile. C(subscription_id) or the environment variable
               C(AZURE_SUBSCRIPTION_ID) can be used to identify the subscription ID if more than one is present otherwise the default
               az cli subscription is used.
@@ -79,9 +82,10 @@ options:
         default: auto
         choices:
         - auto
-        - cli
-        - env
         - msi
+        - env
+        - credential_file
+        - cli
         env:
           - name: ANSIBLE_AZURE_AUTH_SOURCE
 requirements:

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1816,28 +1816,29 @@ class AzureRMAuth(object):
         }
         return cli_credentials
 
-    def _get_env_credentials(self):
-        env_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            env_credentials[attribute] = os.environ.get(env_variable, None)
-
-        if env_credentials['profile']:
-            credentials = self._get_profile(env_credentials['profile'])
-            return credentials
-
-        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
-            return None
-        else:
-            return env_credentials
+    def _read_env_params(self):
+        env = {}
+        for attr, env_var in AZURE_CREDENTIAL_ENV_MAPPING.items():
+            value = os.environ.get(env_var)
+            if value is not None:
+                env[attr] = value
+        return env
 
     def _get_credentials(self, auth_source=None, **params):
-        # Get authentication credentials.
+        """
+        Resolve authentication credentials as data.
+
+        Resolution order:
+        1. Explicit auth_source (msi / cli / env / credential_file)
+        2. Module params
+        3. ENV variables (fill missing params)
+        4. Credential profile (~/.azure/credentials)
+        5. AZ CLI
+        6. Validation of subscription_id
+        """
         self.log('Getting credentials')
 
-        arg_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            arg_credentials[attribute] = params.get(attribute, None)
-
+        # 1. Explicit auth_source
         if auth_source == 'msi':
             self.log('Retrieving credentials from MSI')
             return self._get_msi_credentials(subscription_id=params.get('subscription_id'), client_id=params.get('client_id'),
@@ -1853,8 +1854,16 @@ class AzureRMAuth(object):
 
         if auth_source == 'env':
             self.log('Retrieving credentials from environment')
-            env_credentials = self._get_env_credentials()
-            return env_credentials
+            credentials = {}
+            for attr in AZURE_CREDENTIAL_ENV_MAPPING:
+                credentials[attr] = None
+            env = self._read_env_params()
+            credentials.update(env)
+
+            if credentials.get("profile"):
+                return self._get_profile(credentials["profile"])
+
+            return credentials
 
         if auth_source == 'credential_file':
             self.log("Retrieving credentials from credential file")
@@ -1863,36 +1872,35 @@ class AzureRMAuth(object):
             return default_credentials
 
         # auto, precedence: module parameters -> environment variables -> default profile in ~/.azure/credentials -> azure cli
-        # try module params
-        if arg_credentials['profile'] is not None:
-            self.log('Retrieving credentials with profile parameter.')
-            credentials = self._get_profile(arg_credentials['profile'])
-            return credentials
+        # 2. Module Params
+        credentials = {}
+        for attr in AZURE_CREDENTIAL_ENV_MAPPING:
+            credentials[attr] = params.get(attr)
 
-        if arg_credentials['client_id'] or arg_credentials['ad_user']:
-            self.log('Received credentials from parameters.')
-            return arg_credentials
+        # 3. Fill missing from ENV
+        env = self._read_env_params()
+        for key, value in env.items():
+            if credentials.get(key) is None:
+                credentials[key] = value
 
-        # try environment
-        env_credentials = self._get_env_credentials()
-        if env_credentials:
-            self.log('Received credentials from env.')
-            return env_credentials
+        # Check if has identity
+        if credentials.get("client_id") or credentials.get("ad_user"):
+            return credentials  # return early to prevent overwrites
 
-        # try default profile from ~./azure/credentials
-        default_credentials = self._get_profile()
-        if default_credentials:
-            self.log('Retrieved default profile credentials from ~/.azure/credentials.')
-            return default_credentials
+        # 4. Credential profile
+        profile = credentials.get("profile") or "default"
+        profile_credentials = self._get_profile(profile)
+        if profile_credentials:
+            self.log(f"Retrieved credentials from credential file profile '{profile}'")
+            return profile_credentials
 
+        # 5. AZ CLI
         try:
             self.log('Retrieving credentials from AzureCLI profile')
-            cli_credentials = self._get_azure_cli_credentials(subscription_id=params.get('subscription_id'))
-            return cli_credentials
+            return self._get_azure_cli_credentials(subscription_id=None)
         except CLIError as ce:
             self.log('Error getting AzureCLI profile credentials - {0}'.format(ce))
-
-        return None
+            return None
 
     def _get_cloud_from_metadata_endpoint(self, metadata_endpoint):
         _knownClouds = azure_cloud.KNOWN_CLOUDS

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1834,7 +1834,9 @@ class AzureRMAuth(object):
         3. ENV variables (fill missing params)
         4. Credential profile (~/.azure/credentials)
         5. AZ CLI
-        6. Validation of subscription_id
+
+        Note: Validation of subscription_id is performed in AzureRMAuth.__init__,
+        not in this method.
         """
         self.log('Getting credentials')
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1899,7 +1899,7 @@ class AzureRMAuth(object):
         # 5. AZ CLI
         try:
             self.log('Retrieving credentials from AzureCLI profile')
-            return self._get_azure_cli_credentials(subscription_id=None)
+            return self._get_azure_cli_credentials(subscription_id=credentials.get('subscription_id'))
         except CLIError as ce:
             self.log('Error getting AzureCLI profile credentials - {0}'.format(ce))
             return None


### PR DESCRIPTION
##### SUMMARY
Refactored credential resolution logic to follow a strict precedence model:
> 
> module parameters > environment variables > credential file (~/.azure/credentials) > Azure CLI.
>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py

##### ADDITIONAL INFORMATION
- Environment variables are now treated as a fallback to module parameters and never override higher‑precedence inputs.
- Credential files are only used when no identity is provided via parameters or environment, preserving existing behavior while avoiding silent overrides.
- Explicit `auth_source` values (`env` / `credential_file` / `cli` / `msi`) are now strictly enforced and do not fall back to other sources.