### PR TITLE
﻿New Feature #2212: Add managed identity support for  `azure_rm_openshiftmanagedcluster`

### DIFF
--- a/plugins/modules/azure_rm_openshiftmanagedcluster.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster.py
@@ -886,23 +886,27 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                 elif key == 'network_profile':
                     self.body['properties']['networkProfile'] = {}
                     for item in kwargs[key].keys():
+                        value = kwargs[key].get(item)
+                        if value is None:
+                            continue
                         if item == 'pod_cidr':
-                            self.body['properties']['networkProfile']['podCidr'] = kwargs[key].get(item)
+                            self.body['properties']['networkProfile']['podCidr'] = value
                         elif item == 'service_cidr':
-                            self.body['properties']['networkProfile']['serviceCidr'] = kwargs[key].get(item)
+                            self.body['properties']['networkProfile']['serviceCidr'] = value
                         elif item == 'outbound_type':
-                            self.body['properties']['networkProfile']['outboundType'] = kwargs[key].get(item)
+                            self.body['properties']['networkProfile']['outboundType'] = value
                         elif item == 'preconfigured_nsg':
-                            self.body['properties']['networkProfile']['preconfiguredNSG'] = kwargs[key].get(item)
+                            self.body['properties']['networkProfile']['preconfiguredNSG'] = value
                 elif key == 'master_profile':
                     self.body['properties']['masterProfile'] = {}
-                    if 'subnet_id' in kwargs[key].keys():
+                    if kwargs[key].get('subnet_id') is not None:
                         self.body['properties']['masterProfile']['subnetId'] = kwargs[key].get('subnet_id')
-                    if 'disk_encryption_set_id' in kwargs[key].keys():
+                    if kwargs[key].get('disk_encryption_set_id') is not None:
                         self.body['properties']['masterProfile']['diskEncryptionSetId'] = kwargs[key].get('disk_encryption_set_id')
-                    if 'encryption_at_host' in kwargs[key].keys():
+                    if kwargs[key].get('encryption_at_host') is not None:
                         self.body['properties']['masterProfile']['encryptionAtHost'] = kwargs[key].get('encryption_at_host')
-                    self.body['properties']['masterProfile']['vmSize'] = kwargs[key].get('vm_size')
+                    if kwargs[key].get('vm_size') is not None:
+                        self.body['properties']['masterProfile']['vmSize'] = kwargs[key].get('vm_size')
                 elif key == 'worker_profiles':
                     self.body['properties']['workerProfiles'] = []
                     for item in kwargs[key]:
@@ -911,11 +915,16 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                             worker_profile['name'] = item['name']
                         if item.get('subnet_id') is not None:
                             worker_profile['subnetId'] = item['subnet_id']
-                        worker_profile['count'] = item.get('count')
-                        worker_profile['vmSize'] = item.get('vm_size')
-                        worker_profile['diskSizeGB'] = item.get('disk_size')
-                        worker_profile['encryptionAtHost'] = item.get('encryption_at_host')
-                        worker_profile['diskEncryptionSetId'] = item.get('disk_encryption_set_id')
+                        if item.get('count') is not None:
+                            worker_profile['count'] = item['count']
+                        if item.get('vm_size') is not None:
+                            worker_profile['vmSize'] = item['vm_size']
+                        if item.get('disk_size') is not None:
+                            worker_profile['diskSizeGB'] = item['disk_size']
+                        if item.get('encryption_at_host') is not None:
+                            worker_profile['encryptionAtHost'] = item['encryption_at_host']
+                        if item.get('disk_encryption_set_id') is not None:
+                            worker_profile['diskEncryptionSetId'] = item['disk_encryption_set_id']
 
                         self.body['properties']['workerProfiles'].append(worker_profile)
                 elif key == 'api_server_profile':

--- a/plugins/modules/azure_rm_openshiftmanagedcluster.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster.py
@@ -63,18 +63,35 @@ options:
                 default: Enabled
     service_principal_profile:
         description:
-            - service principal.
+            - Service principal for the cluster.
+            - Required when not using managed identity.
+            - Mutually exclusive with I(identity).
         type: dict
         suboptions:
             client_id:
                 description:
                     - Client ID of the service principal (immutable).
-                required: true
                 type: str
             client_secret:
                 description:
                     - Client secret of the service principal (immutable).
