### PR TITLE
Follow-up #2205: Test fix Public IPs associated with VPN Gateways with AZ VPN skus must have zones configured

### DIFF
--- a/tests/integration/targets/azure_rm_virtualnetworkgatewayconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgatewayconnection/tasks/main.yml
@@ -61,6 +61,9 @@
         allocation_method: Static
         name: "{{ pubipname }}01"
         sku: standard
+        zones:
+          - "1"
+          - "2"
 
     - name: Create the secondary public IP address
       azure.azcollection.azure_rm_publicipaddress:
@@ -68,6 +71,9 @@
         allocation_method: Static
         name: "{{ pubipname }}02"
         sku: standard
+        zones:
+          - "1"
+          - "2"
 
     - name: Create the virtual network gateway without bgp settings
       azure.azcollection.azure_rm_virtualnetworkgateway:

--- a/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualnetworkgatewaynatrule/tasks/main.yml
@@ -31,6 +31,9 @@
         allocation_method: Static
         sku: standard
         name: "{{ pubipname }}"
+        zones:
+          - "1"
+          - "2"
 
     - name: Create a virtual network gateway
       azure.azcollection.azure_rm_virtualnetworkgateway:


### PR DESCRIPTION
##### SUMMARY
**No functionality change**
This is a follow up PR for #2205. This PR includes fixing tests when creating virtual network gateway. 

Error message: 
````
Error creating or updating virtual network gateway - (VmssVpnGatewayPublicIpsMustHaveZonesConfigured) Standard Public IPs associated with VPN Gateways with AZ VPN skus must have zones configured.\nCode: VmssVpnGatewayPublicIpsMustHaveZonesConfigured\nMessage: Standard Public IPs associated with VPN Gateways with AZ VPN skus must have zones configured.
````

##### ISSUE TYPE
- Test Fix Pull Request