### PR TITLE
Test Fix: Upgrade arc integration test VM to Ubuntu 22.04 LTS

### DIFF
--- a/tests/integration/targets/azure_arc_integration/tasks/setup.yml
+++ b/tests/integration/targets/azure_arc_integration/tasks/setup.yml
@@ -59,7 +59,7 @@
     src: "~/.ansible/test/id_rsa.pub"
   register: ssh_public_key_content
 
-- name: Create Azure VM for Arc evaluation (Ubuntu 20.04 LTS)
+- name: Create Azure VM for Arc evaluation (Ubuntu 22.04 LTS)
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ arc_onboarding_rg }}"
     name: "{{ vm_name }}"
@@ -74,9 +74,9 @@
     managed_disk_type: StandardSSD_LRS
     os_disk_caching: ReadWrite
     image:
-      offer: 0001-com-ubuntu-server-focal
+      offer: 0001-com-ubuntu-server-jammy
       publisher: Canonical
-      sku: 20_04-lts-gen2
+      sku: 22_04-lts-gen2
       version: latest
 
 - name: Get VM public IP for connection


### PR DESCRIPTION
##### SUMMARY
The `azure_arc_integration` test﻿ provisions an `Ubuntu 20.04 VM` (Python 3.8.10). `ansible-core ≥ 2.18` requires Python 3.9+ on managed nodes, causing all delegated tasks to the VM to fail with:
````
Ansible requires Python 3.9 or newer on the target. Current version: 3.8.10
````
 
This PR upgrades the VM image from `Ubuntu 20.04 (focal)` to `Ubuntu 22.04 (jammy)`, which ships Python 3.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/azure_arc_integration/tasks/setup.yml

##### ADDITIONAL INFORMATION
﻿Error observed in ADO pipeline under the `azure_arc_integration` target:
````
fatal: [testhost -> arc_test_vm(172.1xx.1xx.1xx)]: FAILED! => {  "changed": false,  "msg": "Ansible requires Python 3.9 or newer
on the target. Current version: 3.8.10 (default, Mar 18 2025, 20:04:55) [GCC 9.4.0]" }
````