-                required: true
+                type: str
+    platform_workload_identity_profile:
+        description:
+            - The workload identity profile for the cluster.
+            - Required when using managed identity (I(identity)).
+            - Maps ARO operator names to user-assigned managed identity resource IDs.
+        type: dict
+        suboptions:
+            platform_workload_identities:
+                description:
+                    - Dictionary of operator names to identity configurations.
+                    - Each key is an operator name (e.g., C(image-registry), C(disk-csi-driver), C(ingress)).
+                    - Each value is a dictionary with a C(resource_id) key pointing to the user-assigned managed identity.
+                type: dict
+            upgradeable_to:
+                description:
+                    - The OpenShift version that the workload identity cluster can be upgraded to.
                 type: str
     network_profile:
         description:
@@ -234,6 +251,7 @@ options:
 extends_documentation_fragment:
     - azure.azcollection.azure
     - azure.azcollection.azure_tags
+    - azure.azcollection.azure_identity_multiple
 author:
     - Haiyuan Zhang (@haiyuazhang)
 '''
@@ -296,6 +314,48 @@ EXAMPLES = '''
     name: myCluster
     location: eastus
     state: absent
+
+- name: Create openshift cluster with managed identity
+  azure_rm_openshiftmanagedcluster:
+    resource_group: "myResourceGroup"
+    name: "myCluster"
+    location: "eastus"
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-cluster-identity"
+    cluster_profile:
+      cluster_resource_group_id: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/clusterResourceGroup"
+      domain: "mydomain"
+    platform_workload_identity_profile:
+      platform_workload_identities:
+        ClusterOperator.OpenShift.IO/cloud-controller-manager:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ccm"
+        ClusterOperator.OpenShift.IO/ingress:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ingress"
+        ClusterOperator.OpenShift.IO/image-registry:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-registry"
+        ClusterOperator.OpenShift.IO/machine-api:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-machine"
+        ClusterOperator.OpenShift.IO/cloud-network-config:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-network"
+        CloudControllerManager.ARO.OpenShift.IO:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-cloud"
+        ServiceOperator.ARO.OpenShift.IO:
+          resource_id: "/subscriptions/xx-xx/resourceGroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-service"
+    network_profile:
+      pod_cidr: "10.128.0.0/14"
+      service_cidr: "172.30.0.0/16"
+    worker_profiles:
+      - name: worker
+        vm_size: "Standard_D4s_v3"
+        subnet_id: "/subscriptions/xx-xx/resourceGroups/myResourceGroup/Microsoft.Network/virtualNetworks/myVnet/subnets/worker"
+        disk_size: 128
+        count: 3
+    master_profile:
+      vm_size: "Standard_D8s_v3"
+      subnet_id: "/subscriptions/xx-xx/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/master"
 '''
 
 RETURN = '''
@@ -323,6 +383,22 @@ location:
     returned: always
     type: str
     sample: eatus
+identity:
+    description:
+        - The managed service identities assigned to the cluster.
+    returned: when configured
+    type: complex
+    contains:
+        type:
+            description:
+                - Type of managed service identity.
+            type: str
+            sample: UserAssigned
+        userAssignedIdentities:
+            description:
+                - The set of user assigned identities associated with the resource.
+            type: dict
+            sample: {"/subscriptions/xx/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id": {}}
 properties:
     description:
         - Properties of a OpenShift managed cluster.
@@ -370,13 +446,29 @@ properties:
             description:
                 - Service principal.
             type: complex
-            returned: always
+            returned: when configured
             contains:
                 clientId:
                     description: Client ID of the service principal.
                     returned: always
                     type: str
                     sample: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
+        platformWorkloadIdentityProfile:
+            description:
+                - The workload identity profile.
+            type: complex
+            returned: when configured
+            contains:
+                platformWorkloadIdentities:
+                    description:
+                        - Dictionary of operator names to workload identity configurations.
+                    type: dict
+                    returned: always
+                upgradeableTo:
+                    description:
+                        - The OpenShift version the cluster can be upgraded to.
+                    type: str
+                    returned: when available
         networkProfile:
             description:
                 - Configuration for OpenShift networking.
@@ -504,8 +596,14 @@ properties:
 import time
 import json
 import random
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
+
+try:
+    from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+    from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
+    from azure.mgmt.redhatopenshift.models import (ManagedServiceIdentity, UserAssignedIdentity)
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
 
 
 class Actions:
