### PR TITLE
New Plugin #1044: Add `azure_bastion_ssh` connection plugin

### DIFF
--- a/plugins/connection/azure_bastion_ssh.py
+++ b/plugins/connection/azure_bastion_ssh.py
@@ -1,0 +1,490 @@
+# Copyright (c) 2025 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: azure_bastion_ssh
+    short_description: Connect to a private Azure VM through Azure Bastion via a local tunnel.
+    version_added: "3.17.0"
+    description:
+        - This connection plugin enables Ansible to reach VMs in private Azure virtual networks by tunneling SSH through an Azure Bastion host.
+        - On first use per host the plugin spawns C(az network bastion tunnel) as a background subprocess on the controller, waits for the local
+          port to be ready, and then delegates to the standard C(ssh) connection plugin which it subclasses. All standard SSH features
+          (SFTP, ControlMaster, become, etc.) work as usual.
+        - The Azure CLI (C(az)) and the C(bastion) extension must be installed on the Ansible controller. The Bastion resource must use
+          the Standard SKU (or higher) with C(enableTunneling=true).
+        - Only SSH key authentication is supported in this version.
+        - All standard C(ssh) connection plugin variables are honored (for example C(ansible_user), C(ansible_ssh_private_key_file),
+          C(ansible_ssh_common_args)). Their option definitions are inherited from the built-in C(ssh) connection plugin at runtime.
+    author:
+        - Ansible Cloud Content Team (@ansible-collections)
+    requirements:
+        - The Azure CLI (V(az)) installed on the Ansible controller.
+        - The V(bastion) Azure CLI extension (V(az extension add --name bastion)).
+        - Bastion SKU Standard or higher with native client tunneling enabled.
+    options:
+        azure_bastion_name:
+            description: Name of the Azure Bastion host to tunnel through.
+            type: str
+            required: true
+            vars:
+                - name: ansible_azure_bastion_name
+        azure_bastion_resource_group:
+            description: Resource group containing the Azure Bastion host.
+            type: str
+            required: true
+            vars:
+                - name: ansible_azure_bastion_resource_group
+        azure_bastion_subscription:
+            description:
+                - Azure subscription ID or name in which the Bastion host
+                  lives. If unset, the C(az) CLI's currently selected
+                  subscription is used.
+            type: str
+            vars:
+                - name: ansible_azure_bastion_subscription
+        azure_bastion_target_resource_id:
+            description:
+                - Full ARM resource ID of the target VM to connect to,
+                  e.g.
+                  V(/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<vm>).
+            type: str
+            required: true
+            vars:
+                - name: ansible_azure_bastion_target_resource_id
+        azure_bastion_target_port:
+            description: Port on the target VM to forward (SSH).
+            type: int
+            default: 22
+            vars:
+                - name: ansible_azure_bastion_target_port
+        azure_bastion_local_port:
+            description:
+                - Local TCP port to bind the tunnel to. If unset, a free
+                  ephemeral port is chosen automatically.
+                - When running plays in parallel against many hosts you
+                  must leave this unset (or unique per host) to avoid
+                  cross-host port collisions.
+            type: int
+            vars:
+                - name: ansible_azure_bastion_local_port
+        azure_bastion_tunnel_timeout:
+            description: Seconds to wait for the local tunnel port to be ready.
+            type: int
+            default: 30
+            vars:
+                - name: ansible_azure_bastion_tunnel_timeout
+        azure_bastion_az_path:
+            description: Path to the C(az) CLI binary on the controller.
+            type: str
+            default: az
+            vars:
+                - name: ansible_azure_bastion_az_path
+        # ---------------------------------------------------------------
+        # Proxy options for the underlying ``ssh`` connection plugin.
+        #
+        # Ansible's task executor only forwards variables to a connection plugin's ``set_options(var_options=...)`` if those variables are
+        # declared in the plugin's own option spec (see ``ansible.executor.task_executor._set_plugin_options``). So we
+        # have to re-declare the standard ssh-plugin vars here to make ``ansible_user``, ``ansible_ssh_private_key_file``, etc. flow
+        # through. 
+        # 
+        # The values land in ``self._options`` under the canonical keys (``remote_user``, ``private_key_file``, ...) where the parent ssh 
+        # plugin's ``get_option`` reads them.
+        # ---------------------------------------------------------------
+        remote_user:
+            description: Username to log in as on the target host (forwarded to the ssh plugin).
+            type: str
+            vars:
+                - name: ansible_user
+                - name: ansible_ssh_user
+            env:
+                - name: ANSIBLE_REMOTE_USER
+            ini:
+                - section: defaults
+                  key: remote_user
+        password:
+            description: Authentication password for the C(remote_user). SSH key auth is preferred for v1.
+            type: str
+            vars:
+                - name: ansible_password
+                - name: ansible_ssh_pass
+                - name: ansible_ssh_password
+        private_key_file:
+            description: Private key file used by ssh.
+            type: path
+            vars:
+                - name: ansible_private_key_file
+                - name: ansible_ssh_private_key_file
+            env:
+                - name: ANSIBLE_PRIVATE_KEY_FILE
+            ini:
+                - section: defaults
+                  key: private_key_file
+        ssh_args:
+            description: Arguments to pass to all ssh CLI tools.
+            type: str
+            default: '-C -o ControlMaster=auto -o ControlPersist=60s'
+            vars:
+                - name: ansible_ssh_args
+            env:
+                - name: ANSIBLE_SSH_ARGS
+            ini:
+                - section: 'ssh_connection'
+                  key: 'ssh_args'
+        ssh_common_args:
+            description: Common extra args for all ssh CLI tools.
+            type: str
+            default: ''
+            vars:
+                - name: ansible_ssh_common_args
+            env:
+                - name: ANSIBLE_SSH_COMMON_ARGS
+            ini:
+                - section: 'ssh_connection'
+                  key: 'ssh_common_args'
+        ssh_extra_args:
+            description: Extra exclusive to the ssh CLI.
+            type: str
+            default: ''
+            vars:
+                - name: ansible_ssh_extra_args
+            env:
+                - name: ANSIBLE_SSH_EXTRA_ARGS
+            ini:
+                - section: 'ssh_connection'
+                  key: 'ssh_extra_args'
+        sftp_extra_args:
+            description: Extra exclusive to the sftp CLI.
+            type: str
+            default: ''
+            vars:
+                - name: ansible_sftp_extra_args
+            env:
+                - name: ANSIBLE_SFTP_EXTRA_ARGS
+            ini:
+                - section: 'ssh_connection'
+                  key: 'sftp_extra_args'
+        scp_extra_args:
+            description: Extra exclusive to the scp CLI.
+            type: str
+            default: ''
+            vars:
+                - name: ansible_scp_extra_args
+            env:
+                - name: ANSIBLE_SCP_EXTRA_ARGS
+            ini:
+                - section: 'ssh_connection'
+                  key: 'scp_extra_args'
+        ssh_executable:
+            description: Location of the ssh binary.
+            type: string
+            default: ssh
+            vars:
+                - name: ansible_ssh_executable
+            env: [{name: ANSIBLE_SSH_EXECUTABLE}]
+            ini:
+                - section: ssh_connection
+                  key: ssh_executable
+        host_key_checking:
+            description: Determines if ssh should check host keys.
+            type: boolean
+            vars:
+                - name: ansible_host_key_checking
+                - name: ansible_ssh_host_key_checking
+            env:
+                - name: ANSIBLE_HOST_KEY_CHECKING
+                - name: ANSIBLE_SSH_HOST_KEY_CHECKING
+            ini:
+                - section: defaults
+                  key: host_key_checking
+                - section: ssh_connection
+                  key: host_key_checking
+        timeout:
+            description: SSH connection timeout in seconds.
+            type: integer
+            default: 10
+            vars:
+                - name: ansible_ssh_timeout
+                - name: ansible_timeout
+            env:
+                - name: ANSIBLE_TIMEOUT
+                - name: ANSIBLE_SSH_TIMEOUT
+            ini:
+                - key: timeout
+                  section: defaults
+                - key: timeout
+                  section: ssh_connection
+        pipelining:
+            description: Enable pipelining for the ssh plugin.
+            type: bool
+            vars:
+                - name: ansible_pipelining
+                - name: ansible_ssh_pipelining
+            env:
+                - name: ANSIBLE_PIPELINING
+                - name: ANSIBLE_SSH_PIPELINING
+            ini:
+                - section: connection
+                  key: pipelining
+                - section: ssh_connection
+                  key: pipelining
+'''
+
+EXAMPLES = '''
+# Inventory:
+#
+# [private_vms]
+# webapp-01 ansible_host=10.0.1.4 \
+#     ansible_azure_bastion_target_resource_id=/subscriptions/.../virtualMachines/webapp-01
+#
+# [private_vms:vars]
+# ansible_connection=azure.azcollection.azure_bastion_ssh
+# ansible_user=azureuser
+# ansible_ssh_private_key_file=~/.ssh/id_rsa
+# ansible_azure_bastion_name=my-bastion
+# ansible_azure_bastion_resource_group=my-network-rg
+'''
+
+import atexit
+import threading
+
+from ansible import constants as C
+from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.plugins.connection.ssh import Connection as SSHConnection
+from ansible.utils.display import Display
+
+from ansible_collections.azure.azcollection.plugins.plugin_utils.bastion_tunnel import (
+    BastionTunnelError,
+    check_az_available,
+    check_bastion_extension,
+    drain_stream_to_buffer,
+    is_port_in_use,
+    pick_free_port,
+    start_tunnel,
+    terminate_tunnel,
+    wait_for_port,
+)
+
+display = Display()
+
+# Strong references to live tunnel subprocesses so an atexit hook can
+# terminate them if a connection close path is skipped (e.g. controller
+# SIGINT). Strong (not weak) so Popen objects aren't GC'd prematurely.
+_LIVE_TUNNELS = set()
+_LIVE_TUNNELS_LOCK = threading.Lock()
+
+
+def _atexit_cleanup():
+    with _LIVE_TUNNELS_LOCK:
+        procs = list(_LIVE_TUNNELS)
+        _LIVE_TUNNELS.clear()
+    for proc in procs:
+        try:
+            terminate_tunnel(proc, grace_seconds=2)
+        except Exception:
+            pass
+
+
+atexit.register(_atexit_cleanup)
+
+
+class Connection(SSHConnection):
+    """SSH-via-Azure-Bastion connection plugin.
+
+    Subclasses the built-in C(ssh) plugin. On the first call to
+    :meth:`_connect` it brings up a local tunnel via
+    ``az network bastion tunnel`` and rewrites the connection target to
+    ``127.0.0.1:<local_port>`` before delegating up the MRO. Subsequent
+    calls reuse the same tunnel. :meth:`close` tears it down.
+    """
+
+    transport = "azure.azcollection.azure_bastion_ssh"
+    has_pipelining = True
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+        self._bastion_tunnel_proc = None
+        self._bastion_local_port = None
+        self._bastion_started = False
+        self._bastion_stderr_buf = bytearray()
+
+    # -- option machinery -------------------------------------------------
+    #
+    # Our DOCUMENTATION re-declares the most-used ``ssh`` connection plugin
+    # options (remote_user, private_key_file, ssh_*, host_key_checking,
+    # timeout, pipelining, control_path[_dir], reconnection_retries, etc.)
+    # so Ansible's task executor passes ``ansible_user`` /
+    # ``ansible_ssh_private_key_file`` / etc. through to our
+    # ``set_options``. Their values then land in ``self._options`` under
+    # the canonical keys (``remote_user``, ``private_key_file``, ...) where
+    # the parent ssh plugin's ``get_option`` reads them.
+    #
+    # For any option ssh declares that we did NOT re-declare,
+    # ``get_option`` falls back to resolving against the ssh plugin's
+    # config so parent-class methods don't blow up.
+
+    def get_option(self, option, hostvars=None):
+        if option in self._options:
+            return self._options[option]
+        try:
+            return super(Connection, self).get_option(option, hostvars=hostvars)
+        except KeyError:
+            try:
+                value, _origin = C.config.get_config_value_and_origin(
+                    option, plugin_type='connection', plugin_name='ssh', variables=hostvars,
+                )
+            except AnsibleError as exc:
+                raise KeyError(str(exc))
+            self._options[option] = value
+            return value
+
+    # -- tunnel lifecycle -------------------------------------------------
+
+    def _ensure_tunnel(self):
+        if (self._bastion_started
+                and self._bastion_tunnel_proc is not None
+                and self._bastion_tunnel_proc.poll() is None
+                and is_port_in_use(self._bastion_local_port)):
+            return
+
+        # If a previous tunnel died or the local port stopped listening,
+        # tear it down before bringing up a new one.
+        if self._bastion_tunnel_proc is not None:
+            self._teardown_tunnel()
+
+        bastion_name = self.get_option("azure_bastion_name")
+        resource_group = self.get_option("azure_bastion_resource_group")
+        subscription = self.get_option("azure_bastion_subscription")
+        target_id = self.get_option("azure_bastion_target_resource_id")
+        target_port = self.get_option("azure_bastion_target_port")
+        local_port = self.get_option("azure_bastion_local_port")
+        timeout = self.get_option("azure_bastion_tunnel_timeout")
+        az_path = self.get_option("azure_bastion_az_path")
+
+        try:
+            az_resolved = check_az_available(az_path)
+            check_bastion_extension(az_resolved)
+        except BastionTunnelError as exc:
+            raise AnsibleConnectionFailure(str(exc))
+
+        if local_port:
+            if is_port_in_use(local_port):
+                raise AnsibleConnectionFailure(
+                    "azure_bastion_local_port=%d is already in use on 127.0.0.1. "
+                    "Pick a different port or leave it unset to auto-allocate. "
+                    "Note: when running against multiple hosts in parallel, a fixed "
+                    "port set as a group var would cause cross-host collisions; "
+                    "leave azure_bastion_local_port unset for parallel runs."
+                    % local_port
+                )
+        else:
+            local_port = pick_free_port()
+
+        display.vvv(
+            "azure_bastion_ssh: starting tunnel via bastion '%s' (rg=%s) -> %s:%d on 127.0.0.1:%d"
+            % (bastion_name, resource_group, target_id, target_port, local_port),
+            host=self.get_option("host"),
+        )
+
+        proc = None
+        try:
+            proc = start_tunnel(
+                az_path=az_resolved,
+                bastion_name=bastion_name,
+                resource_group=resource_group,
+                target_resource_id=target_id,
+                target_port=target_port,
+                local_port=local_port,
+                subscription=subscription,
+            )
+            with _LIVE_TUNNELS_LOCK:
+                _LIVE_TUNNELS.add(proc)
+            wait_for_port(local_port, timeout=timeout, proc=proc)
+        except BastionTunnelError as exc:
+            if proc is not None:
+                terminate_tunnel(proc)
+                with _LIVE_TUNNELS_LOCK:
+                    _LIVE_TUNNELS.discard(proc)
+            raise AnsibleConnectionFailure("Azure Bastion tunnel setup failed: %s" % exc)
+
+        # Drain stdout/stderr so they don't fill the pipe buffer and stall
+        # the long-running tunnel process. Capture stderr into a bounded
+        # buffer for diagnostics if the tunnel dies later.
+        self._bastion_stderr_buf = bytearray()
+        if proc.stdout is not None:
+            drain_stream_to_buffer(proc.stdout, bytearray())
+        if proc.stderr is not None:
+            drain_stream_to_buffer(proc.stderr, self._bastion_stderr_buf)
+
+        self._bastion_tunnel_proc = proc
+        self._bastion_local_port = local_port
+        self._bastion_started = True
+
+        # Redirect the inherited ssh plugin at the loopback tunnel endpoint.
+        # Assign directly into ``self._options`` (rather than calling
+        # ``self.set_option``) because ``set_option`` validates against
+        # OUR plugin's option spec, which doesn't define ``host``/``port``
+        # (those come from the ``ssh`` plugin and are merged into
+        # ``self._options`` by our ``set_options`` override).
+        self._options["host"] = "127.0.0.1"
+        self._options["port"] = local_port
+        self.host = "127.0.0.1"
+        self.port = local_port
+        try:
+            if self._play_context is not None:
+                self._play_context.remote_addr = "127.0.0.1"
+                self._play_context.port = local_port
+        except AttributeError:
+            pass
+
+    def _teardown_tunnel(self):
+        proc = self._bastion_tunnel_proc
+        self._bastion_tunnel_proc = None
+        self._bastion_local_port = None
+        self._bastion_started = False
+        if proc is None:
+            return
+        try:
+            terminate_tunnel(proc)
+        except Exception as exc:
+            display.warning(
+                "azure_bastion_ssh: failed to cleanly terminate tunnel "
+                "(pid=%s): %s" % (getattr(proc, 'pid', '?'), exc)
+            )
+        finally:
+            with _LIVE_TUNNELS_LOCK:
+                _LIVE_TUNNELS.discard(proc)
+
+    # -- connection plugin overrides --------------------------------------
+
+    def _connect(self):
+        self._ensure_tunnel()
+        return super(Connection, self)._connect()
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        self._ensure_tunnel()
+        return super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+    def put_file(self, in_path, out_path):
+        self._ensure_tunnel()
+        return super(Connection, self).put_file(in_path, out_path)
+
+    def fetch_file(self, in_path, out_path):
+        self._ensure_tunnel()
+        return super(Connection, self).fetch_file(in_path, out_path)
+
+    def close(self):
+        try:
+            super(Connection, self).close()
+        finally:
+            self._teardown_tunnel()
+
+    def reset(self):
+        # Delegate to the parent which performs ControlPersist teardown via
+        # ``ssh -O stop``. The parent reset ends by calling ``self.close()``,
+        # so our override of ``close`` will tear down the tunnel as well.
+        self._ensure_tunnel()
+        return super(Connection, self).reset()

--- a/plugins/connection/azure_bastion_ssh.py
+++ b/plugins/connection/azure_bastion_ssh.py
@@ -89,9 +89,9 @@ DOCUMENTATION = '''
         # Ansible's task executor only forwards variables to a connection plugin's ``set_options(var_options=...)`` if those variables are
         # declared in the plugin's own option spec (see ``ansible.executor.task_executor._set_plugin_options``). So we
         # have to re-declare the standard ssh-plugin vars here to make ``ansible_user``, ``ansible_ssh_private_key_file``, etc. flow
