### PR TITLE
Fix: Application Gateway v2 subnet delegation for integration tests

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -157,6 +157,7 @@ options:
                     - Microsoft.Network/managedResolvers
                     - Microsoft.Kusto/clusters
                     - Microsoft.App/environments
+                    - Microsoft.Network/applicationGateways
             actions:
                 description:
                     - A list of actions.
@@ -396,7 +397,8 @@ delegations_spec = dict(
                  'Microsoft.DBforPostgreSQL/singleServers', 'Microsoft.DBforPostgreSQL/flexibleServers', 'Microsoft.DBforMySQL/serversv2',
                  'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.ApiManagement/service', 'Microsoft.Synapse/workspaces',
                  'Microsoft.PowerPlatform/vnetaccesslinks', 'Microsoft.Network/managedResolvers', 'Microsoft.Kusto/clusters',
-                 'Microsoft.ContainerService/managedClusters', 'Microsoft.App/environments']
+                 'Microsoft.ContainerService/managedClusters', 'Microsoft.App/environments',
+                 'Microsoft.Network/applicationGateways']
     ),
     actions=dict(
         type='list',

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -63,6 +63,9 @@
         virtual_network_name: vnet{{ rpfx }}
         resource_group: "{{ resource_group }}-appgateway"
         address_prefix_cidr: 10.1.0.0/24
+        delegations:
+          - name: appgw-delegation
+            serviceName: Microsoft.Network/applicationGateways
       register: subnet_output
 
     - name: Configure public IP for v2 gateway

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -640,6 +640,9 @@
         virtual_network_name: tn{{ rpfx }}
         resource_group: "{{ resource_group }}-nic02"
         address_prefix_cidr: 10.10.1.0/24
+        delegations:
+          - name: appgw-delegation
+            serviceName: Microsoft.Network/applicationGateways
       register: appgw_subnet_output
 
     - name: Create public IP addresses


### PR DESCRIPTION
##### SUMMARY
﻿Azure now requires subnet delegation to `Microsoft.Network/applicationGateways` for all Application Gateway v2 deployments (standard_v2/waf_v2) as of May 5, 2025. This caused `azure_rm_appgateway` and `azure_rm_networkinterface` to fail with `ApplicationGatewayNetworkIsolationRequiresSubnetDelegation`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_subnet.py

##### ADDITIONAL INFORMATION
**Changes**
- `plugins/modules/azure_rm_subnet.py` — Add `Microsoft.Network/applicationGateways` to `serviceName` choices (DOCUMENTATION + argument_spec).
- `tests/.../azure_rm_appgateway/tasks/main.yml` — Add `delegations` to the shared subnet used by all AppGW v2 test cases.
- `tests/.../azure_rm_networkinterface/tasks/main.yml` — Add `delegations` to the AppGW subnet used for NIC integration test.

**Error message example**
````
Error creating the Application Gateway instance: (ApplicationGatewayNetworkIsolationRequiresSubnetDelegation) Application Gateway /subscriptions/<hidden>/resourceGroups/<hidden>-appgateway/providers/Microsoft.Network/applicationGateways/appgateway-<hidden> with NetworkIsolation requires subnet delegation. Please delegate subnet /subscriptions/<hidden>/resourceGroups/<hidden>-appgateway/providers/Microsoft.Network/virtualNetworks/vnet<hidden>/subnets/subnet<hidden> to Microsoft.Network/applicationGateways.
````

----
References: ﻿https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-private-deployment#application-gateway-subnet