@@ -556,12 +654,29 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                 options=dict(
                     client_id=dict(
                         type='str',
-                        required=True
                     ),
                     client_secret=dict(
                         type='str',
                         no_log=True,
-                        required=True
+                    )
+                )
+            ),
+            identity=dict(
+                type='dict',
+                options=self.managed_identity_multiple_spec,
+                required_if=[
+                    ('type', 'UserAssigned', ['user_assigned_identities']),
+                    ('type', 'SystemAssigned, UserAssigned', ['user_assigned_identities']),
+                ]
+            ),
+            platform_workload_identity_profile=dict(
+                type='dict',
+                options=dict(
+                    platform_workload_identities=dict(
+                        type='dict',
+                    ),
+                    upgradeable_to=dict(
+                        type='str',
                     )
                 )
             ),
@@ -688,6 +803,7 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
 
         self.resource_group = None
         self.name = None
+        self.identity = None
 
         self.results = dict(changed=False)
         self.mgmt_client = None
@@ -700,13 +816,33 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
         self.body['properties'] = {}
         self.query_parameters = {}
         self.header_parameters = {}
+        self._managed_identity = None
 
-        self.query_parameters['api-version'] = '2023-09-04'
+        self.query_parameters['api-version'] = '2025-07-25'
         self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
 
         super(AzureRMOpenShiftManagedClusters, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                               supports_check_mode=True,
                                                               supports_tags=True)
+
+    @property
+    def managed_identity(self):
+        if not self._managed_identity:
+            self._managed_identity = {"identity": ManagedServiceIdentity,
+                                      "user_assigned": UserAssignedIdentity}
+        return self._managed_identity
+
+    def format_for_body(self, identity):
+        if identity:
+            identity = identity.as_dict()
+            if identity.get("user_assigned_identities"):
+                identity["userAssignedIdentities"] = identity.pop("user_assigned_identities")
+        return identity
+
+    def format_for_helper(self, identity):
+        if identity and identity.get("userAssignedIdentities"):
+            identity["user_assigned_identities"] = identity.pop("userAssignedIdentities")
+        return identity
 
     def exec_module(self, **kwargs):
         for key in list(self.module_arg_spec.keys()) + ['tags']:
@@ -729,9 +865,24 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                         elif item == 'fips_validated_modules':
                             self.body['properties']['clusterProfile']['fipsValidatedModules'] = kwargs[key].get(item)
                 elif key == 'service_principal_profile':
-                    self.body['properties']['servicePrincipalProfile'] = {}
-                    self.body['properties']['servicePrincipalProfile']['ClientId'] = kwargs[key].get('client_id')
-                    self.body['properties']['servicePrincipalProfile']['clientSecret'] = kwargs[key].get('client_secret')
+                    sp = kwargs[key]
+                    if sp.get('client_id') and sp.get('client_secret'):
+                        self.body['properties']['servicePrincipalProfile'] = {}
+                        self.body['properties']['servicePrincipalProfile']['clientId'] = sp.get('client_id')
+                        self.body['properties']['servicePrincipalProfile']['clientSecret'] = sp.get('client_secret')
+                elif key == 'platform_workload_identity_profile':
+                    pwi_profile = {}
+                    pwi = kwargs[key].get('platform_workload_identities')
+                    if pwi:
+                        pwi_body = {}
+                        for operator_name, identity_config in pwi.items():
+                            pwi_body[operator_name] = {}
+                            if isinstance(identity_config, dict) and identity_config.get('resource_id'):
+                                pwi_body[operator_name]['resourceId'] = identity_config['resource_id']
+                        pwi_profile['platformWorkloadIdentities'] = pwi_body
+                    if kwargs[key].get('upgradeable_to'):
+                        pwi_profile['upgradeableTo'] = kwargs[key]['upgradeable_to']
+                    self.body['properties']['platformWorkloadIdentityProfile'] = pwi_profile
                 elif key == 'network_profile':
                     self.body['properties']['networkProfile'] = {}
                     for item in kwargs[key].keys():
@@ -748,7 +899,7 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                     if 'subnet_id' in kwargs[key].keys():
                         self.body['properties']['masterProfile']['subnetId'] = kwargs[key].get('subnet_id')
                     if 'disk_encryption_set_id' in kwargs[key].keys():
