### PR TITLE
Fix #2233: auth_source=auto regression with module subscription_id

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1754,13 +1754,13 @@ class AzureRMAuth(object):
             except Exception:
                 pass
 
+        if credentials.get('subscription_id') is None and not self.is_ad_resource:
+            return None
+
         if subscription_id is not None:
             credentials['subscription_id'] = subscription_id
 
-        if credentials.get('subscription_id') is None and not self.is_ad_resource:
-            return None
-        else:
-            return credentials
+        return credentials
 
     def _get_msi_credentials(self, subscription_id=None, client_id=None, _cloud_environment=None, **kwargs):
         # Get object `cloud_environment` from string `_cloud_environment`
@@ -1838,13 +1838,13 @@ class AzureRMAuth(object):
             credentials = self._get_profile(env_credentials['profile'], subscription_id=subscription_id)
             return credentials
 
+        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
+            return None
+
         if subscription_id is not None:
             env_credentials['subscription_id'] = subscription_id
 
-        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
-            return None
-        else:
-            return env_credentials
+        return env_credentials
 
     def _get_credentials(self, auth_source=None, **params):
         # Get authentication credentials.


### PR DESCRIPTION
##### SUMMARY
Fix #2233.

Restores the `pre-3.17.0` behavior where `auth_source: auto` falls back to the Azure CLI credential when no environment variables or `~/.azure/credentials` profile carries real auth - even if the module passes `subscription_id`.

**Root Cause**
PR #2223 added `subscription_id` injection into the dicts returned by `_get_profile` and `_get_env_credentials` so that a module-supplied `subscription_id` could override the env/profile one. The injection happened **before** the "no real creds > return None" gate, so when no env vars / profile auth fields were set, the dict still came back non-empty (just `{subscription_id}`). The auto-flow then accepted it as a valid credential set and never fell through to `AzureCliCredential`, producing:
```
Failed to authenticate with provided credentials. Some attributes were missing.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py

##### ADDITIONAL INFORMATION
1. Run the gate first against the *original* env/profile dict — preserves pre-3.17.0 detection semantics.
2. Then inject the param-supplied `subscription_id` on top.