### PR TITLE
Fix 'occured' -> 'occurred' typos in Azure storage/monitor modules (3 files)

### DIFF
--- a/plugins/modules/azure_rm_monitordatacollectionendpoint.py
+++ b/plugins/modules/azure_rm_monitordatacollectionendpoint.py
@@ -331,7 +331,7 @@ class AzureRMDataCollectionRuleEndpoint(AzureRMModuleBaseExt):
                                                                                                              data_collection_endpoint_name=self.name,
                                                                                                              body=body)
         except Exception as ex:
-            self.fail("Create the data collection endponts occured exception, Exception as {0}".format(ex))
+            self.fail("Create the data collection endponts occurred exception, Exception as {0}".format(ex))
 
         if response:
             return response.as_dict()
@@ -344,7 +344,7 @@ class AzureRMDataCollectionRuleEndpoint(AzureRMModuleBaseExt):
             self.monitor_management_client_data_collection_rules.data_collection_endpoints.delete(resource_group_name=self.resource_group,
                                                                                                   data_collection_endpoint_name=self.name)
         except Exception as ex:
-            self.fail("Delete the data collection endponts occured exception, Exception as {0}".format(ex))
+            self.fail("Delete the data collection endponts occurred exception, Exception as {0}".format(ex))
 
 
 def main():

--- a/plugins/modules/azure_rm_monitordatacollectionruleassociation.py
+++ b/plugins/modules/azure_rm_monitordatacollectionruleassociation.py
@@ -242,7 +242,7 @@ class AzureRMDataCollectionRuleAssociation(AzureRMModuleBase):
                                                                                                                      association_name=self.association_name,
                                                                                                                      body=body)
         except Exception as ex:
-            self.fail("Creates or update the association occured exception, Exception as {0}".format(ex))
+            self.fail("Creates or update the association occurred exception, Exception as {0}".format(ex))
         return response.as_dict()
 
     def delete_association(self):
@@ -253,7 +253,7 @@ class AzureRMDataCollectionRuleAssociation(AzureRMModuleBase):
             self.monitor_management_client_data_collection_rules.data_collection_rule_associations.delete(resource_uri=self.resource_uri,
                                                                                                           association_name=self.association_name)
         except Exception as ex:
-            self.fail("Deletes the association occured exception, Exception as {0}".format(ex))
+            self.fail("Deletes the association occurred exception, Exception as {0}".format(ex))
 
 
 def main():

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1376,7 +1376,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         try:
             account_obj = self.storage_client.storage_accounts.get_properties(self.resource_group, self.name, expand='georeplicationstats')
         except Exception as exc:
-            self.fail("Error occured while acquiring geo-replication status. {0}".format(str(exc)))
+            self.fail("Error occurred while acquiring geo-replication status. {0}".format(str(exc)))
 
         if account_obj.failover_in_progress:
             self.fail("Storage account is already in process of failing over to secondary region.")
@@ -1388,7 +1388,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             poller = self.storage_client.storage_accounts.begin_failover(self.resource_group, self.name)
             result = self.get_poller_result(poller)
         except Exception as exc:
-            self.fail("Error occured while attempting a failover operation. {0}".format(str(exc)))
+            self.fail("Error occurred while attempting a failover operation. {0}".format(str(exc)))
 
         self.results['changed'] = True
         return result


### PR DESCRIPTION
Fix 6 instances of `occured` → `occurred` in error messages:

| File | Instances |
|------|-----------|
| `azure_rm_monitordatacollectionendpoint.py` | 2 |
| `azure_rm_monitordatacollectionruleassociation.py` | 2 |
| `azure_rm_storageaccount.py` | 2 |

Note: `azure_rm_resourcehealthstates_info.py` also contains `occured_time` but that's a field name from Azure's Resource Health API response, so it's left as-is to preserve API contract.

All fixes are in `self.fail()` error messages — user-visible in Ansible task output.