-                        self.body['properties']['masterProfile']['encryptionAtHost'] = kwargs[key].get('disk_encryption_set_id')
+                        self.body['properties']['masterProfile']['diskEncryptionSetId'] = kwargs[key].get('disk_encryption_set_id')
                     if 'encryption_at_host' in kwargs[key].keys():
                         self.body['properties']['masterProfile']['encryptionAtHost'] = kwargs[key].get('encryption_at_host')
                     self.body['properties']['masterProfile']['vmSize'] = kwargs[key].get('vm_size')
@@ -764,7 +915,7 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
                         worker_profile['vmSize'] = item.get('vm_size')
                         worker_profile['diskSizeGB'] = item.get('disk_size')
                         worker_profile['encryptionAtHost'] = item.get('encryption_at_host')
-                        worker_profile['DiskEncryptionSetId'] = item.get('disk_encryption_set_id')
+                        worker_profile['diskEncryptionSetId'] = item.get('disk_encryption_set_id')
 
                         self.body['properties']['workerProfiles'].append(worker_profile)
                 elif key == 'api_server_profile':
@@ -794,6 +945,14 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
         self.url = self.url.replace('{{ open_shift_managed_cluster_name }}', self.name)
 
         old_response = self.get_resource()
+
+        # Handle managed identity
+        if self.identity:
+            old_identity = self.format_for_helper((old_response or {}).get('identity') or {})
+            update_identity, identity = self.update_managed_identity(
+                new_identity=self.identity,
+                curr_identity=old_identity)
+            self.body['identity'] = self.format_for_body(identity)
 
         if not old_response:
             self.log("OpenShiftManagedCluster instance doesn't exist")
@@ -853,20 +1012,41 @@ class AzureRMOpenShiftManagedClusters(AzureRMModuleBaseExt):
             self.results["type"] = response["type"]
             self.results["location"] = response["location"]
             self.results["properties"] = response["properties"]
+            if response.get("identity"):
+                self.results["identity"] = response["identity"]
 
         return self.results
 
     def create_update_resource(self):
 
         if self.to_do == Actions.Create:
-            required_profile_for_creation = ["workerProfiles", "clusterProfile", "servicePrincipalProfile", "masterProfile"]
+            required_profile_for_creation = ["workerProfiles", "clusterProfile", "masterProfile"]
 
             if 'properties' not in self.body:
                 self.fail('{0} are required for creating a openshift cluster'.format(
-                    '[worker_profile, cluster_profile, service_principal_profile, master_profile]'))
+                    '[worker_profile, cluster_profile, master_profile]'))
             for profile in required_profile_for_creation:
                 if profile not in self.body['properties']:
                     self.fail('{0} is required for creating a openshift cluster'.format(profile))
+
+            # Validate authentication: require either service_principal_profile or identity (not both)
+            has_sp = 'servicePrincipalProfile' in self.body['properties']
+            has_identity = 'identity' in self.body
+            if has_sp and has_identity:
+                self.fail('service_principal_profile and identity are mutually exclusive. '
+                          'Provide either service_principal_profile or identity, not both.')
+            if not has_sp and not has_identity:
+                self.fail('Either service_principal_profile or identity is required for creating a openshift cluster.')
+            if has_identity:
+                pwi_profile = self.body['properties'].get('platformWorkloadIdentityProfile', {})
+                pwi = pwi_profile.get('platformWorkloadIdentities', {})
+                if not pwi_profile or not pwi:
+                    self.fail('platform_workload_identity_profile with at least one platform_workload_identities entry '
+                              'is required when using managed identity.')
+                for operator_name, identity_config in pwi.items():
+                    if not identity_config.get('resourceId'):
+                        self.fail("platform_workload_identities entry '{0}' is missing required field 'resource_id'.".format(
+                            operator_name))
 
             self.set_default()
 

--- a/plugins/modules/azure_rm_openshiftmanagedcluster_info.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster_info.py
@@ -69,6 +69,22 @@ location:
     returned: always
     type: str
     sample: eatus
+identity:
+    description:
+        - The managed service identities assigned to the cluster.
+    returned: when configured
+    type: complex
+    contains:
+        type:
+            description:
+                - Type of managed service identity.
+            type: str
+            sample: UserAssigned
+        userAssignedIdentities:
+            description:
+                - The set of user assigned identities associated with the resource.
+            type: dict
+            sample: {"/subscriptions/xx/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id": {}}
 properties:
     description:
         - Properties of a OpenShift managed cluster.
