### PR TITLE
Fix #2126: Fix reserved parameters and return keys

### DIFF
--- a/plugins/modules/azure_rm_automationaccount_info.py
+++ b/plugins/modules/azure_rm_automationaccount_info.py
@@ -124,9 +124,35 @@ automation_accounts:
             type: str
             returned: always
             sample: ok
+        account_keys:
+            description:
+                - Resource keys.
+            type: complex
+            returned: always
+            contains:
+                key_name:
+                    description:
+                        - Name of the key.
+                    type: str
+                    returned: always
+                    sample: Primary
+                permissions:
+                    description:
+                        - Permission of the key.
+                    type: str
+                    returned: always
+                    sample: Full
+                value:
+                    description:
+                        - Value of the key.
+                    type: str
+                    returned: always
+                    sample: "MbepKTO6IyGwml0GaKBkKN"
         keys:
             description:
                 - Resource keys.
+                - This return value has been deprecated and will be removed in a release after
+                  2027-05-01. Use C(account_keys) instead.
             type: complex
             returned: always
             contains:
@@ -285,6 +311,13 @@ class AzureRMAutomationAccountInfo(AzureRMModuleBase):
         for key in list(self.module_arg_spec):
             setattr(self, key, kwargs[key])
 
+        if self.list_keys:
+            self.module.deprecate(
+                "The 'keys' return key is deprecated. Use 'account_keys' instead.",
+                date="2027-05-01",
+                collection_name="azure.azcollection",
+            )
+
         if self.resource_group and self.name:
             accounts = [self.get()]
         elif self.resource_group:
@@ -305,7 +338,8 @@ class AzureRMAutomationAccountInfo(AzureRMModuleBase):
         if self.list_usages:
             result['usages'] = self.get_usages(id_dict['resource_group'], account.name)
         if self.list_keys:
-            result['keys'] = self.list_account_keys(id_dict['resource_group'], account.name)
+            result['account_keys'] = self.list_account_keys(id_dict['resource_group'], account.name)
+            result['keys'] = result['account_keys']
         return result
 
     def get(self):

--- a/plugins/modules/azure_rm_automationaccount_info.py
+++ b/plugins/modules/azure_rm_automationaccount_info.py
@@ -128,25 +128,25 @@ automation_accounts:
             description:
                 - Resource keys.
             type: complex
-            returned: always
+            returned: when I(list_keys=True)
             contains:
                 key_name:
                     description:
                         - Name of the key.
                     type: str
-                    returned: always
+                    returned: when I(list_keys=True)
                     sample: Primary
                 permissions:
                     description:
                         - Permission of the key.
                     type: str
-                    returned: always
+                    returned: when I(list_keys=True)
                     sample: Full
                 value:
                     description:
                         - Value of the key.
                     type: str
-                    returned: always
+                    returned: when I(list_keys=True)
                     sample: "MbepKTO6IyGwml0GaKBkKN"
         keys:
             description:
@@ -154,25 +154,25 @@ automation_accounts:
                 - This return value has been deprecated and will be removed in a release after
                   2027-05-01. Use C(account_keys) instead.
             type: complex
-            returned: always
+            returned: when I(list_keys=True)
             contains:
                 key_name:
                     description:
                         - Name of the key.
                     type: str
-                    returned: always
+                    returned: when I(list_keys=True)
                     sample: Primary
                 permissions:
                     description:
                         - Permission of the key.
                     type: str
-                    returned: always
+                    returned: when I(list_keys=True)
                     sample: Full
                 value:
                     description:
                         - Value of the key.
                     type: str
-                    returned: always
+                    returned: when I(list_keys=True)
                     sample: "MbepKTO6IyGwml0GaKBkKN"
         statistics:
             description:

--- a/plugins/modules/azure_rm_cognitivesearch_info.py
+++ b/plugins/modules/azure_rm_cognitivesearch_info.py
@@ -90,9 +90,31 @@ search:
             sample:
                 principal_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
                 type: SystemAssigned