-        # through. 
-        # 
-        # The values land in ``self._options`` under the canonical keys (``remote_user``, ``private_key_file``, ...) where the parent ssh 
+        # through.
+        #
+        # The values land in ``self._options`` under the canonical keys (``remote_user``, ``private_key_file``, ...) where the parent ssh
         # plugin's ``get_option`` reads them.
         # ---------------------------------------------------------------
         remote_user:

--- a/plugins/plugin_utils/bastion_tunnel.py
+++ b/plugins/plugin_utils/bastion_tunnel.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2025 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Helpers for spawning and managing an ``az network bastion tunnel`` subprocess.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import errno
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import threading
+import time
+
+
+class BastionTunnelError(Exception):
+    """Raised when starting/operating the Bastion tunnel fails."""
+
+
+def pick_free_port():
+    """Bind to port 0 on loopback to let the OS hand us a free port, then
+    release it. Caller must accept the small TOCTOU race between picking
+    and the subprocess binding.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def is_port_in_use(port, host="127.0.0.1"):
+    """Return True if some process is already listening on host:port."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.5)
+    try:
+        sock.connect((host, port))
+    except OSError:
+        return False
+    else:
+        return True
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+# Per-process cache so we only run `az extension list` once per controller
+# invocation, keyed by resolved az binary path.
+_EXTENSION_CHECK_CACHE = set()
+_EXTENSION_CHECK_LOCK = threading.Lock()
+
+
+def check_az_available(az_path):
+    """Verify the ``az`` CLI binary is on PATH (or at the given path).
+    Returns the resolved absolute path. Raises BastionTunnelError otherwise.
+    """
+    resolved = shutil.which(az_path) if not os.path.isabs(az_path) else (
+        az_path if os.path.isfile(az_path) and os.access(az_path, os.X_OK) else None
+    )
+    if not resolved:
+        raise BastionTunnelError(
+            "Could not find the Azure CLI binary '%s' on PATH. "
+            "Install it from https://aka.ms/azcli and ensure it is in PATH on the Ansible controller." % az_path
+        )
+    return resolved
+
+
+def check_bastion_extension(az_path):
+    """Verify that the ``bastion`` az CLI extension is installed.
+    Raises BastionTunnelError with the remediation command if not.
+    Result is cached per-process for the lifetime of the controller.
+    """
+    with _EXTENSION_CHECK_LOCK:
+        if az_path in _EXTENSION_CHECK_CACHE:
+            return
+    try:
+        completed = subprocess.run(
+            [az_path, "extension", "list", "--query", "[].name", "-o", "tsv"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BastionTunnelError("Failed to query az extensions: %s" % exc)
+    if completed.returncode != 0:
+        raise BastionTunnelError(
+            "Failed to query az extensions (rc=%d): %s"
+            % (completed.returncode, completed.stderr.decode("utf-8", "replace").strip())
+        )
+    installed = set(completed.stdout.decode("utf-8", "replace").split())
+    if "bastion" not in installed:
+        raise BastionTunnelError(
+            "The 'bastion' az CLI extension is not installed. "
+            "Install it on the Ansible controller with: az extension add --name bastion"
+        )
+    with _EXTENSION_CHECK_LOCK:
+        _EXTENSION_CHECK_CACHE.add(az_path)
+
+
+def start_tunnel(az_path, bastion_name, resource_group, target_resource_id,
+                 target_port, local_port, subscription=None, extra_env=None):
+    """Spawn ``az network bastion tunnel`` as a subprocess.
+
+    Returns the subprocess.Popen handle. Caller is responsible for
+    polling readiness via :func:`wait_for_port` and for terminating
+    the process via :func:`terminate_tunnel`.
+    """
+    cmd = [
+        az_path, "network", "bastion", "tunnel",
+        "--name", bastion_name,
+        "--resource-group", resource_group,
+        "--target-resource-id", target_resource_id,
+        "--resource-port", str(target_port),
+        "--port", str(local_port),
+    ]
+    if subscription:
+        cmd.extend(["--subscription", subscription])
+
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    # Suppress interactive prompts; az should not ask us anything here.
+    env.setdefault("AZURE_CORE_OUTPUT", "none")
+    env.setdefault("AZURE_CORE_ONLY_SHOW_ERRORS", "true")
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - args list, not shell
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        raise BastionTunnelError("Failed to spawn az tunnel subprocess: %s" % exc)
+    return proc
+
+
+def drain_stream_to_buffer(stream, buf, max_bytes=64 * 1024):
+    """Read from ``stream`` until EOF in a daemon thread, appending into a
+    bytearray buffer (capped at ``max_bytes``). Used to keep the tunnel's
+    stderr/stdout pipes from filling and blocking the subprocess after
+    readiness. Returns the started Thread.
+    """
+    def _drain():
+        try:
+            while True:
+                chunk = stream.read(4096)
+                if not chunk:
+                    break
+                if len(buf) < max_bytes:
+                    buf.extend(chunk[: max(0, max_bytes - len(buf))])
+        except Exception:
+            pass
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    thread = threading.Thread(target=_drain, daemon=True)
+    thread.start()
+    return thread
+
+
+def wait_for_port(port, timeout, proc=None, host="127.0.0.1"):
+    """Poll a TCP port until it accepts a connection or ``timeout`` elapses.
+
+    If ``proc`` is provided and exits before the port is ready, raise
+    BastionTunnelError including any captured stderr (most common cause:
+    Bastion SKU does not support tunneling, or auth failure).
+    """
+    deadline = time.monotonic() + timeout
+    last_err = None
+    while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            stderr = b""
+            try:
+                stderr = proc.stderr.read() or b""
+            except Exception:
+                pass
+            raise BastionTunnelError(
+                "az network bastion tunnel exited prematurely (rc=%d): %s"
+                % (proc.returncode, stderr.decode("utf-8", "replace").strip()
+                   or "no stderr captured. Verify the Bastion SKU is Standard or higher with "
+                   "enableTunneling=true, and that the target resource id is correct.")
+            )
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(1.0)
+        try:
+            sock.connect((host, port))
+            sock.close()
+            return
+        except OSError as exc:
+            last_err = exc
+            if exc.errno not in (errno.ECONNREFUSED, errno.EHOSTUNREACH, errno.ETIMEDOUT, errno.EAGAIN):
+                # Unexpected error — propagate.
+                sock.close()
+                raise BastionTunnelError("Unexpected error probing tunnel port %d: %s" % (port, exc))
+        finally:
+            try:
+                sock.close()
+            except Exception:
+                pass
+        time.sleep(0.25)
+    raise BastionTunnelError(
+        "Timed out after %ss waiting for az bastion tunnel to listen on 127.0.0.1:%d (last error: %s)"
+        % (timeout, port, last_err)
+    )
+
+
+def terminate_tunnel(proc, grace_seconds=5):
+    """Politely terminate the tunnel subprocess, escalating to KILL.
+
+    Safe to call multiple times. No-op if proc is None or already exited.
+    """
+    if proc is None:
+        return
+    if proc.poll() is not None:
+        return
+    try:
+        # We started the subprocess in its own session; signal the whole group
+        # so any child forks (the az CLI sometimes spawns helpers) also exit.
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.terminate()
+    except Exception:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=grace_seconds)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        pass

--- a/tests/integration/targets/connection_azure_bastion_ssh/aliases
+++ b/tests/integration/targets/connection_azure_bastion_ssh/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+shippable/azure/group15
+destructive

--- a/tests/integration/targets/connection_azure_bastion_ssh/meta/main.yml
+++ b/tests/integration/targets/connection_azure_bastion_ssh/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/connection_azure_bastion_ssh/tasks/main.yml
+++ b/tests/integration/targets/connection_azure_bastion_ssh/tasks/main.yml
@@ -1,0 +1,172 @@
+- name: Set unique suffix for resources
+  ansible.builtin.set_fact:
+    rpfx: "{{ resource_group | hash('md5') | truncate(8, True, '') }}"
+    bastion_rg: "{{ resource_group }}-bastionconn"
+    target_vm_name: "bvm{{ resource_group | hash('md5') | truncate(6, True, '') }}"
+    bastion_name: "bh{{ resource_group | hash('md5') | truncate(6, True, '') }}"
+    ssh_key_path: "/tmp/azure_bastion_conn_test_id_rsa"
+
+- name: Run azure_bastion_ssh connection plugin test
+  block:
+    - name: Generate ephemeral SSH keypair on the controller
+      ansible.builtin.command:
+        cmd: "ssh-keygen -t rsa -b 2048 -N '' -f {{ ssh_key_path }}"
+        creates: "{{ ssh_key_path }}"
+      delegate_to: localhost
+
+    - name: Read public key
+      ansible.builtin.slurp:
+        src: "{{ ssh_key_path }}.pub"
+      register: ssh_pub_key
+      delegate_to: localhost
+
+    - name: Create resource group for bastion+target VM
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ bastion_rg }}"
+        location: eastus
+
+    - name: Create virtual network
+      azure.azcollection.azure_rm_virtualnetwork:
+        resource_group: "{{ bastion_rg }}"
+        name: "vnet{{ rpfx }}"
+        address_prefixes_cidr:
+          - 10.10.0.0/16
+
+    - name: Create AzureBastionSubnet (mandatory name for Bastion)
+      azure.azcollection.azure_rm_subnet:
+        resource_group: "{{ bastion_rg }}"
+        name: AzureBastionSubnet
+        virtual_network_name: "vnet{{ rpfx }}"
+        address_prefix_cidr: "10.10.0.0/26"
+      register: bastion_subnet
+
+    - name: Create workload subnet for the target VM
+      azure.azcollection.azure_rm_subnet:
+        resource_group: "{{ bastion_rg }}"
+        name: "workload{{ rpfx }}"
+        virtual_network_name: "vnet{{ rpfx }}"
+        address_prefix_cidr: "10.10.1.0/24"
+      register: workload_subnet
+
+    - name: Create public IP for Bastion
+      azure.azcollection.azure_rm_publicipaddress:
+        resource_group: "{{ bastion_rg }}"
+        name: "pip{{ rpfx }}"
+        allocation_method: Static
+        sku: Standard
+
+    - name: Get Bastion public IP ID
+      azure.azcollection.azure_rm_publicipaddress_info:
+        resource_group: "{{ bastion_rg }}"
+        name: "pip{{ rpfx }}"
+      register: publicip_output
+
+    - name: Create Bastion host (Standard SKU with native tunneling enabled)
+      azure.azcollection.azure_rm_bastionhost:
+        resource_group: "{{ bastion_rg }}"
+        name: "{{ bastion_name }}"
+        ip_configurations:
+          - name: tunnelipconfig
+            subnet:
+              id: "{{ bastion_subnet.state.id }}"
+            public_ip_address:
+              id: "{{ publicip_output.publicipaddresses[0].id }}"
+            private_ip_allocation_method: Dynamic
+        sku:
+          name: Standard
+        enable_tunneling: true
+        scale_units: 2
+
+    - name: Create NIC for the target VM (no public IP)
+      azure.azcollection.azure_rm_networkinterface:
+        resource_group: "{{ bastion_rg }}"
+        name: "nic{{ rpfx }}"
+        virtual_network: "vnet{{ rpfx }}"
+        subnet: "workload{{ rpfx }}"
+        create_with_security_group: true
+        security_group: "nsg{{ rpfx }}"
+        ip_configurations:
+          - name: ipconfig1
+            primary: true
+
+    - name: Create target VM in private subnet
+      azure.azcollection.azure_rm_virtualmachine:
+        resource_group: "{{ bastion_rg }}"
+        name: "{{ target_vm_name }}"
+        vm_size: Standard_B1s
+        admin_username: azureuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/azureuser/.ssh/authorized_keys
+            key_data: "{{ ssh_pub_key.content | b64decode }}"
+        network_interfaces:
+          - "nic{{ rpfx }}"
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts
+          version: latest
+      register: target_vm
+
+    - name: Add target VM to in-memory inventory using the new connection plugin
+      ansible.builtin.add_host:
+        name: "{{ target_vm_name }}"
+        groups: bastion_test_targets
+        ansible_connection: azure.azcollection.azure_bastion_ssh
+        ansible_user: azureuser
+        ansible_ssh_private_key_file: "{{ ssh_key_path }}"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+        ansible_azure_bastion_name: "{{ bastion_name }}"
+        ansible_azure_bastion_resource_group: "{{ bastion_rg }}"
+        ansible_azure_bastion_target_resource_id: "{{ target_vm.ansible_facts.azure_vm.id }}"
+
+    - name: Run a remote command via the Bastion tunnel (retry while sshd warms up)
+      ansible.builtin.command:
+        cmd: hostname
+      register: remote_cmd
+      delegate_to: "{{ target_vm_name }}"
+      retries: 10
+      delay: 15
+      until: remote_cmd is succeeded
+
+    - name: Assert command ran on the target VM
+      ansible.builtin.assert:
+        that:
+          - remote_cmd.rc == 0
+          - remote_cmd.stdout | length > 0
+
+    - name: Verify SFTP path works (put_file)
+      ansible.builtin.copy:
+        content: "azure_bastion_ssh integration test\n"
+        dest: "/tmp/azure_bastion_ssh_canary"
+        mode: "0644"
+      delegate_to: "{{ target_vm_name }}"
+
+    - name: Read back the canary file
+      ansible.builtin.slurp:
+        src: "/tmp/azure_bastion_ssh_canary"
+      register: canary
+      delegate_to: "{{ target_vm_name }}"
+
+    - name: Assert canary content
+      ansible.builtin.assert:
+        that:
+          - "'azure_bastion_ssh integration test' in (canary.content | b64decode)"
+
+  always:
+    - name: Tear down resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ bastion_rg }}"
+        force_delete_nonempty: true
+        state: absent
+      ignore_errors: true
+
+    - name: Remove ephemeral SSH key
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ ssh_key_path }}"
+        - "{{ ssh_key_path }}.pub"
+      delegate_to: localhost
+      ignore_errors: true