@@ -116,13 +132,29 @@ properties:
             description:
                 - Service principal.
             type: complex
-            returned: always
+            returned: when configured
             contains:
                 clientId:
                     description: Client ID of the service principal.
                     returned: always
                     type: str
                     sample: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
+        platformWorkloadIdentityProfile:
+            description:
+                - The workload identity profile.
+            type: complex
+            returned: when configured
+            contains:
+                platformWorkloadIdentities:
+                    description:
+                        - Dictionary of operator names to workload identity configurations.
+                    type: dict
+                    returned: always
+                upgradeableTo:
+                    description:
+                        - The OpenShift version the cluster can be upgraded to.
+                    type: str
+                    returned: when available
         networkProfile:
             description:
                 - Configuration for OpenShift networking.
@@ -277,7 +309,7 @@ class AzureRMOpenShiftManagedClustersInfo(AzureRMModuleBaseExt):
         self.status_code = [200]
 
         self.query_parameters = {}
-        self.query_parameters['api-version'] = '2023-09-04'
+        self.query_parameters['api-version'] = '2025-07-25'
         self.header_parameters = {}
         self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
 

--- a/plugins/modules/azure_rm_openshiftmanagedclusterkubeconfig_info.py
+++ b/plugins/modules/azure_rm_openshiftmanagedclusterkubeconfig_info.py
@@ -107,7 +107,7 @@ class AzureRMOpenShiftManagedClustersKubeconfigInfo(AzureRMModuleBaseExt):
         self.status_code = [200]
 
         self.query_parameters = {}
-        self.query_parameters['api-version'] = '2021-09-01-preview'
+        self.query_parameters['api-version'] = '2023-09-04'
         self.header_parameters = {}
         self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
 
@@ -154,7 +154,7 @@ class AzureRMOpenShiftManagedClustersKubeconfigInfo(AzureRMModuleBaseExt):
                                               30)
             results = json.loads(response.body())
         except Exception as e:
-            self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
+            self.fail('Could not get admin kubeconfig for cluster {0}: {1}'.format(self.name, str(e)))
         return self.format_item(results)
 
     def format_item(self, item):

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ azure-mgmt-rdbms==10.2.0b17
 azure-mgmt-recoveryservices==3.0.0
 azure-mgmt-recoveryservicesbackup==9.1.0
 azure-mgmt-redis==14.4.0
+azure-mgmt-redhatopenshift==3.0.0
 azure-mgmt-resource==23.2.0
 azure-mgmt-resourcegraph==8.1.0b3
 azure-mgmt-resourcehealth==1.0.0b6

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/aliases
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/aliases
@@ -1,4 +1,3 @@
 cloud/azure
 shippable/azure/group5
 destructive
-disabled

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Create a new resource group for openshift cluster test
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}-{{ item }}"
-    location: eastus
+    location: australiaeast
   loop:
     - openshiftmanagedcluster01
     - openshiftmanagedcluster02
@@ -70,7 +70,7 @@
 
     - name: Get available openshift cluster versions
       azure.azcollection.azure_rm_openshiftmanagedclusterversion_info:
-        location: "eastus"
+        location: "australiaeast"
       register: ocp_cl_vers
 
     - name: Extract the latest available version
@@ -87,7 +87,7 @@
       azure.azcollection.azure_rm_openshiftmanagedcluster:
         resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
         name: "{{ cluster_name }}"
-        location: "eastus"
+        location: "australiaeast"
         cluster_profile:
           cluster_resource_group_id: "{{ rg_output.resourcegroups[0].id }}"
           domain: "{{ cluster_name }}"
@@ -105,7 +105,7 @@
             disk_size: 128
             count: 3
         master_profile:
-          vm_size: "Standard_D8s_v5"
+          vm_size: "Standard_D8s_v3"
           subnet_id: "{{ master_sub_output.state.id }}"
       register: output
 
@@ -189,7 +189,7 @@
       azure.azcollection.azure_rm_openshiftmanagedcluster:
         resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
         name: "{{ cluster_name }}"
-        location: "eastus"
+        location: "australiaeast"
         state: absent
       register: output
 
@@ -207,7 +207,7 @@
         managed_identity_test_unique: 'arocluster'
         managed_identity_unique: "{{ item }}"
         managed_identity_action: 'create'
