### PR TITLE
Fix #883: `managed_disk_type` for data disks was ignored when creating a VM from a custom image.

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -2668,7 +2668,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                 elif powerstate_change == 'deallocated':
                     self.deallocate_vm()
                 elif powerstate_change == 'generalized':
-                    self.power_off_vm()
+                    current_powerstate = self.results['ansible_facts']['azure_vm']['powerstate']
+                    if current_powerstate not in ('deallocated', 'deallocating', 'stopped'):
+                        self.power_off_vm()
                     self.generalize_vm()
 
                 self.results['ansible_facts']['azure_vm'] = self.serialize_vm(self.get_vm())

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -2669,8 +2669,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     self.deallocate_vm()
                 elif powerstate_change == 'generalized':
                     current_powerstate = self.results['ansible_facts']['azure_vm']['powerstate']
-                    if current_powerstate not in ('deallocated', 'deallocating', 'stopped'):
-                        self.power_off_vm()
+                    if current_powerstate != 'deallocated':
+                        self.deallocate_vm()
                     self.generalize_vm()
 
                 self.results['ansible_facts']['azure_vm'] = self.serialize_vm(self.get_vm())

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -350,6 +350,18 @@ options:
                     - None
                     - ReadOnly
                     - ReadWrite
+            create_option:
+                description:
+                    - Specifies how the data disk should be created.
+                    - Use C(Empty) to create a new blank data disk.
+                    - Use C(FromImage) to create the data disk from a custom image that includes data disks at the matching LUN.
+                    - When set to C(FromImage), you can combine with I(managed_disk_type) to override the disk type defined in the image.
+                    - Not used when I(managed_disk_id) is specified (attach mode is chosen automatically).
+                type: str
+                default: Empty
+                choices:
+                    - Empty
+                    - FromImage
             delete_option:
                 description:
                     - Specifies the delete behavior for the data disk when deleting the VM.
