### PR TITLE
Fix azure arc role proxy handling during download of install script

### DIFF
--- a/roles/azure_arc/defaults/main.yml
+++ b/roles/azure_arc/defaults/main.yml
@@ -4,6 +4,9 @@ azure_arc_tags:
   ArcSQLServerExtensionDeployment: "Disabled"
 azure_arc_cloud: AzureCloud
 
+# Default url for arc install script download
+azure_arc_azcmagent_install_script_url: https://aka.ms/azcmagent
+
 # Mandatory variables for role:
 # azure_arc_resource_group: NoDefault
 # azure_arc_subscription_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -13,3 +16,11 @@ azure_arc_cloud: AzureCloud
 # proxy:
 #   hostname: proxy.company.tld
 #   port: 8080
+
+# azure_arc_application_id and azure_arc_client_secret are optional variables
+# They are needed if you are using a service principal
+# if you operate with a single subscription you can also set them via environment variables AZURE_CLIENT_ID and AZURE_CLIENT_SECRET
+# or via another auth source
+# example:
+# azure_arc_application_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# azure_arc_client_secret: xxxxxxxxxxxxxxxxxxxx

--- a/roles/azure_arc/tasks/linux_connect.yml
+++ b/roles/azure_arc/tasks/linux_connect.yml
@@ -5,7 +5,7 @@
   no_log: true
   ansible.builtin.command:
     argv:
-      - /usr/bin/azcmagent
+      - azcmagent
       - connect
       - --resource-group
       - "{{ azure_arc_resource_group }}"

--- a/roles/azure_arc/tasks/linux_install.yml
+++ b/roles/azure_arc/tasks/linux_install.yml
@@ -23,13 +23,21 @@
   ansible.builtin.set_fact:
     azure_arc_azcmagent_install_script_path: "{{ azure_arc_tmpdir.path }}/azcmagent-linux.sh"
 
+- name: Set fact for http/https proxy if defined in proxy variable
+  when: azure_arc_proxy_url is defined
+  ansible.builtin.set_fact:
+    azure_arc_proxy_environment:
+      http_proxy: "{{ azure_arc_proxy_url }}"
+      https_proxy: "{{ azure_arc_proxy_url }}"
+
 - name: Download azcmagent install script
   when: not azure_arc_azcmagent_installed
   become: true
   ansible.builtin.get_url:
-    url: https://aka.ms/azcmagent
+    url: "{{ azure_arc_azcmagent_install_script_url }}"
     dest: "{{ azure_arc_azcmagent_install_script_path }}"
     mode: '0700'
+  environment: "{{ azure_arc_proxy_environment | default({}) }}"
 
 - name: Initialize azcmagent install script argv
   when: not azure_arc_azcmagent_installed

--- a/roles/azure_arc/tasks/main.yml
+++ b/roles/azure_arc/tasks/main.yml
@@ -78,6 +78,10 @@
       # This command produces output that includes an access token
       no_log: true
       azure.azcollection.azure_rm_accesstoken_info:
+        client_id: "{{ azure_arc_application_id | default(omit) }}"
+        secret: "{{ azure_arc_client_secret | default(omit) }}"
+        tenant: "{{ azure_arc_tenant_id | default(omit) }}"
+        subscription_id: "{{ azure_arc_subscription_id | default(omit) }}"
         scopes:
           - https://management.azure.com/.default
         auth_source: "{{ auth_source | default(omit) }}"


### PR DESCRIPTION
Main reason:
Fix azure arc role proxy handling during download of install script


Side fixes:
add azure_arc_azcmagent_install_script_url to make download url configureable add azure_arc_application_id and azure_arc_client_secret as optional vars to enable service principal usage for access token make azcmagent executeable consistent (one invocation used full path, others rely on $PATH)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
roles/azure_arc


@stefanoochoa please verify this is also okay with you :)