### PR TITLE
New Feature #2226: support key_vault_secret_id on ssl_certificates in azure_rm_appgateway

### DIFF
--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -369,6 +369,13 @@ options:
                 description:
                     - Name of the resource that is unique within a resource group. This name can be used to access the resource.
                 type: str
+            key_vault_secret_id:
+                description:
+                    - Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault.
+                    - When using this option, the application gateway must have a user-assigned managed identity with access to the Key Vault.
+                    - Mutually exclusive with I(data) and I(password).
+                default: ''
+                type: str
     trusted_root_certificates:
         version_added: "1.15.0"
         description:
@@ -1001,6 +1008,9 @@ EXAMPLES = '''
     trusted_root_certificates:
       - name: "root_cert"
         key_vault_secret_id: "https://kv/secret"
+    ssl_certificates:
+      - name: "ssl_cert"
+        key_vault_secret_id: "https://kv/secrets/ssl-cert"
     backend_address_pools:
       - backend_addresses:
           - ip_address: 10.0.0.4
@@ -1784,6 +1794,14 @@ trusted_root_certificates_spec = dict(
 )
 
 
+ssl_certificates_spec = dict(
+    name=dict(type='str'),
+    data=dict(type='str'),
+    password=dict(type='str', no_log=True),
+    key_vault_secret_id=dict(type='str', default='')
+)
+
+
 class AzureRMApplicationGateways(AzureRMModuleBaseExt):
     """Configuration class for an Azure RM Application Gateway resource"""
 
@@ -1834,11 +1852,7 @@ class AzureRMApplicationGateways(AzureRMModuleBaseExt):
             ssl_certificates=dict(
                 type='list',
                 elements='dict',
-                options=dict(
-                    data=dict(type='str'),
-                    password=dict(type='str', no_log=True),
-                    name=dict(type='str')
-                )
+                options=ssl_certificates_spec
             ),
             trusted_root_certificates=dict(
                 type='list',

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -29,6 +29,7 @@
     - name: Create managed_identity_ids list
       ansible.builtin.set_fact:
         managed_identity_ids: []
+        access_policies_object_ids: []
 
     - name: Create user managed identities
       ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
@@ -2013,6 +2014,443 @@
       ansible.builtin.assert:
         that:
           - output is not changed
+
+    # ---------------------------------------------------------------------------
+    # Issue #2226: ssl_certificates must support key_vault_secret_id
+    # Verifies an Application Gateway SSL certificate sourced from a Key Vault
+    # secret URI (mirrors the existing trusted_root_certificates support).
+    # Reuses the already-provisioned appgateway-v2 + UMI; the UMI's principalId
+    # is auto-populated into access_policies_object_ids by managed_identity.yml.
+    # ---------------------------------------------------------------------------
+    - name: Lookup service principal object_id for Key Vault access policy
+      ansible.builtin.set_fact:
+        appgw_kv_sp_object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
+                                          azure_client_id=azure_client_id,
+                                          azure_secret=azure_secret,
+                                          azure_tenant=azure_tenant) }}"
+
+    - name: Generate a passwordless self-signed PFX (App Gateway requires no-password PFX in KV)
+      ansible.builtin.shell: |
+        set -eu
+        WORKDIR=$(mktemp -d)
+        cd "$WORKDIR"
+        openssl req -x509 -newkey rsa:2048 -nodes \
+          -keyout key.pem -out cert.pem -days 30 \
+          -subj "/CN=appgw-kv-{{ rpfx }}.example.com" >/dev/null 2>&1
+        openssl pkcs12 -export -out kv.pfx \
+          -inkey key.pem -in cert.pem -passout pass: >/dev/null 2>&1
+        base64 -w0 kv.pfx
+      args:
+        executable: /bin/bash
+      register: appgw_kv_pfx_b64
+      changed_when: false
+
+    - name: Create a Key Vault to host the App Gateway SSL certificate
+      azure.azcollection.azure_rm_keyvault:
+        resource_group: "{{ resource_group }}-appgateway"
+        vault_name: "appgwkv{{ rpfx }}"
+        enabled_for_template_deployment: true
+        vault_tenant: "{{ azure_tenant }}"
+        sku:
+          name: standard
+          family: A
+        access_policies:
+          - tenant_id: "{{ azure_tenant }}"
+            object_id: "{{ appgw_kv_sp_object_id }}"
+            secrets:
+              - get
+              - list
+              - set
+              - delete
+          - tenant_id: "{{ azure_tenant }}"
+            object_id: "{{ access_policies_object_ids[0] }}"
+            secrets:
+              - get
+              - list
+
+    - name: Upload the PFX to Key Vault as an App Gateway-compatible secret
+      azure.azcollection.azure_rm_keyvaultsecret:
+        keyvault_uri: "https://appgwkv{{ rpfx }}.vault.azure.net"
+        secret_name: "appgw-ssl-cert"
+        secret_value: "{{ appgw_kv_pfx_b64.stdout }}"
+        content_type: "application/x-pkcs12"
+
+    - name: Set the unversioned KV secret URI fact
+      ansible.builtin.set_fact:
+        appgw_kv_secret_id: "https://appgwkv{{ rpfx }}.vault.azure.net/secrets/appgw-ssl-cert"
+
+    - name: Update Application Gateway to add an ssl_certificate sourced from Key Vault
+      azure.azcollection.azure_rm_appgateway:
+        resource_group: "{{ resource_group }}-appgateway"
+        name: "appgateway-v2-{{ rpfx }}"
+        sku:
+          name: standard_v2
+          tier: standard_v2
+        autoscale_configuration:
+          max_capacity: 2
+          min_capacity: 1
+        enable_http2: true
+        identity:
+          type: UserAssigned
+          user_assigned_identities:
+            id:
+              - "{{ managed_identity_ids[0] }}"
+        ssl_policy:
+          policy_type: "predefined"
+          policy_name: "ssl_policy20170401_s"
+        ssl_certificates:
+          - name: cert2
+            password: "{{ cert2_password }}"
+            data: "{{ lookup('file', cert2_file) }}"
+          - name: kv-ssl-cert
+            key_vault_secret_id: "{{ appgw_kv_secret_id }}"
+        trusted_root_certificates:
+          - name: "rootCert3"
+            data: "{{ lookup('file', cert3b64_file) }}"
+        gateway_ip_configurations:
+          - subnet:
+              id: "{{ subnet_output.state.id }}"
+            name: app_gateway_ip_config
+        frontend_ip_configurations:
+          - name: "public-inbound-ip"
+            public_ip_address: "appgateway-v2-{{ rpfx }}-pip"
+        frontend_ports:
+          - name: "inbound-http"
+            port: 80
+          - name: "inbound-https"
+            port: 443
+        backend_address_pools:
+          - name: test_backend_address_pool1
+            backend_addresses:
+              - ip_address: 10.0.0.1
+          - name: test_backend_address_pool2
+            backend_addresses:
+              - ip_address: 10.0.0.2
+        backend_http_settings_collection:
+          - name: "http-profile1"
+            port: 443
+            protocol: https
+            pick_host_name_from_backend_address: true
+            probe: "http-probe1"
+            cookie_based_affinity: "disabled"
+            connection_draining:
+              drain_timeout_in_sec: 60
+              enabled: true
+            trusted_root_certificates:
+              - "rootCert3"
+          - name: "http-profile2"
+            port: 8080
+            protocol: http
+            pick_host_name_from_backend_address: true
+            probe: "http-probe2"
+            cookie_based_affinity: "disabled"
+        http_listeners:
+          - name: "inbound-http"
+            protocol: "http"
+            frontend_ip_configuration: "public-inbound-ip"
+            frontend_port: "inbound-http"
+          - name: "inbound-traffic1"
+            protocol: "https"
+            frontend_ip_configuration: "public-inbound-ip"
+            frontend_port: "inbound-https"
+            host_name: "traffic1.example.com"
+            require_server_name_indication: true
+            ssl_certificate: "cert2"
+          - name: "inbound-traffic2"
+            protocol: "https"
+            frontend_ip_configuration: "public-inbound-ip"
+            frontend_port: "inbound-https"
+            host_name: "traffic2.example.com"
+            require_server_name_indication: true
+            ssl_certificate: "kv-ssl-cert"
+        url_path_maps:
+          - name: "path_mappings"
+            default_redirect_configuration: "redirect-traffic1"
+            default_rewrite_rule_set: "configure-headers"
+            path_rules:
+              - name: "path_rules"
+                backend_address_pool: "test_backend_address_pool1"
+                backend_http_settings: "http-profile1"
+                paths:
+                  - "/abc"
+                  - "/123/*"
+        request_routing_rules:
+          - name: "app-routing1"
+            rule_type: "basic"
+            priority: 100
+            http_listener: "inbound-traffic1"
+            backend_address_pool: "test_backend_address_pool2"
+            backend_http_settings: "http-profile1"
+            rewrite_rule_set: "configure-headers"
+          - name: "app-routing2"
+            rule_type: "path_based_routing"
+            priority: 101
+            http_listener: "inbound-traffic2"
+            url_path_map: "path_mappings"
+          - name: "redirect-routing"
+            rule_type: "basic"
+            priority: 102
+            http_listener: "inbound-http"
+            redirect_configuration: "redirect-http"
+        rewrite_rule_sets:
+          - name: "configure-headers"
+            rewrite_rules:
+              - name: "add-security-response-header"
+                rule_sequence: 1
+                action_set:
+                  response_header_configurations:
+                    - header_name: "Strict-Transport-Security"
+                      header_value: "max-age=31536000"
+              - name: "remove-backend-response-headers"
+                rule_sequence: 2
+                action_set:
+                  response_header_configurations:
+                    - header_name: "Server"
+                    - header_name: "X-Powered-By"
+              - name: "set-custom-header-condition"
+                rule_sequence: 3
+                conditions:
+                  - variable: "var_client_ip"
+                    pattern: "1.1.1.1"
+                  - variable: "http_req_Authorization"
+                    pattern: "12345"
+                    ignore_case: false
+                action_set:
+                  request_header_configurations:
+                    - header_name: "Foo"
+                      header_value: "Bar"
+        probes:
+          - name: "http-probe1"
+            interval: 30
+            path: "/abc"
+            protocol: "https"
+            pick_host_name_from_backend_http_settings: true
+            timeout: 30
+            unhealthy_threshold: 2
+          - name: "http-probe2"
+            interval: 30
+            path: "/xyz"
+            protocol: "http"
+            pick_host_name_from_backend_http_settings: true
+            timeout: 30
+            unhealthy_threshold: 2
+        redirect_configurations:
+          - name: "redirect-http"
+            redirect_type: "permanent"
+            target_listener: "inbound-traffic1"
+            include_path: true
+            include_query_string: true
+            request_routing_rules:
+              - "redirect-routing"
+          - name: "redirect-traffic1"
+            redirect_type: "found"
+            target_listener: "inbound-traffic1"
+            include_path: true
+            include_query_string: true
+            url_path_maps:
+              - "path_mappings"
+      register: output
+
+    - name: Assert the App Gateway was updated with the KV-sourced SSL certificate
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Fetch the App Gateway and verify key_vault_secret_id is populated
+      azure.azcollection.azure_rm_appgateway_info:
+        resource_group: "{{ resource_group }}-appgateway"
+        name: "appgateway-v2-{{ rpfx }}"
+      register: appgw_kv_info
+
+    - name: Extract the kv-ssl-cert entry from the returned ssl_certificates
+      ansible.builtin.set_fact:
+        appgw_kv_cert: "{{ appgw_kv_info.gateways[0].ssl_certificates
+                           | selectattr('name', 'equalto', 'kv-ssl-cert')
+                           | list }}"
+
+    - name: Assert kv-ssl-cert exists and references the Key Vault secret
+      ansible.builtin.assert:
+        that:
+          - appgw_kv_cert | length == 1
+          - appgw_kv_cert[0].key_vault_secret_id is search('appgw-ssl-cert')
+        fail_msg: "kv-ssl-cert is missing or key_vault_secret_id is not populated by ARM."
+
+    - name: Re-run the same module call to verify idempotency for ssl_certificates.key_vault_secret_id
+      azure.azcollection.azure_rm_appgateway:
+        resource_group: "{{ resource_group }}-appgateway"
+        name: "appgateway-v2-{{ rpfx }}"
+        sku:
+          name: standard_v2
+          tier: standard_v2
+        autoscale_configuration:
+          max_capacity: 2
+          min_capacity: 1
+        enable_http2: true
+        identity:
+          type: UserAssigned
+          user_assigned_identities:
+            id:
+              - "{{ managed_identity_ids[0] }}"
+        ssl_policy:
+          policy_type: "predefined"
+          policy_name: "ssl_policy20170401_s"
+        ssl_certificates:
+          - name: cert2
+            password: "{{ cert2_password }}"
+            data: "{{ lookup('file', cert2_file) }}"
+          - name: kv-ssl-cert
+            key_vault_secret_id: "{{ appgw_kv_secret_id }}"
+        trusted_root_certificates:
+          - name: "rootCert3"
+            data: "{{ lookup('file', cert3b64_file) }}"
+        gateway_ip_configurations:
+          - subnet:
+              id: "{{ subnet_output.state.id }}"
+            name: app_gateway_ip_config
+        frontend_ip_configurations:
+          - name: "public-inbound-ip"
+            public_ip_address: "appgateway-v2-{{ rpfx }}-pip"
+        frontend_ports:
+          - name: "inbound-http"
+            port: 80
+          - name: "inbound-https"
+            port: 443
+        backend_address_pools:
+          - name: test_backend_address_pool1
+            backend_addresses:
+              - ip_address: 10.0.0.1
+          - name: test_backend_address_pool2
+            backend_addresses:
+              - ip_address: 10.0.0.2
+        backend_http_settings_collection:
+          - name: "http-profile1"
+            port: 443
+            protocol: https
+            pick_host_name_from_backend_address: true
+            probe: "http-probe1"
+            cookie_based_affinity: "disabled"
+            connection_draining:
+              drain_timeout_in_sec: 60
+              enabled: true
+            trusted_root_certificates:
+              - "rootCert3"
+          - name: "http-profile2"
+            port: 8080
+            protocol: http
+            pick_host_name_from_backend_address: true
+            probe: "http-probe2"
+            cookie_based_affinity: "disabled"
+        http_listeners:
+          - name: "inbound-http"
+            protocol: "http"
+            frontend_ip_configuration: "public-inbound-ip"
+            frontend_port: "inbound-http"
+          - name: "inbound-traffic1"
+            protocol: "https"
+            frontend_ip_configuration: "public-inbound-ip"
+            frontend_port: "inbound-https"
+            host_name: "traffic1.example.com"
+            require_server_name_indication: true
+            ssl_certificate: "cert2"
+          - name: "inbound-traffic2"
+            protocol: "https"
+            frontend_ip_configuration: "public-inbound-ip"
+            frontend_port: "inbound-https"
+            host_name: "traffic2.example.com"
+            require_server_name_indication: true
+            ssl_certificate: "kv-ssl-cert"
+        url_path_maps:
+          - name: "path_mappings"
+            default_redirect_configuration: "redirect-traffic1"
+            default_rewrite_rule_set: "configure-headers"
+            path_rules:
+              - name: "path_rules"
+                backend_address_pool: "test_backend_address_pool1"
+                backend_http_settings: "http-profile1"
+                paths:
+                  - "/abc"
+                  - "/123/*"
+        request_routing_rules:
+          - name: "app-routing1"
+            rule_type: "basic"
+            priority: 100
+            http_listener: "inbound-traffic1"
+            backend_address_pool: "test_backend_address_pool2"
+            backend_http_settings: "http-profile1"
+            rewrite_rule_set: "configure-headers"
+          - name: "app-routing2"
+            rule_type: "path_based_routing"
+            priority: 101
+            http_listener: "inbound-traffic2"
+            url_path_map: "path_mappings"
+          - name: "redirect-routing"
+            rule_type: "basic"
+            priority: 102
+            http_listener: "inbound-http"
+            redirect_configuration: "redirect-http"
+        rewrite_rule_sets:
+          - name: "configure-headers"
+            rewrite_rules:
+              - name: "add-security-response-header"
+                rule_sequence: 1
+                action_set:
+                  response_header_configurations:
+                    - header_name: "Strict-Transport-Security"
+                      header_value: "max-age=31536000"
+              - name: "remove-backend-response-headers"
+                rule_sequence: 2
+                action_set:
+                  response_header_configurations:
+                    - header_name: "Server"
+                    - header_name: "X-Powered-By"
+              - name: "set-custom-header-condition"
+                rule_sequence: 3
+                conditions:
+                  - variable: "var_client_ip"
+                    pattern: "1.1.1.1"
+                  - variable: "http_req_Authorization"
+                    pattern: "12345"
+                    ignore_case: false
+                action_set:
+                  request_header_configurations:
+                    - header_name: "Foo"
+                      header_value: "Bar"
+        probes:
+          - name: "http-probe1"
+            interval: 30
+            path: "/abc"
+            protocol: "https"
+            pick_host_name_from_backend_http_settings: true
+            timeout: 30
+            unhealthy_threshold: 2
+          - name: "http-probe2"
+            interval: 30
+            path: "/xyz"
+            protocol: "http"
+            pick_host_name_from_backend_http_settings: true
+            timeout: 30
+            unhealthy_threshold: 2
+        redirect_configurations:
+          - name: "redirect-http"
+            redirect_type: "permanent"
+            target_listener: "inbound-traffic1"
+            include_path: true
+            include_query_string: true
+            request_routing_rules:
+              - "redirect-routing"
+          - name: "redirect-traffic1"
+            redirect_type: "found"
+            target_listener: "inbound-traffic1"
+            include_path: true
+            include_query_string: true
+            url_path_maps:
+              - "path_mappings"
+      register: output_idem
+
+    - name: Assert no change on second run (key_vault_secret_id idempotency)
+      ansible.builtin.assert:
+        that:
+          - output_idem is not changed
 
     - name: Delete v2 instance of Application Gateway
       azure.azcollection.azure_rm_appgateway:

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -2249,19 +2249,6 @@
         that:
           - output is changed
 
-    - name: Fetch the App Gateway and verify key_vault_secret_id is populated
-      azure.azcollection.azure_rm_appgateway_info:
-        resource_group: "{{ resource_group }}-appgateway"
-        name: "appgateway-v2-{{ rpfx }}"
-      register: appgw_kv_info
-
-    - name: Assert kv-ssl-cert exists and references the Key Vault secret
-      ansible.builtin.assert:
-        that:
-          - (appgw_kv_info.gateways[0].ssl_certificates | selectattr('name', 'equalto', 'kv-ssl-cert') | list | length) == 1
-          - (appgw_kv_info.gateways[0].ssl_certificates | selectattr('name', 'equalto', 'kv-ssl-cert') | map(attribute='key_vault_secret_id') | first) is search('appgw-ssl-cert')
-        fail_msg: "kv-ssl-cert is missing or its key_vault_secret_id is not populated by the ARM API."
-
     - name: Re-run the same module call to verify idempotency for ssl_certificates.key_vault_secret_id
       azure.azcollection.azure_rm_appgateway:
         resource_group: "{{ resource_group }}-appgateway"

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -2015,13 +2015,6 @@
         that:
           - output is not changed
 
-    # ---------------------------------------------------------------------------
-    # Issue #2226: ssl_certificates must support key_vault_secret_id
-    # Verifies an Application Gateway SSL certificate sourced from a Key Vault
-    # secret URI (mirrors the existing trusted_root_certificates support).
-    # Reuses the already-provisioned appgateway-v2 + UMI; the UMI's principalId
-    # is auto-populated into access_policies_object_ids by managed_identity.yml.
-    # ---------------------------------------------------------------------------
     - name: Lookup service principal object_id for Key Vault access policy
       ansible.builtin.set_fact:
         appgw_kv_sp_object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
@@ -2262,18 +2255,12 @@
         name: "appgateway-v2-{{ rpfx }}"
       register: appgw_kv_info
 
-    - name: Extract the kv-ssl-cert entry from the returned ssl_certificates
-      ansible.builtin.set_fact:
-        appgw_kv_cert: "{{ appgw_kv_info.gateways[0].ssl_certificates
-                           | selectattr('name', 'equalto', 'kv-ssl-cert')
-                           | list }}"
-
     - name: Assert kv-ssl-cert exists and references the Key Vault secret
       ansible.builtin.assert:
         that:
-          - appgw_kv_cert | length == 1
-          - appgw_kv_cert[0].key_vault_secret_id is search('appgw-ssl-cert')
-        fail_msg: "kv-ssl-cert is missing or key_vault_secret_id is not populated by ARM."
+          - (appgw_kv_info.gateways[0].ssl_certificates | selectattr('name', 'equalto', 'kv-ssl-cert') | list | length) == 1
+          - (appgw_kv_info.gateways[0].ssl_certificates | selectattr('name', 'equalto', 'kv-ssl-cert') | map(attribute='key_vault_secret_id') | first) is search('appgw-ssl-cert')
+        fail_msg: "kv-ssl-cert is missing or its key_vault_secret_id is not populated by the ARM API."
 
     - name: Re-run the same module call to verify idempotency for ssl_certificates.key_vault_secret_id
       azure.azcollection.azure_rm_appgateway:

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -2426,6 +2426,13 @@
         that:
           - output_idem is not changed
 
+    - name: Delete the Key Vault used for the SSL certificate test
+      azure.azcollection.azure_rm_keyvault:
+        resource_group: "{{ resource_group }}-appgateway"
+        vault_name: "appgwkv{{ rpfx }}"
+        state: absent
+      ignore_errors: true
+
     - name: Delete v2 instance of Application Gateway
       azure.azcollection.azure_rm_appgateway:
         resource_group: "{{ resource_group }}-appgateway"


### PR DESCRIPTION
##### SUMMARY
Fix #2226.

Add `key_vault_secret_id` support to the `ssl_certificates` option of `azure_rm_appggateway`, matching the pattern already used for `trusted_root_certificates`. This lets users keep the App Gateway TLS PFX in Key Vault (referenced by an unversioned secret URI) instead of base64-embeding it in the playbook.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_appgateway.py

##### ADDITIONAL INFORMATION
- New `key_vault_secret_id` suboption documented under `ssl_certificates`.
- New `EXAMPLES` snippet for the KV-sourced cert.
- Inline argspec replaced with a module-level `ssl_certificates_spec` dict (parallel to `trusted_root_certificates_spec`).
- No CRUD / serialization changes — `self.parameters["ssl_certificates"] = kwargs[key]` already forwards the dict verbatim, and the SDK accepts the new key.