--- a/tests/integration/targets/connection_azure_bastion_ssh/tasks/main.yml
+++ b/tests/integration/targets/connection_azure_bastion_ssh/tasks/main.yml
@@ -8,6 +8,13 @@
 
 - name: Run azure_bastion_ssh connection plugin test
   block:
+    - name: Ensure the 'bastion' az CLI extension is installed on the controller
+      ansible.builtin.command:
+        cmd: az extension add --name bastion --upgrade --yes
+      register: bastion_ext_install
+      changed_when: bastion_ext_install.rc == 0
+      delegate_to: localhost
+
     - name: Generate ephemeral SSH keypair on the controller
       ansible.builtin.command:
         cmd: "ssh-keygen -t rsa -b 2048 -N '' -f {{ ssh_key_path }}"

--- a/tests/integration/targets/connection_azure_bastion_ssh/tasks/main.yml
+++ b/tests/integration/targets/connection_azure_bastion_ssh/tasks/main.yml
@@ -93,7 +93,7 @@
       azure.azcollection.azure_rm_virtualmachine:
         resource_group: "{{ bastion_rg }}"
         name: "{{ target_vm_name }}"
-        vm_size: Standard_B1s
+        vm_size: Standard_D2s_v3
         admin_username: azureuser
         ssh_password_enabled: false
         ssh_public_keys:


