### PR TITLE
feat(inventory): log filter expression when azure_rm host is excluded

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -434,8 +434,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             display.vvvv(f"Populate {inventory_hostname}")
 
             if self._filter_exclude_host(inventory_hostname, hostvars):
+                display.v(f"azure_rm inventory: host '{inventory_hostname}' excluded by exclude_host_filters/default_host_filters")
                 continue
             if not self._filter_include_host(inventory_hostname, hostvars):
+                display.v(f"azure_rm inventory: host '{inventory_hostname}' excluded by include_host_filters (no include rule matched)")
                 continue
 
             try:
@@ -467,6 +469,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 conditional = trust_as_template(conditional)
             try:
                 if boolean(self.templar.template(conditional)):
+                    display.v(f"azure_rm inventory: host '{inventory_hostname}' matched filter: {condition}")
                     return True
             except Exception as e:
                 if boolean(self.get_option('fail_on_template_errors')):


### PR DESCRIPTION
## Summary

- Adds verbose logging (`display.v`) to the `azure_rm` inventory plugin's `_filter_host()` method
- When a host is excluded by `exclude_host_filters`, `default_host_filters`, or `include_host_filters`, the specific filter expression that matched is now logged at verbosity level 1 (`-v`)
- Messages only appear with `-v` flag — no noise at default verbosity

## Problem

When hosts are excluded by filter rules, there is no log output explaining which filter caused the exclusion. This makes it difficult to troubleshoot why hosts disappear from inventory, especially when using `overwrite: true` in AAP inventory syncs where silent exclusion can cause destructive host deletion.

## Changes

- `_filter_host()`: Log the matching filter expression at `display.v()` when a condition evaluates to `True`
- `_populate()`: Log at `display.v()` when a host is skipped due to exclude or include filters, with context about which filter type caused it

## Example output (with `-v`)

```
azure_rm inventory: host 'my-vm-01' matched filter: powerstate != 'running'
azure_rm inventory: host 'my-vm-01' excluded by exclude_host_filters/default_host_filters
```

## Resolves

- [AAPRFE-2898](https://redhat.atlassian.net/browse/AAPRFE-2898) — Improve logging around azure_rm inventory plugin to log the filter that excluded a host