+        search_keys:
+            description:
+                - Admin and query keys for Azure Cognitive Search Service.
+            type: dict
+            contains:
+                admin_primary:
+                    description:
+                        - Primary admin key for Azure Cognitive Search Service.
+                    type: str
+                    sample: 12345ABCDE67890FGHIJ123ABC456DEF
+                admin_secondary:
+                    description:
+                        - Secondary admin key for Azure Cognitive Search Service.
+                    type: str
+                    sample: 12345ABCDE67890FGHIJ123ABC456DEF
+                query:
+                    description:
+                        - List of query keys for Azure Cognitive Search Service.
+                    type: list
+                    sample: [{'key': '12345ABCDE67890FGHIJ123ABC456DEF', 'name': 'Query key'}]
         keys:
             description:
                 - Admin and query keys for Azure Cognitive Search Service.
+                - This return value has been deprecated and will be removed in a release after
+                  2027-05-01. Use C(search_keys) instead.
             type: dict
             contains:
                 admin_primary:
@@ -207,6 +229,13 @@ class AzureRMSearchInfo(AzureRMModuleBase):
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
+        if self.show_keys:
+            self.module.deprecate(
+                "The 'keys' return key is deprecated. Use 'search_keys' instead.",
+                date="2027-05-01",
+                collection_name="azure.azcollection",
+            )
+
         if self.name and not self.resource_group:
             self.fail("Parameter error: resource group required when filtering by name.")
 
@@ -294,16 +323,18 @@ class AzureRMSearchInfo(AzureRMModuleBase):
             account_dict['network_rule_set'].append(rule.value)
 
         if self.show_keys:
-            account_dict['keys'] = dict()
+            account_dict['search_keys'] = dict()
 
             admin_keys = self.search_client.admin_keys.get(self.resource_group, self.name)
-            account_dict['keys']['admin_primary'] = admin_keys.primary_key
-            account_dict['keys']['admin_secondary'] = admin_keys.secondary_key
+            account_dict['search_keys']['admin_primary'] = admin_keys.primary_key
+            account_dict['search_keys']['admin_secondary'] = admin_keys.secondary_key
 
             query_keys = self.search_client.query_keys.list_by_search_service(self.resource_group, self.name)
-            account_dict['keys']['query'] = list()
+            account_dict['search_keys']['query'] = list()
             for key in query_keys:
-                account_dict['keys']['query'].append(dict(name=key.name, key=key.key))
+                account_dict['search_keys']['query'].append(dict(name=key.name, key=key.key))
+
+            account_dict['keys'] = account_dict['search_keys']
 
         return account_dict
 

--- a/plugins/modules/azure_rm_imagesku_info.py
+++ b/plugins/modules/azure_rm_imagesku_info.py
@@ -101,9 +101,17 @@ available_skus:
                     type: str
                     returned: always
                     sample: "location"
+                restriction_values:
+                    description:
+                        - A list of restricted locations, regions, or zones where the image SKU cannot be used.
+                    type: list
+                    returned: always
+                    sample: ["eastus", "westeurope"]
                 values:
                     description:
                         - A list of restricted locations, regions, or zones where the image SKU cannot be used.
+                        - This return value has been deprecated and will be removed in a release after
+                          2027-05-01. Use C(restriction_values) instead.
                     type: list
                     returned: always
                     sample: ["eastus", "westeurope"]
@@ -167,6 +175,11 @@ class AzureRMImageskuInfo(AzureRMModuleBase):
         available_skus = self.list_skus()
         self.results['available_skus'] = available_skus
         self.results['count'] = len(available_skus)
+        self.module.deprecate(
+            "The 'values' return key in 'restrictions' is deprecated. Use 'restriction_values' instead.",
+            date="2027-05-01",
+            collection_name="azure.azcollection",
+        )
         return self.results
 
     def list_skus(self):
@@ -180,7 +193,11 @@ class AzureRMImageskuInfo(AzureRMModuleBase):
             available_skus = []
 
             for sku_info in skus_result:
-                available_skus.append(sku_info.as_dict())
+                sku_dict = sku_info.as_dict()
+                for restriction in sku_dict.get('restrictions', []):
+                    if 'values' in restriction:
+                        restriction['restriction_values'] = restriction['values']
+                available_skus.append(sku_dict)
             return available_skus
 
         except HttpResponseError as e:

--- a/plugins/modules/azure_rm_keyvault_info.py
+++ b/plugins/modules/azure_rm_keyvault_info.py
@@ -209,9 +209,19 @@ keyvaults:
                     type: complex
                     returned: always
                     contains:
