### PR TITLE
Deprecate allow_remote_vnet_to_use_hub_vnet_gateways and allow_hub_to_remote_vnet_transit in azure_rm_virtualhubconnection

### DIFF
--- a/plugins/modules/azure_rm_virtualhubconnection.py
+++ b/plugins/modules/azure_rm_virtualhubconnection.py
@@ -38,11 +38,15 @@ options:
         type: bool
     allow_remote_vnet_to_use_hub_vnet_gateways:
         description:
-            - Allow RemoteVnet to use Virtual Hub's gateways.
+            - (Deprecated) Allow RemoteVnet to use Virtual Hub's gateways.
+            - This parameter has been deprecated and is ignored by the service.
+            - It will be removed in later version release.
         type: bool
     allow_hub_to_remote_vnet_transit:
         description:
-            - VirtualHub to RemoteVnet transit to enabled or not.
+            - (Deprecated) VirtualHub to RemoteVnet transit to enabled or not.
+            - This parameter has been deprecated and is ignored by the service.
+            - It will be removed in later version release.
         type: bool
     remote_virtual_network:
         description:
@@ -126,8 +130,6 @@ EXAMPLES = '''
     vhub_name: testhub
     name: Myconnection
     enable_internet_security: false
-    allow_remote_vnet_to_use_hub_vnet_gateways: true
-    allow_hub_to_remote_vnet_transit: true
     remote_virtual_network:
       id: /subscriptions/xxx-xxx/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/testvnet
     routing_configuration:
@@ -268,13 +270,15 @@ state:
             sample: Succeeded
         allow_hub_to_remote_vnet_transit:
             description:
-                - Enable hub to remote VNet transit.
+                - (Deprecated) Enable hub to remote VNet transit.
+                - This field has been deprecated and will be removed in later version release.
             returned: always
             type: bool
             sample: true
         allow_remote_vnet_to_use_hub_vnet_gateways:
             description:
-                - Allow remote VNet to use hub's VNet gateways.
+                - (Deprecated) Allow remote VNet to use hub's VNet gateways.
+                - This field has been deprecated and will be removed in later version release.
             returned: always
             type: bool
             sample: true
@@ -325,10 +329,14 @@ class AzureRMVirtualHubConnection(AzureRMModuleBaseExt):
                 type='bool'
             ),
             allow_remote_vnet_to_use_hub_vnet_gateways=dict(
-                type='bool'
+                type='bool',
+                removed_in_version='3.17.0',
+                removed_from_collection='azure.azcollection'
             ),
             allow_hub_to_remote_vnet_transit=dict(
-                type='bool'
+                type='bool',
+                removed_in_version='3.17.0',
+                removed_from_collection='azure.azcollection'
             ),
             remote_virtual_network=dict(
                 type='dict',

--- a/plugins/modules/azure_rm_virtualhubconnection.py
+++ b/plugins/modules/azure_rm_virtualhubconnection.py
@@ -40,13 +40,13 @@ options:
         description:
             - (Deprecated) Allow RemoteVnet to use Virtual Hub's gateways.
             - This parameter has been deprecated and is ignored by the service.
-            - It will be removed in later version release.
+            - It will be removed in next major version release.
         type: bool
     allow_hub_to_remote_vnet_transit:
         description:
             - (Deprecated) VirtualHub to RemoteVnet transit to enabled or not.
             - This parameter has been deprecated and is ignored by the service.
-            - It will be removed in later version release.
+            - It will be removed in next major version release.
         type: bool
     remote_virtual_network:
         description:

--- a/plugins/modules/azure_rm_virtualhubconnection.py
+++ b/plugins/modules/azure_rm_virtualhubconnection.py
@@ -271,14 +271,14 @@ state:
         allow_hub_to_remote_vnet_transit:
             description:
                 - (Deprecated) Enable hub to remote VNet transit.
-                - This field has been deprecated and will be removed in later version release.
+                - This field has been deprecated and will be removed in next major version release.
             returned: always
             type: bool
             sample: true
         allow_remote_vnet_to_use_hub_vnet_gateways:
             description:
                 - (Deprecated) Allow remote VNet to use hub's VNet gateways.
-                - This field has been deprecated and will be removed in later version release.
+                - This field has been deprecated and will be removed in next major version release.
             returned: always
             type: bool
             sample: true
@@ -330,12 +330,12 @@ class AzureRMVirtualHubConnection(AzureRMModuleBaseExt):
             ),
             allow_remote_vnet_to_use_hub_vnet_gateways=dict(
                 type='bool',
-                removed_in_version='3.17.0',
+                removed_in_version='4.0.0',
                 removed_from_collection='azure.azcollection'
             ),
             allow_hub_to_remote_vnet_transit=dict(
                 type='bool',
-                removed_in_version='3.17.0',
+                removed_in_version='4.0.0',
                 removed_from_collection='azure.azcollection'
             ),
             remote_virtual_network=dict(

--- a/plugins/modules/azure_rm_virtualhubconnection_info.py
+++ b/plugins/modules/azure_rm_virtualhubconnection_info.py
@@ -164,14 +164,14 @@ virtual_hub_connection:
         allow_hub_to_remote_vnet_transit:
             description:
                 - (Deprecated) Enable hub to remote VNet transit.
-                - This field has been deprecated and will be removed in later version release.
+                - This field has been deprecated and will be removed in next major version release.
             returned: always
             type: bool
             sample: true
         allow_remote_vnet_to_use_hub_vnet_gateways:
             description:
                 - (Deprecated) Allow remote VNet to use hub's VNet gateways.
-                - This field has been deprecated and will be removed in later version release.
+                - This field has been deprecated and will be removed in next major version release.
             returned: always
             type: bool
             sample: true

--- a/plugins/modules/azure_rm_virtualhubconnection_info.py
+++ b/plugins/modules/azure_rm_virtualhubconnection_info.py
@@ -163,13 +163,15 @@ virtual_hub_connection:
             sample: Succeeded
         allow_hub_to_remote_vnet_transit:
             description:
-                - Enable hub to remote VNet transit.
+                - (Deprecated) Enable hub to remote VNet transit.
+                - This field has been deprecated and will be removed in later version release.
             returned: always
             type: bool
             sample: true
         allow_remote_vnet_to_use_hub_vnet_gateways:
             description:
-                - Allow remote VNet to use hub's VNet gateways.
+                - (Deprecated) Allow remote VNet to use hub's VNet gateways.
+                - This field has been deprecated and will be removed in later version release.
             returned: always
             type: bool
             sample: true

--- a/tests/integration/targets/azure_rm_virtualhubconnection/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualhubconnection/tasks/main.yml
@@ -49,8 +49,6 @@
         vhub_name: "vhub{{ rpfx }}"
         name: "connection{{ rpfx }}"
         enable_internet_security: true
-        allow_remote_vnet_to_use_hub_vnet_gateways: false
-        allow_hub_to_remote_vnet_transit: true
         remote_virtual_network:
           id: "{{ vnet_output.state.id }}"
         routing_configuration:
@@ -83,8 +81,6 @@
         vhub_name: "vhub{{ rpfx }}"
         name: "connection{{ rpfx }}"
         enable_internet_security: true
-        allow_remote_vnet_to_use_hub_vnet_gateways: false
-        allow_hub_to_remote_vnet_transit: true
         remote_virtual_network:
           id: "{{ vnet_output.state.id }}"
         routing_configuration:
@@ -117,8 +113,6 @@
         vhub_name: "vhub{{ rpfx }}"
         name: "connection{{ rpfx }}"
         enable_internet_security: false
-        allow_remote_vnet_to_use_hub_vnet_gateways: false
-        allow_hub_to_remote_vnet_transit: true
         remote_virtual_network:
           id: "{{ vnet_output.state.id }}"
         routing_configuration:
@@ -157,8 +151,6 @@
     - name: Assert fact returns
       ansible.builtin.assert:
         that:
-          - output.virtual_hub_connection[0].allow_hub_to_remote_vnet_transit
-          - not output.virtual_hub_connection[0].allow_remote_vnet_to_use_hub_vnet_gateways
           - not output.virtual_hub_connection[0].enable_internet_security
           - output.virtual_hub_connection[0].routing_configuration.propagated_route_tables.labels | length == 3
           - output.virtual_hub_connection[0].routing_configuration.vnet_routes.static_routes | length == 2


### PR DESCRIPTION
##### SUMMARY
Deprecate the `allow_remote_vnet_to_use_hub_vnet_gateways` and `allow_hub_to_remote_vnet_transit` parameters on `azure_rm_virtualhubconnection` (and their return fields on `azure_rm_virtualhubconnection_info`). Both are deprecated in the underlying Azure REST API /  `azure-mgmt-network` SDK and are silently ignored / normalized by the service, which breaks module idempotency.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualhubconnection.py
plugins/modules/azure_rm_virtualhubconnection_info.py

##### ADDITIONAL INFORMATION
- Azure Python SDK HubVirtualNetworkConnection docs: https://learn.microsoft.com/en-us/python/api/azure-mgmt-network/azure.mgmt.network.models.hubvirtualnetworkconnection