### PR DESCRIPTION
##### SUMMARY
Fix #1044.

Adds `azure.azcollection.azure_bastion_ssh`, a new connection plugin that lets Ansible reach VMs in private Azure virtual networks by tunneling SSH through an Azure Bastion host. Today users have to run `az network bastion tunnel` manually in a separate terminal and target `127.0.0.1:<port>`; this plugin automates that per host.


##### ISSUE TYPE
- New Plugin Pull Request

##### COMPONENT NAME
plugins/connection/azure_bastion_ssh.py

##### ADDITIONAL INFORMATION
The plugin subclasses Ansible's built-in `ssh` connection plugin. For each host the first connection attempt:
1. Picks a free local TCP port (or honors `ansible_azure_bastion_local_port`).
2. Spawns `az network bastion tunnel --name ... --resource-group ... --target-resource-id ... --resource-port22 --port <local>` as a background subprocess on the controller.
3. Waits for the local port to be listening (configurable timeout).
4. Sets `self._options['host'] = '127.0.0.1'` / `port = <local>` so the parent ssh plugin connects through the tunnel.
5. Hands control to the parent — auth, SFTP, ControlMaster, become, file transfer all work as usual.
6. Tears the tunnel down on `close()` and via `atexit` on interpreter exit.

 Tunnels are cached per host (idempotent re-entry) and torn down via process-group SIGTERM with SIGKILL fallback.

**Requirements**
- Azure CLI (`az`) on the Ansible controller
- `bastion` az extension (`az extension add --name bastion`)
- Bastion host: **Standard SKU or higher**, with native-client tunneling enabled
- SSH key authentication (password auth not supported in v1)

**Usage**
 ```yaml
 [private_vms:vars]
 ansible_connection=azure.azcollection.azure_bastion_ssh
 ansible_user=azureuser
 ansible_ssh_private_key_file=~/.ssh/id_rsa
 ansible_azure_bastion_name=my-bastion
 ansible_azure_bastion_resource_group=my-network-rg

 [private_vms]
 webapp-01 ansible_azure_bastion_target_resource_id=/subscriptions/.../virtualMachines/webapp-01
```