### PR TITLE
feat: add support for feedback queue

### DIFF
--- a/extensions/eda/plugins/event_source/azure_event_hub.py
+++ b/extensions/eda/plugins/event_source/azure_event_hub.py
@@ -9,8 +9,8 @@ import json
 import logging
 from typing import Any
 
-from azure.eventhub.aio import (EventHubConsumerClient, PartitionContext)
 from azure.eventhub import EventData
+from azure.eventhub.aio import EventHubConsumerClient, PartitionContext
 from azure.identity.aio import ClientSecretCredential
 
 DOCUMENTATION = r"""
@@ -56,6 +56,30 @@ options:
       - The name of the consumer group
     type: str
     default: "$Default"
+  feedback:
+    type: bool
+    default: false
+    description:
+      - Should the source plugin wait for feedback before
+        processing the next event from the Azure Event Hub
+        This flag allows ansible rulebook to pass in an asyncio
+        queue which is passed in the args['eda_feedback_queue']
+        The source plugin should wait for the response to come
+        back on this queue before it picks the next event from
+        Azure Event Hub.
+  feedback_timeout:
+    type: int
+    default: 120
+    description:
+      - Timeout in seconds to wait for feedback from the rule engine
+        before raising an exception. Only applies when feedback is enabled.
+  eda_feedback_queue:
+    description:
+      - Provided automatically by ansible-rulebook when the feedback parameter
+        is enabled, this parameter utilizes an asyncio.Queue. It allows the
+        system to wait for confirmation that an event has been safely persisted
+        in the database before removing it from the event bus. Users do not need
+        to provide a value for this manually.
 """
 
 EXAMPLES = r"""
@@ -79,6 +103,8 @@ REQUIRED_ARGS = [
     "azure_event_hub_name",
 ]
 
+DEFAULT_FEEDBACK_TIMEOUT = 120
+
 
 class AzureHubConsumer:
     """Azure Hub Consumer."""
@@ -95,6 +121,17 @@ class AzureHubConsumer:
 
         self.consumer_group = args.get("azure_consumer_group", "$Default")
         self.starting_position = int(args.get("azure_starting_position", "-1"))
+        self.feedback_timeout = int(args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT))
+        self.feedback = args.get("feedback", False)
+        self.eda_feedback_queue = args.get("eda_feedback_queue")
+
+        if self.feedback and self.eda_feedback_queue is None:
+            msg = (
+                "feedback: true was set but no feedback queue was provided. "
+                "This requires a compatible version of ansible-rulebook that "
+                "supports the feedback mechanism."
+            )
+            raise ValueError(msg)
 
         self.credential = ClientSecretCredential(
             tenant_id=tenant_id,
@@ -102,11 +139,21 @@ class AzureHubConsumer:
             client_secret=client_secret,
         )
 
-    async def on_event(self, partition_context: PartitionContext, event: EventData) -> None:
+    async def on_event(
+        self, partition_context: PartitionContext, event: EventData,
+    ) -> None:
         """Receiving event data."""
         if event:
-            await partition_context.update_checkpoint(event)
             meta = {}
+            msg_id = (
+                event.message_id
+                or event.correlation_id
+                or f"{partition_context.partition_id}:{event.sequence_number}"
+            )
+
+            meta["event"] = {"uuid": msg_id}
+            if event.enqueued_time:
+                meta["event"]["produced_at"] = event.enqueued_time.isoformat()
             # Process message body
             try:
                 value = event.body_as_str()
@@ -128,6 +175,19 @@ class AzureHubConsumer:
             # Add data to the event and put it into the queue
             if data:
                 await self.queue.put({"body": data, "meta": meta})
+
+            if self.feedback and self.eda_feedback_queue:
+                try:
+                    await asyncio.wait_for(
+                        self.eda_feedback_queue.get(),
+                        timeout=self.feedback_timeout,
+                    )
+                    await partition_context.update_checkpoint(event)
+                except asyncio.TimeoutError:
+                    logger.exception("Timed out waiting for feedback")
+                    raise
+            else:
+                await partition_context.update_checkpoint(event)
 
         await asyncio.sleep(0)
 

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -7,6 +7,7 @@ events into Ansible EDA rulebooks.
 import asyncio
 import contextlib
 import json
+import logging
 from typing import Any
 
 from azure.servicebus.aio import ServiceBusClient
@@ -34,6 +35,30 @@ options:
       - Whether to turn on logging.
     type: bool
     default: true
+  feedback:
+    type: bool
+    default: false
+    description:
+      - Should the source plugin wait for feedback before
+        processing the next event from the Azure Event Hub
+        This flag allows ansible rulebook to pass in an asyncio
+        queue which is passed in the args['eda_feedback_queue']
+        The source plugin should wait for the response to come
+        back on this queue before it picks the next event from
+        Azure Event Hub.
+  feedback_timeout:
+    type: int
+    default: 120
+    description:
+      - Timeout in seconds to wait for feedback from the rule engine
+        before raising an exception. Only applies when feedback is enabled.
+  eda_feedback_queue:
+    description:
+      - Provided automatically by ansible-rulebook when the feedback parameter
+        is enabled, this parameter utilizes an asyncio.Queue. It allows the
+        system to wait for confirmation that an event has been safely persisted
+        in the database before removing it from the event bus. Users do not need
+        to provide a value for this manually.
 """
 
 EXAMPLES = r"""
@@ -42,12 +67,27 @@ EXAMPLES = r"""
     queue_name: "{{queue_name}}"
 """
 
+DEFAULT_FEEDBACK_TIMEOUT = 120
+
+logger = logging.getLogger()
+
 
 async def receive_events(
     queue: asyncio.Queue[Any],
     args: dict[str, Any],  # pylint: disable=W0621
 ) -> None:
     """Receive events from service bus asynchronously."""
+    feedback_enabled = args.get("feedback", False)
+    eda_feedback_queue = args.get("eda_feedback_queue")
+    feedback_timeout = int(args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT))
+
+    if feedback_enabled and eda_feedback_queue is None:
+        msg = (
+            "feedback: true was set but no feedback queue was provided. "
+            "This requires a compatible version of ansible-rulebook that "
+            "supports the feedback mechanism."
+        )
+        raise ValueError(msg)
     servicebus_client = ServiceBusClient.from_connection_string(
         conn_str=args["conn_str"],
         logging_enable=bool(args.get("logging_enable", True)),
@@ -57,13 +97,29 @@ async def receive_events(
         receiver = servicebus_client.get_queue_receiver(queue_name=args["queue_name"])
         async with receiver:
             async for msg in receiver:
-                meta = {"message_id": msg.message_id}
+                meta = {"message_id": msg.message_id, "event": {}}
+                meta["event"]["uuid"] = msg.message_id
+                if msg.enqueued_time_utc:
+                    meta["event"]["produced_at"] = msg.enqueued_time_utc.isoformat()
+
                 body = str(msg)
                 with contextlib.suppress(json.JSONDecodeError):
                     body = json.loads(body)
 
                 await queue.put({"body": body, "meta": meta})
-                await receiver.complete_message(msg)
+
+                if feedback_enabled and eda_feedback_queue:
+                    try:
+                        await asyncio.wait_for(
+                            eda_feedback_queue.get(),
+                            timeout=feedback_timeout,
+                        )
+                        await receiver.complete_message(msg)
+                    except asyncio.TimeoutError:
+                        logger.exception("Timed out waiting for feedback")
+                        raise
+                else:
+                    await receiver.complete_message(msg)
 
 
 async def main(

--- a/extensions/eda/plugins/event_source/schemas/azure_event_hub.json
+++ b/extensions/eda/plugins/event_source/schemas/azure_event_hub.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://redhat.com/ansible_events/sources/azure_event_hub.json",
+    "title": "Azure Event Hub plugin for EDA",
+    "description": "An ansible-rulebook event source plugin for receiving events from an Azure Event Hub",
+    "type": "object",
+    "properties": {
+        "azure_tenant_id": {
+            "description": "The azure tenant id",
+            "type": "string",
+            "title": "Azure Tenant ID"
+        },
+        "azure_client_id": {
+            "description": "The azure client id",
+            "type": "string",
+            "title": "Azure Client ID"
+        },
+        "azure_client_secret": {
+            "description": "The azure client secret",
+            "type": "string",
+            "title": "Azure Client Secret"
+        },
+        "azure_namespace": {
+            "description": "The azure event hub namespace which includes the host name",
+            "type": "string",
+            "title": "Azure Namespace",
+            "examples": ["test.servicebus.windows.net"]
+        },
+        "azure_event_hub_name": {
+            "description": "The azure event hub name",
+            "type": "string",
+            "title": "Azure Event Hub Name"
+        },
+        "azure_starting_position": {
+            "description": "The starting position",
+            "type": "string",
+            "title": "Azure Starting Position",
+            "default": "-1"
+        },
+        "azure_consumer_group": {
+            "description": "The name of the consumer group",
+            "type": "string",
+            "title": "Azure Consumer Group",
+            "default": "$Default"
+        },
+        "feedback": {
+            "description": "Should the source plugin wait for feedback before processing the next event from the Azure Event Hub.",
+            "type": "boolean",
+            "title": "Feedback",
+            "default": false
+        },
+        "feedback_timeout": {
+            "description": "Timeout in seconds to wait for feedback from the rule engine before raising an exception. Only applies when feedback is enabled.",
+            "type": "integer",
+            "title": "Feedback Timeout",
+            "default": 120
+        }
+    },
+    "required": [
+        "azure_tenant_id",
+        "azure_client_id",
+        "azure_client_secret",
+        "azure_namespace",
+        "azure_event_hub_name"
+    ]
+}

--- a/extensions/eda/plugins/event_source/schemas/azure_service_bus.json
+++ b/extensions/eda/plugins/event_source/schemas/azure_service_bus.json
@@ -20,6 +20,18 @@
             "type": "boolean",
             "default": true,
             "title": "Enable Logging"
+        },
+        "feedback": {
+            "description": "Should the source plugin wait for feedback before processing the next event from the Azure Service Bus.",
+            "type": "boolean",
+            "title": "Feedback",
+            "default": false
+        },
+        "feedback_timeout": {
+            "description": "Timeout in seconds to wait for feedback from the rule engine before raising an exception. Only applies when feedback is enabled.",
+            "type": "integer",
+            "title": "Feedback Timeout",
+            "default": 120
         }
     },
     "required": [

--- a/tests/unit/event_source/test_azure_event_hub.py
+++ b/tests/unit/event_source/test_azure_event_hub.py
@@ -4,13 +4,23 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from extensions.eda.plugins.event_source.azure_event_hub import (
-    AzureHubConsumer, main)
+from extensions.eda.plugins.event_source.azure_event_hub import AzureHubConsumer, main
 
 
 class MockEvent:
-    def __init__(self, body: str) -> None:
+    def __init__(
+        self,
+        body: str,
+        message_id: str | None = None,
+        correlation_id: str | None = None,
+        sequence_number: int = 0,
+        enqueued_time: Any = None,
+    ) -> None:
         self._body = body
+        self.message_id = message_id
+        self.correlation_id = correlation_id
+        self.sequence_number = sequence_number
+        self.enqueued_time = enqueued_time
 
     def body_as_str(self) -> str:
         return self._body
@@ -109,7 +119,10 @@ async def test_azure_hub_consumer_on_event_json() -> None:
         await consumer.on_event(partition_context, event)
 
         result = await queue.get()
-        assert result == {"body": {"message": "Hello World"}, "meta": {}}
+        assert result == {
+            "body": {"message": "Hello World"},
+            "meta": {"event": {"uuid": "0:0"}},
+        }
 
 
 @pytest.mark.asyncio
@@ -134,7 +147,7 @@ async def test_azure_hub_consumer_on_event_raw_string() -> None:
         await consumer.on_event(partition_context, event)
 
         result = await queue.get()
-        assert result == {"body": "Hello World", "meta": {}}
+        assert result == {"body": "Hello World", "meta": {"event": {"uuid": "0:0"}}}
 
 
 @pytest.mark.asyncio
@@ -264,4 +277,105 @@ async def test_azure_hub_consumer_start_receiving() -> None:
         await consumer.start_receiving()
 
         result = await queue.get()
-        assert result == {"body": {"test": "data"}, "meta": {}}
+        assert result == {"body": {"test": "data"}, "meta": {"event": {"uuid": "0:0"}}}
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_feedback_enabled_without_queue() -> None:
+    """Test that ValueError is raised when feedback is enabled but no queue is provided."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+        "feedback": True,
+    }
+
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ), pytest.raises(ValueError, match="feedback: true was set but no feedback queue"):
+        AzureHubConsumer(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_feedback_enabled_with_queue() -> None:
+    """Test that consumer waits for feedback when enabled."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+        "feedback": True,
+        "eda_feedback_queue": feedback_queue,
+    }
+
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
+        consumer = AzureHubConsumer(queue, args)
+        partition_context = MockPartitionContext()
+        event = MockEvent('{"message": "Hello World"}')
+
+        # Put feedback in queue immediately so it doesn't block
+        await feedback_queue.put("feedback_received")
+
+        await consumer.on_event(partition_context, event)
+
+        result = await queue.get()
+        assert result["body"] == {"message": "Hello World"}
+        # Verify feedback was consumed
+        assert feedback_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_feedback_timeout() -> None:
+    """Test that TimeoutError is raised when feedback timeout is exceeded."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+        "feedback": True,
+        "eda_feedback_queue": feedback_queue,
+        "feedback_timeout": 0.1,  # Short timeout for testing
+    }
+
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
+        consumer = AzureHubConsumer(queue, args)
+        partition_context = MockPartitionContext()
+        event = MockEvent('{"message": "Hello World"}')
+
+        # Don't put anything in feedback queue, so it times out
+        with pytest.raises(asyncio.TimeoutError):
+            await consumer.on_event(partition_context, event)
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_feedback_defaults() -> None:
+    """Test that feedback defaults are set correctly."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "azure_tenant_id": "test_tenant_id",
+        "azure_client_id": "test_client_id",
+        "azure_client_secret": "test_client_secret",
+        "azure_namespace": "test.servicebus.windows.net",
+        "azure_event_hub_name": "test_hub",
+    }
+
+    with patch(
+        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+    ):
+        consumer = AzureHubConsumer(queue, args)
+        assert consumer.feedback is False
+        assert consumer.feedback_timeout == 120
+        assert consumer.eda_feedback_queue is None

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -8,9 +8,12 @@ from extensions.eda.plugins.event_source.azure_service_bus import receive_events
 
 
 class MockMsg:
-    def __init__(self, message_id: int, body: str) -> None:
+    def __init__(
+        self, message_id: int, body: str, enqueued_time_utc: Any = None
+    ) -> None:
         self.message_id = message_id
         self._body = body
+        self.enqueued_time_utc = enqueued_time_utc
 
     def __str__(self) -> str:
         return self._body
@@ -79,5 +82,176 @@ async def test_receive_events() -> None:
 
         result1 = await queue.get()
         result2 = await queue.get()
-        assert result1 == {"body": "Hello World", "meta": {"message_id": 1}}
-        assert result2 == {"body": {"Say": "Hello World"}, "meta": {"message_id": 2}}
+        assert result1 == {
+            "body": "Hello World",
+            "meta": {"message_id": 1, "event": {"uuid": 1}},
+        }
+        assert result2 == {
+            "body": {"Say": "Hello World"},
+            "meta": {"message_id": 2, "event": {"uuid": 2}},
+        }
+
+
+@pytest.mark.asyncio
+async def test_receive_events_feedback_enabled_without_queue() -> None:
+    """Test that ValueError is raised when feedback is enabled but no queue is provided."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {
+        "conn_str": "fake",
+        "queue_name": "queue",
+        "feedback": True,
+    }
+
+    with pytest.raises(
+        ValueError, match="feedback: true was set but no feedback queue"
+    ):
+        await receive_events(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_receive_events_feedback_enabled_with_queue() -> None:
+    """Test that consumer waits for feedback when enabled."""
+    msg1 = MockMsg(1, '{"message": "Test"}')
+
+    class AsyncMsgIter:
+        def __init__(self, msgs: list[MockMsg]) -> None:
+            self._msgs = msgs
+            self._idx = 0
+
+        def __aiter__(self) -> "AsyncMsgIter":
+            return self
+
+        async def __anext__(self) -> MockMsg:
+            if self._idx < len(self._msgs):
+                msg = self._msgs[self._idx]
+                self._idx += 1
+                return msg
+            raise StopAsyncIteration
+
+    class MockReceiver:
+        async def __aenter__(self) -> "MockReceiver":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Any,
+        ) -> None:
+            pass
+
+        def __aiter__(self) -> AsyncMsgIter:
+            return AsyncMsgIter([msg1])
+
+        async def complete_message(self, msg: MockMsg) -> None:
+            pass
+
+    class MockServiceBusClient:
+        async def __aenter__(self) -> "MockServiceBusClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Any,
+        ) -> None:
+            pass
+
+        def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
+            return MockReceiver()
+
+    with patch(
+        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient.from_connection_string",
+        return_value=MockServiceBusClient(),
+    ):
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
+        args: Dict[str, Any] = {
+            "conn_str": "fake",
+            "queue_name": "queue",
+            "feedback": True,
+            "eda_feedback_queue": feedback_queue,
+        }
+
+        # Put feedback in queue immediately so it doesn't block
+        await feedback_queue.put("feedback_received")
+
+        await receive_events(queue, args)
+
+        result = await queue.get()
+        assert result["body"] == {"message": "Test"}
+        # Verify feedback was consumed
+        assert feedback_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_receive_events_feedback_timeout() -> None:
+    """Test that TimeoutError is raised when feedback timeout is exceeded."""
+    msg1 = MockMsg(1, '{"message": "Test"}')
+
+    class AsyncMsgIter:
+        def __init__(self, msgs: list[MockMsg]) -> None:
+            self._msgs = msgs
+            self._idx = 0
+
+        def __aiter__(self) -> "AsyncMsgIter":
+            return self
+
+        async def __anext__(self) -> MockMsg:
+            if self._idx < len(self._msgs):
+                msg = self._msgs[self._idx]
+                self._idx += 1
+                return msg
+            raise StopAsyncIteration
+
+    class MockReceiver:
+        async def __aenter__(self) -> "MockReceiver":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Any,
+        ) -> None:
+            pass
+
+        def __aiter__(self) -> AsyncMsgIter:
+            return AsyncMsgIter([msg1])
+
+        async def complete_message(self, msg: MockMsg) -> None:
+            pass
+
+    class MockServiceBusClient:
+        async def __aenter__(self) -> "MockServiceBusClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Any,
+        ) -> None:
+            pass
+
+        def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
+            return MockReceiver()
+
+    with patch(
+        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient.from_connection_string",
+        return_value=MockServiceBusClient(),
+    ):
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
+        args: Dict[str, Any] = {
+            "conn_str": "fake",
+            "queue_name": "queue",
+            "feedback": True,
+            "eda_feedback_queue": feedback_queue,
+            "feedback_timeout": 0.1,  # Short timeout for testing
+        }
+
+        # Don't put anything in feedback queue, so it times out
+        with pytest.raises(asyncio.TimeoutError):
+            await receive_events(queue, args)


### PR DESCRIPTION
##### SUMMARY
ansible-rulebook now has an optional event persistence feature which allows the source plugin to know that the inflight event has been stored in a database and if there is an outage the event wont be lost. The Azure source plugins now have 2 extra parameters
 * feedback: bool : default (False)
 * feedback_timeout: int: default (120)

When feedback is set to True, ansible-rulebook will pass in an asyncio.Queue under the key "eda_feedback_queue". The source plugin can send in an event to ansible-rulebook and wait on the feedback Queue to get a response back after the rule engine has commited the event to disk if its needed. If its not needed the Event will be discarded.

This feature is only for in-flight events which are being processed. It is not meant to store every event in the Database.

https://redhat.atlassian.net/browse/AAP-66377

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
EDA Source Plugins
  Azure Event Hub
  Azure Service Bus

##### ADDITIONAL INFORMATION