@@ -814,6 +826,24 @@ EXAMPLES = '''
     admin_password: "{{ password }}"
     image:
       id: '{{image_id}}'
+
+- name: Create a VM from a custom image and override data disk types
+  azure_rm_virtualmachine:
+    resource_group: myResourceGroup
+    name: testvm001
+    vm_size: Standard_DS1_v2
+    admin_username: "{{ username }}"
+    admin_password: "{{ password }}"
+    managed_disk_type: StandardSSD_LRS
+    image:
+      id: '{{ image_id }}'
+    data_disks:
+      - lun: 0
+        create_option: FromImage
+        managed_disk_type: StandardSSD_LRS
+      - lun: 1
+        create_option: FromImage
+        managed_disk_type: StandardSSD_LRS
 
 - name: Create a VM with spcified OS disk size
   azure_rm_virtualmachine:
@@ -1299,6 +1329,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     storage_container_name=dict(type='str', default='vhds'),
                     storage_blob_name=dict(type='str'),
                     caching=dict(type='str', choices=['None', 'ReadOnly', 'ReadWrite']),
+                    create_option=dict(type='str', choices=['Empty', 'FromImage'], default='Empty'),
                     delete_option=dict(type='str', choices=['Delete', 'Detach'])
                 )
             ),
@@ -2207,6 +2238,18 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                             if data_disk.get('managed_disk_id'):
                                 create_option = self.compute_models.DiskCreateOptionTypes.attach
                                 data_disk_managed_disk = self.compute_models.ManagedDiskParameters(id=data_disk.get('managed_disk_id'))
+                            elif data_disk.get('create_option') == 'FromImage':
+                                create_option = self.compute_models.DiskCreateOptionTypes.from_image
+                                if data_disk.get('managed_disk_type'):
+                                    data_disk_managed_disk = self.compute_models.ManagedDiskParameters(storage_account_type=data_disk['managed_disk_type'])
+                                    if data_disk.get('disk_encryption_set'):
+                                        data_disk_managed_disk.disk_encryption_set = self.compute_models.DiskEncryptionSetParameters(
+                                            id=data_disk['disk_encryption_set']
+                                        )
+                                else:
+                                    data_disk_managed_disk = None
+                                disk_name = self.name + "-datadisk-" + str(count)
+                                count += 1
                             else:
                                 create_option = self.compute_models.DiskCreateOptionTypes.empty
 

--- a/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
@@ -56,6 +56,10 @@ all:
       network: 10.42.3.0/24
       subnet: 10.42.3.0/28
 
+    azure_test_fromimage_disk:
+      network: 10.42.10.0/24
+      subnet: 10.42.10.0/28
+
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_fromimage_disk.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_fromimage_disk.yml
@@ -1,0 +1,243 @@
+- name: Set variables
+  ansible.builtin.include_tasks: setup.yml
+
+# Phase 1: Create a source VM with Premium_LRS data disks
+- name: Create source VM with Premium_LRS data disks
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+    admin_username: "testuser"
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/testuser/.ssh/authorized_keys
+        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    image:
+      offer: 0001-com-ubuntu-server-focal
+      publisher: Canonical
+      sku: 20_04-lts
+      version: latest
+    data_disks:
+      - lun: 0
+        disk_size_gb: 4
+        managed_disk_type: Premium_LRS
+      - lun: 1
+        disk_size_gb: 4
+        managed_disk_type: Premium_LRS
+  register: source_vm
+
+- name: Assert source VM created
+  ansible.builtin.assert:
+    that:
+      - source_vm.changed
+
+# Phase 2: Deallocate, generalize, capture image
+- name: Deallocate source VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+    started: false
+    allocated: false
+
+- name: Generalize source VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+    generalized: true
+
+- name: Capture custom image from source VM
+  azure.azcollection.azure_rm_image:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-image"
+    source: "{{ vm_name }}-src"
+    os_type: Linux
+  register: image_result
+
+- name: Set custom image id
+  ansible.builtin.set_fact:
+    custom_image_id: "{{ image_result.id }}"
+
+# Test 1: create_option=FromImage with managed_disk_type override
+- name: Create VM from custom image with create_option FromImage and disk type override
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-fi"
+    admin_username: "testuser"
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/testuser/.ssh/authorized_keys
+        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    image:
+      id: "{{ custom_image_id }}"
+    data_disks:
+      - lun: 0
+        create_option: FromImage
+        managed_disk_type: StandardSSD_LRS
+      - lun: 1
+        create_option: FromImage
+        managed_disk_type: StandardSSD_LRS
+  register: vm_fromimage
+
+- name: Assert FromImage VM was created
+  ansible.builtin.assert:
+    that:
+      - vm_fromimage.changed
+
+- name: Get FromImage VM info
+  azure.azcollection.azure_rm_virtualmachine_info:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-fi"
+  register: vm_fromimage_info
+
+- name: Assert data disks are StandardSSD_LRS not Premium_LRS
+  ansible.builtin.assert:
+    that:
+      - vm_fromimage_info.vms[0].data_disks | length == 2
+      - vm_fromimage_info.vms[0].data_disks[0].managed_disk_type == 'StandardSSD_LRS'
+      - vm_fromimage_info.vms[0].data_disks[1].managed_disk_type == 'StandardSSD_LRS'
+
+# Test 2: create_option=FromImage without managed_disk_type (inherit from image)
+- name: Create VM from custom image with create_option FromImage without disk type override
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-fi2"
+    admin_username: "testuser"
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/testuser/.ssh/authorized_keys
+        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    image:
+      id: "{{ custom_image_id }}"
+    data_disks:
+      - lun: 0
+        create_option: FromImage
+      - lun: 1
+        create_option: FromImage
+  register: vm_fromimage_inherit
+
+- name: Assert FromImage inherit VM was created
+  ansible.builtin.assert:
+    that:
+      - vm_fromimage_inherit.changed
+
+- name: Get FromImage inherit VM info
+  azure.azcollection.azure_rm_virtualmachine_info:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-fi2"
+  register: vm_fromimage_inherit_info
+
+- name: Assert data disks inherited Premium_LRS from image
+  ansible.builtin.assert:
+    that:
+      - vm_fromimage_inherit_info.vms[0].data_disks | length == 2
+      - vm_fromimage_inherit_info.vms[0].data_disks[0].managed_disk_type == 'Premium_LRS'
+      - vm_fromimage_inherit_info.vms[0].data_disks[1].managed_disk_type == 'Premium_LRS'
+
+# Test 3: Default create_option (Empty)
+- name: Create VM with default empty data disk
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-em"
+    admin_username: "testuser"
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/testuser/.ssh/authorized_keys
+        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    image:
+      offer: 0001-com-ubuntu-server-focal
+      publisher: Canonical
+      sku: 20_04-lts
+      version: latest
+    data_disks:
+      - lun: 0
+        disk_size_gb: 4
+        managed_disk_type: Standard_LRS
+  register: vm_empty
+
+- name: Assert empty disk VM was created
+  ansible.builtin.assert:
+    that:
+      - vm_empty.changed
+
+- name: Get empty disk VM info
+  azure.azcollection.azure_rm_virtualmachine_info:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-em"
+  register: vm_empty_info
+
+- name: Assert empty data disk is Standard_LRS
+  ansible.builtin.assert:
+    that:
+      - vm_empty_info.vms[0].data_disks | length == 1
+      - vm_empty_info.vms[0].data_disks[0].managed_disk_type == 'Standard_LRS'
+
+# Cleanup
+- name: Delete FromImage VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-fi"
+    remove_on_absent: all_autocreated
+    state: absent
+
+- name: Delete FromImage inherit VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-fi2"
+    remove_on_absent: all_autocreated
+    state: absent
+
+- name: Delete empty disk VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-em"
+    remove_on_absent: all_autocreated
+    state: absent
+
+- name: Delete source VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+    remove_on_absent: all_autocreated
+    state: absent
+
+- name: Delete custom image
+  azure.azcollection.azure_rm_image:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-image"
+    state: absent
+
+- name: Destroy subnet
+  azure.azcollection.azure_rm_subnet:
+    resource_group: "{{ resource_group }}-vm01"
+    virtual_network: "{{ network_name }}"
+    name: "{{ subnet_name }}"
+    state: absent
+
+- name: Destroy virtual network
+  azure.azcollection.azure_rm_virtualnetwork:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ network_name }}"
+    state: absent
+
+- name: Destroy availability set
+  azure.azcollection.azure_rm_availabilityset:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ availability_set }}"
+    state: absent
+
+- name: Destroy storage account
+  azure.azcollection.azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ storage_account }}"
+    state: absent

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_fromimage_disk.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_fromimage_disk.yml
@@ -11,7 +11,7 @@
     ssh_public_keys:
       - path: /home/testuser/.ssh/authorized_keys
         key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     image:
@@ -69,7 +69,7 @@
     ssh_public_keys:
       - path: /home/testuser/.ssh/authorized_keys
         key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     image:
@@ -111,7 +111,7 @@
     ssh_public_keys:
       - path: /home/testuser/.ssh/authorized_keys
         key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     image:
@@ -151,7 +151,7 @@
     ssh_public_keys:
       - path: /home/testuser/.ssh/authorized_keys
         key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     image:

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_fromimage_disk.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_fromimage_disk.yml
@@ -217,6 +217,12 @@
     name: "{{ vm_name }}-image"
     state: absent
 
+- name: Delete the network interface
+  azure.azcollection.azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ interface_name }}"
+    state: absent
+
 - name: Destroy subnet
   azure.azcollection.azure_rm_subnet:
     resource_group: "{{ resource_group }}-vm01"


### PR DESCRIPTION
##### SUMMARY
Fix #883

**Root Cause**
In `azure_rm_virtualmachine.py`, data disks without `managed_disk_id` always received `create_option=Empty`. When creating a VM from a custom image that includes data disks, Azure requires `create_option=FromImage` for the data disk type override to take effect.

**Changes**
- Added `create_option` parameter to `data_disks` arg spec (`Empty` | `FromImage`, default `Empty`)
- Added `FromImage` branch in data disk creation logic that correctly sets `DiskCreateOptionTypes.from_image` and applies `managed_disk_type` override when specified
- Changed generalization flow to use deallocate_vm() instead of power_off_vm(), skipping deallocation if the VM is already deallocated.
- Existing `Empty` and `Attach` code paths are untouched

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachine.py