-        managed_identity_location: "eastus"
+        managed_identity_location: "australiaeast"
         new_resource_group: "{{ resource_group }}-openshiftmanagedcluster02"
       with_items:
         - '1'
@@ -216,7 +216,7 @@
       azure.azcollection.azure_rm_openshiftmanagedcluster:
         resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
         name: "{{ cluster_name }}mi"
-        location: "eastus"
+        location: "australiaeast"
         identity:
           type: UserAssigned
           user_assigned_identities:
@@ -240,7 +240,7 @@
             disk_size: 128
             count: 3
         master_profile:
-          vm_size: "Standard_D8s_v5"
+          vm_size: "Standard_D8s_v3"
           subnet_id: "{{ master_sub_output.state.id }}"
       check_mode: true
       register: mi_check_output
@@ -253,7 +253,7 @@
       azure.azcollection.azure_rm_openshiftmanagedcluster:
         resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
         name: "{{ cluster_name }}mi"
-        location: "eastus"
+        location: "australiaeast"
         identity:
           type: UserAssigned
           user_assigned_identities:
@@ -279,7 +279,7 @@
             disk_size: 128
             count: 3
         master_profile:
-          vm_size: "Standard_D8s_v5"
+          vm_size: "Standard_D8s_v3"
           subnet_id: "{{ master_sub_output.state.id }}"
       register: mutual_excl_output
       ignore_errors: true
@@ -294,7 +294,7 @@
         managed_identity_test_unique: 'arocluster'
         managed_identity_unique: "{{ item }}"
         managed_identity_action: 'delete'
-        managed_identity_location: "eastus"
+        managed_identity_location: "australiaeast"
         new_resource_group: "{{ resource_group }}-openshiftmanagedcluster02"
       with_items:
         - '1'

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -89,7 +89,7 @@
         name: "{{ cluster_name }}"
         location: "australiaeast"
         cluster_profile:
-          cluster_resource_group_id: "{{ rg_output.resourcegroups[0].id }}"
+          cluster_resource_group_id: "/subscriptions/{{ lookup('env', 'AZURE_SUBSCRIPTION_ID') }}/resourceGroups/{{ resource_group }}-openshiftmanagedcluster-aro"
           domain: "{{ cluster_name }}"
           version: "{{ ocp_version }}"
         service_principal_profile:
@@ -237,7 +237,7 @@
             id:
               - "{{ managed_identity_ids[0] }}"
         cluster_profile:
-          cluster_resource_group_id: "{{ rg_output.resourcegroups[0].id }}"
+          cluster_resource_group_id: "/subscriptions/{{ lookup('env', 'AZURE_SUBSCRIPTION_ID') }}/resourceGroups/{{ resource_group }}-openshiftmanagedcluster-aromi"
           domain: "{{ cluster_name }}mi"
           version: "{{ ocp_version }}"
         platform_workload_identity_profile:
@@ -277,7 +277,7 @@
           client_id: "{{ azure_client_id }}"
           client_secret: "{{ azure_secret }}"
         cluster_profile:
-          cluster_resource_group_id: "{{ rg_output.resourcegroups[0].id }}"
+          cluster_resource_group_id: "/subscriptions/{{ lookup('env', 'AZURE_SUBSCRIPTION_ID') }}/resourceGroups/{{ resource_group }}-openshiftmanagedcluster-aromi"
           domain: "{{ cluster_name }}mi"
         platform_workload_identity_profile:
           platform_workload_identities:
@@ -321,3 +321,5 @@
       loop:
         - openshiftmanagedcluster01
         - openshiftmanagedcluster02
+        - openshiftmanagedcluster-aro
+        - openshiftmanagedcluster-aromi

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -75,7 +75,9 @@
 
     - name: Extract the latest available version
       ansible.builtin.set_fact:
-        ocp_version: "{{ ocp_cl_vers.versions | community.general.version_sort | last }}"
+        ocp_version: "{{ item }}"
+      loop: "{{ ocp_cl_vers.versions }}"
+      when: ocp_version is not defined or item is version(ocp_version, '>')
 
     - name: Assert that selected ocp version is not empty
       ansible.builtin.assert:

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -105,7 +105,7 @@
             disk_size: 128
             count: 3
         master_profile:
-          vm_size: "Standard_D8s_v3"
+          vm_size: "Standard_D8s_v5"
           subnet_id: "{{ master_sub_output.state.id }}"
       register: output
 
