### PR TITLE
fix: add missing type field to Registry and Replication create calls

### DIFF
--- a/plugins/modules/azure_rm_containerregistry.py
+++ b/plugins/modules/azure_rm_containerregistry.py
@@ -338,6 +338,7 @@ class AzureRMContainerRegistry(AzureRMModuleBaseExt):
                             registry_name=self.name,
                             registry=Registry(
                                 location=self.location,
+                                type="Microsoft.ContainerRegistry/registries",
                                 sku=Sku(
                                     name=self.sku
                                 ),

--- a/plugins/modules/azure_rm_containerregistryreplication.py
+++ b/plugins/modules/azure_rm_containerregistryreplication.py
@@ -238,6 +238,7 @@ class AzureRMReplications(AzureRMModuleBase):
             if self.to_do == Actions.Create:
                 replication = Replication(
                     location=self.location,
+                    type="Microsoft.ContainerRegistry/registries/replications",
                 )
                 response = self.containerregistry_client.replications.begin_create(resource_group_name=self.resource_group,
                                                                                    registry_name=self.registry_name,


### PR DESCRIPTION
##### SUMMARY
azure.azcollection.azure_rm_containerregistry fails when creating/updating ACR, 400 (Bad Request)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure.azcollection.azure_rm_containerregistry

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

[ERROR]: Task failed: Module failed: Error creating / updating the container registry instance: Operation returned an invalid status 'Bad Request'
Content: {"errors":{"Type":["The Type field is required."]},"type":"https://tools.ietf.org/html/rfc9110#section-15.5.1","title":"One or more validation errors occurred.","status":400,"extensions":{"traceId":"00-cfac9e4738b96f8700ae47dc93bbab5d-8f579f1620a2fe23-01"}}

This was fixed by adding the "type" property to the module's function.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