-                        keys:
+                        key_permissions:
                             description:
                                 Permissions to keys.
+                            type: list
+                            returned: always
+                            sample:
+                                - get
+                                - create
+                        keys:
+                            description:
+                                - Permissions to keys.
+                                - This return value has been deprecated and will be removed in a
+                                  release after 2027-05-01. Use C(key_permissions) instead.
                             type: list
                             returned: always
                             sample:
@@ -266,6 +276,7 @@ def keyvault_to_dict(vault):
             tenant_id=policy.tenant_id,
             object_id=policy.object_id,
             permissions=dict(
+                key_permissions=[kp.lower() for kp in policy.permissions.keys] if policy.permissions.keys else None,
                 keys=[kp.lower() for kp in policy.permissions.keys] if policy.permissions.keys else None,
                 secrets=[sp.lower() for sp in policy.permissions.secrets] if policy.permissions.secrets else None,
                 certificates=[cp.lower() for cp in policy.permissions.certificates] if policy.permissions.certificates else None,
@@ -340,6 +351,12 @@ class AzureRMKeyVaultInfo(AzureRMModuleBase):
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             if hasattr(self, key):
                 setattr(self, key, kwargs[key])
+
+        self.module.deprecate(
+            "The 'keys' return key in 'permissions' is deprecated. Use 'key_permissions' instead.",
+            date="2027-05-01",
+            collection_name="azure.azcollection",
+        )
 
         self._client = self.get_mgmt_svc_client(KeyVaultManagementClient,
                                                 base_url=self._cloud_environment.endpoints.resource_manager,

--- a/plugins/modules/azure_rm_servicebussaspolicy.py
+++ b/plugins/modules/azure_rm_servicebussaspolicy.py
@@ -96,9 +96,49 @@ id:
     type: str
     sample: "/subscriptions/xxx...xxx/resourceGroups/myResourceGroup/providers/Microsoft.ServiceBus/
             namespaces/nsb57dc95979/topics/topicb57dc95979/authorizationRules/testpolicy"
+sas_keys:
+    description:
+        - Key dict of the SAS policy.
+    returned: Successed
+    type: complex
+    contains:
+        key_name:
+            description:
+                - Name of the SAS policy.
+            returned: Successed
+            type: str
+            sample: testpolicy
+        primary_connection_string:
+            description:
+                - Primary connection string.
+            returned: Successed
+            type: str
+            sample: "Endpoint=sb://nsb57dc95979.servicebus.windows.net/;SharedAccessKeyName=testpolicy;
+                    SharedAccessKey=xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        primary_key:
+            description:
+                - Primary key.
+            returned: Successed
+            type: str
+            sample: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        secondary_key:
+            description:
+                - Secondary key.
+            returned: Successed
+            type: str
+            sample: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        secondary_connection_string:
+            description:
+                - Secondary connection string.
+            returned: Successed
+            type: str
+            sample: "Endpoint=sb://nsb57dc95979.servicebus.windows.net/;SharedAccessKeyName=testpolicy;
+                    SharedAccessKey=xxxxxxxxxxxxxxxxxxxxxxxxx"
 keys:
     description:
         - Key dict of the SAS policy.
+        - This return value has been deprecated and will be removed in a release after
+          2027-05-01. Use C(sas_keys) instead.
     returned: Successed
     type: complex
     contains:
@@ -224,7 +264,13 @@ class AzureRMServiceBusSASPolicy(AzureRMModuleBase):
                 if self.regenerate_secondary_key and not self.check_mode:
                     self.regenerate_sas_key('secondary')
             self.results = self.policy_to_dict(policy)
-            self.results['keys'] = self.get_sas_key()
+            self.results['sas_keys'] = self.get_sas_key()
+            self.results['keys'] = self.results['sas_keys']
+            self.module.deprecate(
+                "The 'keys' return key is deprecated. Use 'sas_keys' instead.",
+                date="2027-05-01",
+                collection_name="azure.azcollection",
+            )
         elif policy:
             changed = True
             if not self.check_mode:

--- a/plugins/modules/azure_rm_tags_info.py
+++ b/plugins/modules/azure_rm_tags_info.py
@@ -67,9 +67,35 @@ tag_details:
             returned: always
             type: dict
             sample: { 'type': 'Total', 'value': 1}
+        tag_values:
+            description:
+                - The list of tag values.
+            returned: always
+            type: complex
+            contains:
+                id:
+                    description:
+                        - The tag value ID.
+                    returned: always
+                    type: str
+                    sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/tagNames/key2/tagValues/v1"
+                tag_value:
+                    description:
+                        - The tag value.
+                    returned: always
+                    type: str
+                    sample: V1
+                count:
+                    description:
+                        - The tag value count
+                    returned: always
+                    type: dict
+                    sample: {'type': 'totoal', 'value': 1}
         values:
             description:
                 - The list of tag values.
+                - This return value has been deprecated and will be removed in a release after 2027-05-01.
+                  Use C(tag_values) instead.
             returned: always
             type: complex
             contains:
@@ -158,6 +184,11 @@ class AzureRMTagsInfo(AzureRMModuleBase):
             self.results['tag_info'] = self.get_at_scope(self.scope)
         else:
             self.results['tag_details'] = self.list_all()
+            self.module.deprecate(
+                "The 'values' return key in 'tag_details' is deprecated. Use 'tag_values' instead.",
+                date="2027-05-01",
+                collection_name="azure.azcollection",
+            )
 
         return self.results
 
@@ -180,7 +211,10 @@ class AzureRMTagsInfo(AzureRMModuleBase):
         try:
             response = self.rm_client.tags.list()
             while True:
-                results.append(response.next().as_dict())
+                tag_dict = response.next().as_dict()
+                if 'values' in tag_dict:
+                    tag_dict['tag_values'] = tag_dict['values']
+                results.append(tag_dict)
         except StopIteration:
             pass
         except Exception as exc:

--- a/plugins/modules/azure_rm_tags_info.py
+++ b/plugins/modules/azure_rm_tags_info.py
@@ -90,7 +90,7 @@ tag_details:
                         - The tag value count
                     returned: always
                     type: dict
-                    sample: {'type': 'totoal', 'value': 1}
+                    sample: {'type': 'Total', 'value': 1}
         values:
             description:
                 - The list of tag values.

--- a/plugins/modules/azure_rm_vmsku_info.py
+++ b/plugins/modules/azure_rm_vmsku_info.py
@@ -177,9 +177,19 @@ available_skus:
                     type: str
                     returned: always
                     sample: "location"
+                restriction_values:
+                    description:
+                        - The value of restrictions. If the restriction type is set to location.
+                          This would be different locations where the SKU is restricted.
+                    type: str
+                    returned: always
+                    sample: ["eastus"]
                 values:
                     description:
-                        - The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.
+                        - The value of restrictions. If the restriction type is set to location.
+                          This would be different locations where the SKU is restricted.
+                        - This return value has been deprecated and will be removed in a release after
+                          2027-05-01. Use C(restriction_values) instead.
                     type: str
                     returned: always
                     sample: ["eastus"]
@@ -257,7 +267,11 @@ class AzureRMVmskuInfo(AzureRMModuleBase):
                     continue
                 if self.zone and not (sku_info.location_info and sku_info.location_info[0].zones):
                     continue
-                available_skus.append(sku_info.as_dict())
+                sku_dict = sku_info.as_dict()
+                for restriction in sku_dict.get('restrictions', []):
+                    if 'values' in restriction:
+                        restriction['restriction_values'] = restriction['values']
+                available_skus.append(sku_dict)
             return available_skus
         except HttpResponseError as e:
             # Handle exceptions
@@ -270,6 +284,11 @@ class AzureRMVmskuInfo(AzureRMModuleBase):
         available_skus = self.list_skus()
         self.results['available_skus'] = available_skus
         self.results['count'] = len(available_skus)
+        self.module.deprecate(
+            "The 'values' return key in 'restrictions' is deprecated. Use 'restriction_values' instead.",
+            date="2027-05-01",
+            collection_name="azure.azcollection",
+        )
         return self.results
 
 

--- a/plugins/modules/azure_rm_vmsku_info.py
+++ b/plugins/modules/azure_rm_vmsku_info.py
@@ -181,7 +181,7 @@ available_skus:
                     description:
                         - The value of restrictions. If the restriction type is set to location.
                           This would be different locations where the SKU is restricted.
-                    type: str
+                    type: list
                     returned: always
                     sample: ["eastus"]
                 values:
@@ -190,7 +190,7 @@ available_skus:
                           This would be different locations where the SKU is restricted.
                         - This return value has been deprecated and will be removed in a release after
                           2027-05-01. Use C(restriction_values) instead.
-                    type: str
+                    type: list
                     returned: always
                     sample: ["eastus"]
                 restriction_info:

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,1 +1,8 @@
+plugins/modules/azure_rm_automationaccount_info.py validate-modules:bad-return-value-key
+plugins/modules/azure_rm_cognitivesearch_info.py validate-modules:bad-return-value-key
+plugins/modules/azure_rm_imagesku_info.py validate-modules:bad-return-value-key
+plugins/modules/azure_rm_keyvault_info.py validate-modules:bad-return-value-key
+plugins/modules/azure_rm_servicebussaspolicy.py validate-modules:bad-return-value-key
+plugins/modules/azure_rm_tags_info.py validate-modules:bad-return-value-key
+plugins/modules/azure_rm_vmsku_info.py validate-modules:bad-return-value-key
 plugins/module_utils/azure_rm_common.py pylint:ansible-bad-function

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,8 +1,1 @@
-plugins/modules/azure_rm_automationaccount_info.py validate-modules:bad-return-value-key
-plugins/modules/azure_rm_cognitivesearch_info.py validate-modules:bad-return-value-key
-plugins/modules/azure_rm_imagesku_info.py validate-modules:bad-return-value-key
-plugins/modules/azure_rm_keyvault_info.py validate-modules:bad-return-value-key
-plugins/modules/azure_rm_servicebussaspolicy.py validate-modules:bad-return-value-key
-plugins/modules/azure_rm_tags_info.py validate-modules:bad-return-value-key
-plugins/modules/azure_rm_vmsku_info.py validate-modules:bad-return-value-key
 plugins/module_utils/azure_rm_common.py pylint:ansible-bad-function


### PR DESCRIPTION
##### SUMMARY

**FUTURE ACTION NEEDED:**
- Remove [`ignore-2.21.txt line 1-7`](https://github.com/ansible-collections/azure/blob/023679ed967087cdce89e84203c80e7d55f2adef/tests/sanity/ignore-2.21.txt#L1-L7) after 2027-05-01.
- Remove old keys reference in module code and RETURN docstring.

Fix #2126, related to #2112

﻿Renames reserved Python built-in return value keys (keys, values) that conflict with Jinja2 dot-notation access. ﻿
These `validate-modules:bad-return-value-key` sanity errors are reported starting with `ansible-core 2.21` (currently in `devel`). They were temporarily suppressed via `tests/sanity/ignore-2.21.txt`. The 7 ignore entries can be removed after the removal date of `2027-05-01`.

Each affected module now: 
1. Adds a new non-reserved return key as the primary documented key
2. Keeps the old key populated (aliased to the new key) for backward compatibility
3. Marks the old key as deprecated in the RETURN docstring with a removal date of `2027-05-01`
4. Emits a runtime deprecation warning via `module.deprecate()`

| Module | Old Key | New Key |
| ------------- | ------------- | ------------- |
| azure_rm_automationaccount_info | `keys` | `account_keys` |
| azure_rm_cognitivesearch_info | `keys` | `search_keys` |
| azure_rm_keyvault_info | `keys` (in `permissions`) | `key_permissions` |
| azure_rm_servicebussaspolicy | `keys` | `sas_keys` |
| azure_rm_imagesku_info | `values` (in `restrictions`) | `restriction_values` |
| azure_rm_vmsku_info | `values` (in `restrictions`) | `restriction_values` |
| azure_rm_tags_info | `values` (in `tag_details`) | `tag_values` |

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- azure_rm_automationaccount_info
- azure_rm_cognitivesearch_info
- azure_rm_keyvault_info
- azure_rm_servicebussaspolicy
- azure_rm_imagesku_info
- azure_rm_vmsku_info
- azure_rm_tags_info

##### ADDITIONAL INFORMATION
Sample deprecation warning:
````
[DEPRECATION WARNING]: The 'keys' return key in 'permissions' is deprecated. Use 'key_permissions' instead. This feature will be removed from collection 'azure.azcollection' in a release after 2027-05-01.
````
