### PR TITLE
VPN Gateway SKU consolidation and migration

### DIFF
--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -104,7 +104,7 @@ options:
     sku:
         description:
             - The reference of the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
-            - Default is now C(VpnGw1AZ) instead of C(VpnGw1). 
+            - Default is now C(VpnGw1AZ) instead of C(VpnGw1).
             - VpnGw1-5 (Non-AZ SKUs) will be retired on Sep 30, 2026. Gateways will be automatically migrated to AZ SKUs.
             - More information on the retirement https://azure.microsoft.com/updates/v2/vpngw1-5-non-az-skus-will-be-retired-on-30-september-2026.
         default: VpnGw1AZ

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -104,7 +104,10 @@ options:
     sku:
         description:
             - The reference of the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
-        default: VpnGw1
+            - Default is now C(VpnGw1AZ) instead of C(VpnGw1). 
+            - VpnGw1-5 (Non-AZ SKUs) will be retired on Sep 30, 2026. Gateways will be automatically migrated to AZ SKUs.
+            - More information on the retirement https://azure.microsoft.com/updates/v2/vpngw1-5-non-az-skus-will-be-retired-on-30-september-2026.
+        default: VpnGw1AZ
         type: str
         choices:
             - VpnGw1
@@ -233,8 +236,8 @@ ip_configuration_spec = dict(
 
 
 sku_spec = dict(
-    name=dict(type='str', default='VpnGw1'),
-    tier=dict(type='str', default='VpnGw1')
+    name=dict(type='str', default='VpnGw1AZ'),
+    tier=dict(type='str', default='VpnGw1AZ')
 )
 
 
@@ -282,7 +285,7 @@ class AzureRMVirtualNetworkGateway(AzureRMModuleBase):
             vpn_type=dict(type='str', default='route_based', choices=['route_based', 'policy_based']),
             vpn_gateway_generation=dict(type='str', default='Generation1', choices=['None', 'Generation1', 'Generation2']),
             enable_bgp=dict(type='bool', default=False),
-            sku=dict(type='str', default='VpnGw1', choices=[
+            sku=dict(type='str', default='VpnGw1AZ', choices=[
                 'VpnGw1', 'VpnGw2', 'VpnGw3', 'Standard', 'Basic', 'HighPerformance',
                 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ', 'VpnGw4AZ', 'VpnGw5AZ',
                 'ErGw1AZ', 'ErGw2AZ', 'ErGw3AZ', 'ErGwScale'

--- a/plugins/modules/azure_rm_virtualnetworkgateway.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway.py
@@ -104,9 +104,6 @@ options:
     sku:
         description:
             - The reference of the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
-            - Default is now C(VpnGw1AZ) instead of C(VpnGw1).
-            - VpnGw1-5 (Non-AZ SKUs) will be retired on Sep 30, 2026. Gateways will be automatically migrated to AZ SKUs.
-            - More information on the retirement https://azure.microsoft.com/updates/v2/vpngw1-5-non-az-skus-will-be-retired-on-30-september-2026.
         default: VpnGw1AZ
         type: str
         choices:

--- a/plugins/modules/azure_rm_virtualnetworkgateway_info.py
+++ b/plugins/modules/azure_rm_virtualnetworkgateway_info.py
@@ -142,7 +142,7 @@ virtual_network_gatways:
                 - The reference to the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
             type: dict
             returned: always
-            sample: {'name':'VpnGw1', 'tier':'VpnGw1'}
+            sample: {'name':'VpnGw1AZ', 'tier':'VpnGw1AZ'}
         tags:
             description:
                 - Resource tags.

--- a/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
@@ -77,6 +77,9 @@
             name: "{{ pubipname }}{{ item }}"
             sku: Standard
             allocation_method: Static
+            zones:
+              - "1"
+              - "2"
           with_items:
             - '01'
             - '02'

--- a/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
@@ -36,7 +36,7 @@
       azure.azcollection.azure_rm_virtualnetworkgateway:
         resource_group: "{{ resource_group }}-vnetgw"
         name: "{{ vngname }}02"
-        sku: VpnGw2
+        sku: VpnGw2AZ
         vpn_gateway_generation: Generation2
         ip_configurations:
           - name: testipconfig
@@ -95,10 +95,10 @@
             tags:
               common: "xyz"
           loop:
-            - sku: VpnGw1
+            - sku: VpnGw1AZ
               vpn_gateway_generation: Generation1
               number: '01'
-            - sku: VpnGw2
+            - sku: VpnGw2AZ
               vpn_gateway_generation: Generation2
               number: '02'
           register: network_gateway_output
@@ -136,7 +136,7 @@
                 private_ip_allocation_method: Dynamic
                 public_ip_address_name: "{{ pubipname }}01"
             virtual_network: "{{ vnetname }}01"
-            sku: VpnGw1
+            sku: VpnGw1AZ
             vpn_gateway_generation: Generation1
             tags:
               common: "xyz"

--- a/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgateway/tasks/main.yml
@@ -224,7 +224,6 @@
     - name: Delete public IP address
       azure.azcollection.azure_rm_publicipaddress:
         resource_group: "{{ resource_group }}-vnetgw"
-        allocation_method: Dynamic
         name: "{{ pubipname }}{{ item }}"
         state: absent
       with_items:

--- a/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/tasks/main.yml
@@ -36,7 +36,7 @@
       azure.azcollection.azure_rm_virtualnetworkgateway:
         resource_group: "{{ resource_group }}-vnetgwnatrule"
         name: "{{ vngname }}"
-        sku: VpnGw2
+        sku: VpnGw2AZ
         vpn_gateway_generation: Generation2
         ip_configurations:
           - name: testipconfig


### PR DESCRIPTION
##### SUMMARY
This PR include changing the SKU default of `azure_rm_virtualnetworkgateway.py` to `VpnGw1AZ` instead of `VpnGw1` corresponds to the[ retirement notice](https://review.learn.microsoft.com/en-us/azure/vpn-gateway/gateway-sku-consolidation?branch=main&branchFallbackFrom=pr-en-us-286880) on 09/26/2024

##### ISSUE TYPE
- Migration Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualnetworkgateway.py
plugins/modules/azure_rm_virtualnetworkgateway_info.py

##### ADDITIONAL INFORMATION
- Default is now `VpnGw1AZ` instead of `VpnGw1`.
- VpnGw1-5 (Non-AZ SKUs) will be retired on Sep 30, 2026. Gateways will be automatically migrated to AZ SKUs.
- More information on the [retirement](https://azure.microsoft.com/updates/v2/vpngw1-5-non-az-skus-will-be-retired-on-30-september-2026).