@@ -240,7 +240,7 @@
             disk_size: 128
             count: 3
         master_profile:
-          vm_size: "Standard_D8s_v3"
+          vm_size: "Standard_D8s_v5"
           subnet_id: "{{ master_sub_output.state.id }}"
       check_mode: true
       register: mi_check_output
@@ -279,7 +279,7 @@
             disk_size: 128
             count: 3
         master_profile:
-          vm_size: "Standard_D8s_v3"
+          vm_size: "Standard_D8s_v5"
           subnet_id: "{{ master_sub_output.state.id }}"
       register: mutual_excl_output
       ignore_errors: true

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -194,10 +194,112 @@
     - name: Assert the cluster deleted
       ansible.builtin.assert:
         that: output is changed
+
+    - name: Create identities array for managed identity test
+      ansible.builtin.set_fact:
+        managed_identity_ids: []
+
+    - name: Create user managed identity for ARO cluster
+      ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
+      vars:
+        managed_identity_test_unique: 'arocluster'
+        managed_identity_unique: "{{ item }}"
+        managed_identity_action: 'create'
+        managed_identity_location: "eastus"
+        new_resource_group: "{{ resource_group }}-openshiftmanagedcluster02"
+      with_items:
+        - '1'
+
+    - name: Create openshift cluster with managed identity (check mode)
+      azure.azcollection.azure_rm_openshiftmanagedcluster:
+        resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
+        name: "{{ cluster_name }}mi"
+        location: "eastus"
+        identity:
+          type: UserAssigned
+          user_assigned_identities:
+            id:
+              - "{{ managed_identity_ids[0] }}"
+        cluster_profile:
+          cluster_resource_group_id: "{{ rg_output.resourcegroups[0].id }}"
+          domain: "{{ cluster_name }}mi"
+          version: "{{ ocp_version }}"
+        platform_workload_identity_profile:
+          platform_workload_identities:
+            ServiceOperator.ARO.OpenShift.IO:
+              resource_id: "{{ managed_identity_ids[0] }}"
+        network_profile:
+          pod_cidr: "10.128.0.0/14"
+          service_cidr: "172.30.0.0/16"
+        worker_profiles:
+          - name: worker
+            vm_size: "Standard_D4s_v3"
+            subnet_id: "{{ worker_sub_output.state.id }}"
+            disk_size: 128
+            count: 3
+        master_profile:
+          vm_size: "Standard_D8s_v3"
+          subnet_id: "{{ master_sub_output.state.id }}"
+      check_mode: true
+      register: mi_check_output
+
+    - name: Assert the managed identity cluster check mode returns changed
+      ansible.builtin.assert:
+        that: mi_check_output is changed
+
+    - name: Verify mutual exclusion - should fail with both SP and identity
+      azure.azcollection.azure_rm_openshiftmanagedcluster:
+        resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
+        name: "{{ cluster_name }}mi"
+        location: "eastus"
+        identity:
+          type: UserAssigned
+          user_assigned_identities:
+            id:
+              - "{{ managed_identity_ids[0] }}"
+        service_principal_profile:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        cluster_profile:
+          cluster_resource_group_id: "{{ rg_output.resourcegroups[0].id }}"
+          domain: "{{ cluster_name }}mi"
+        platform_workload_identity_profile:
+          platform_workload_identities:
+            ServiceOperator.ARO.OpenShift.IO:
+              resource_id: "{{ managed_identity_ids[0] }}"
+        network_profile:
+          pod_cidr: "10.128.0.0/14"
+          service_cidr: "172.30.0.0/16"
+        worker_profiles:
+          - name: worker
+            vm_size: "Standard_D4s_v3"
+            subnet_id: "{{ worker_sub_output.state.id }}"
+            disk_size: 128
+            count: 3
+        master_profile:
+          vm_size: "Standard_D8s_v3"
+          subnet_id: "{{ master_sub_output.state.id }}"
+      register: mutual_excl_output
+      ignore_errors: true
+
+    - name: Assert mutual exclusion fails
+      ansible.builtin.assert:
+        that: mutual_excl_output is failed
+
+    - name: Delete user managed identities
+      ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
+      vars:
+        managed_identity_test_unique: 'arocluster'
+        managed_identity_unique: "{{ item }}"
+        managed_identity_action: 'delete'
+        managed_identity_location: "eastus"
+        new_resource_group: "{{ resource_group }}-openshiftmanagedcluster02"
+      with_items:
+        - '1'
   always:
     - name: Force delete the resource group
       azure.azcollection.azure_rm_resourcegroup:
-        name: "{{ resource_group }}-openshiftmanagedcluster01"
+        name: "{{ resource_group }}-{{ item }}"
         force_delete_nonempty: true
         state: absent
       loop:

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -141,14 +141,19 @@
       ansible.builtin.assert:
         that: output['clusters'] | length >= 1
 
-    - name: Wait for cluster provisioning to succeed
+    - name: Wait for cluster provisioning to complete
       azure.azcollection.azure_rm_openshiftmanagedcluster_info:
         resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
         name: "{{ cluster_name }}"
       register: cluster_wait
-      until: cluster_wait['clusters']['properties']['provisioningState'] == 'Succeeded'
+      until: cluster_wait['clusters']['properties']['provisioningState'] in ['Succeeded', 'Failed']
       retries: 120
       delay: 60
+
+    - name: Fail if cluster provisioning failed
+      ansible.builtin.fail:
+        msg: "Cluster provisioning failed: {{ cluster_wait['clusters']['properties'] }}"
+      when: cluster_wait['clusters']['properties']['provisioningState'] == 'Failed'
 
     - name: Fetch kubeconfig file to register
       azure.azcollection.azure_rm_openshiftmanagedclusterkubeconfig_info:

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -10,7 +10,7 @@
   block:
     - name: Set variables
       ansible.builtin.set_fact:
-        cluster_name: "{{ resource_group | hash('md5') | truncate(8, True, '') }}"
+        cluster_name: "a{{ resource_group | hash('md5') | truncate(7, True, '') }}"
 
     - name: Get resource group info
       azure.azcollection.azure_rm_resourcegroup_info:

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -131,7 +131,7 @@
 
     - name: Assert the cluster facts
       ansible.builtin.assert:
-        that: output['clusters']['name'] == "{{ cluster_name }}"
+        that: output['clusters']['name'] == cluster_name
 
     - name: Get all clusters
       azure.azcollection.azure_rm_openshiftmanagedcluster_info:
@@ -140,6 +140,15 @@
     - name: Assert all cluster
       ansible.builtin.assert:
         that: output['clusters'] | length >= 1
+
+    - name: Wait for cluster provisioning to succeed
+      azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+        resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
+        name: "{{ cluster_name }}"
+      register: cluster_wait
+      until: cluster_wait.clusters.provisioning_state == 'Succeeded'
+      retries: 120
+      delay: 60
 
     - name: Fetch kubeconfig file to register
       azure.azcollection.azure_rm_openshiftmanagedclusterkubeconfig_info:

--- a/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_openshiftmanagedcluster/tasks/main.yml
@@ -146,7 +146,7 @@
         resource_group: "{{ resource_group }}-openshiftmanagedcluster01"
         name: "{{ cluster_name }}"
       register: cluster_wait
-      until: cluster_wait.clusters.provisioning_state == 'Succeeded'
+      until: cluster_wait['clusters']['properties']['provisioningState'] == 'Succeeded'
       retries: 120
       delay: 60
 


### PR DESCRIPTION
##### SUMMARY
Fix #2212.

- Add `identity` parameter (UserAssigned managed identity) using the collection's standard `managed_identity_multiple_spec` and `azure_identity_multiple` doc fragment
- Add `platform_workload_identity_profile` parameter for mapping ARO operator names to user-assigned managed identity resource IDs
- Make `service_principal_profile` optional with mutual exclusion validation against `identity`
- Bump API version from `2023-09-04` to `2025-07-25` (GA with identity support)
- Add `azure-mgmt-redhatopenshift==3.0.0` to requirements for SDK identity model imports
- Update info module RETURN docs to document new `identity` and `platformWorkloadIdentityProfile` fields
- Fix pre-existing bugs: `ClientId` casing, `diskEncryptionSetId` mapping for master/worker profiles
- Fix test cleanup loop not deleting all resource groups


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_openshiftmanagedcluster.py
plugins/modules/azure_rm_openshiftmanagedcluster_info.py


----
References:
- https://learn.microsoft.com/en-us/rest/api/openshift/open-shift-clusters/create-or-update?view=rest-openshift-2025-07-25
- https://learn.microsoft.com/en-us/azure/openshift/howto-create-openshift-cluster
