### PR TITLE
Add missing plural return keys to event_query.yml audit chain

### DIFF
--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -37,23 +37,49 @@ azure.azcollection.*:
        "storage": "Storage",
        "web": "App Integration & Messaging"
       } as $mapping |
-      (.aks_agent_pools //
+      (.accounts //
+       .aks_agent_pools //
        .ansible_facts.azure_vm //
        .ansible_facts.azure_vmss //
        .bastion_host //
+       .clusters //
        .connection //
+       .containerinstances //
        .database //
+       .databases //
        .deployment //
+       .deployments //
        .elastic_pool //
        .firewall_policy //
        .firewall_rule //
+       .firewallpolicies //
+       .firewalls //
+       .gateways //
        .instances //
        .ip_security_restrictions //
+       .keyvaults //
        .link_service //
+       .loadbalancers //
        .long_term_retention_policy //
+       .networkinterfaces //
+       .publicipaddresses //
+       .rediscaches //
+       .registries //
+       .resourcegroups //
        .response //
-       .state //
+       .rules //
+       .securitygroups //
+       .servers //
+       .servicebuses //
        .short_term_retention_policy //
+       .state //
+       .storageaccounts //
+       .subnets //
+       .virtual_hubs //
+       .virtualnetworks //
+       .vms //
+       .vpn_sites //
+       .webapps //
        .) |
       (if type=="array" then .[]
         else if type=="object" then .


### PR DESCRIPTION
## Summary

The jq expression in `extensions/audit/event_query.yml` extracts Azure resource IDs from Ansible module return data to count **indirectly managed nodes**. The expression uses a fallback chain of keys to locate the resource data in each module's return value.

**Bug:** Many `_info` modules (which list/query resources) return results under **plural** keys (e.g., `databases`, `servers`, `firewalls`), but the fallback chain only contained **singular** forms (e.g., `database`). When no key in the chain matched, the expression fell through to `.` (the entire result object), which itself lacks an `.id` field. The subsequent `select($data.id != null)` then **silently dropped** all resources from the count.

**Impact:** Indirect managed node counts were under-reported for any playbook using affected `_info` modules. This affects billing and tracking accuracy in AAP 2.7's indirect node counting feature.

## Changes

Added 26 missing return keys to the fallback chain, all verified against the actual module source code in `plugins/modules/`:

| Key added | Module(s) affected |
|---|---|
| `accounts` | `azure_rm_cosmosdbaccount_info` |
| `clusters` | `azure_rm_hdinsightcluster_info` |
| `containerinstances` | `azure_rm_containerinstance_info` |
| `databases` | `azure_rm_sqldatabase_info`, `azure_rm_mysqldatabase_info` |
| `deployments` | `azure_rm_deployment_info` |
| `firewallpolicies` | `azure_rm_firewallpolicy_info` |
| `firewalls` | `azure_rm_azurefirewall_info` |
| `gateways` | `azure_rm_appgateway_info`, `azure_rm_natgateway_info` |
| `keyvaults` | `azure_rm_keyvault_info` |
| `loadbalancers` | `azure_rm_loadbalancer_info` |
| `networkinterfaces` | `azure_rm_networkinterface_info` |
| `publicipaddresses` | `azure_rm_publicipaddress_info` |
| `rediscaches` | `azure_rm_rediscache_info` |
| `registries` | `azure_rm_containerregistry_info` |
| `resourcegroups` | `azure_rm_resourcegroup_info` |
| `rules` | `azure_rm_sqlfirewallrule_info` |
| `securitygroups` | `azure_rm_securitygroup_info` |
| `servers` | `azure_rm_sqlserver_info`, `azure_rm_mysqlserver_info` |
| `servicebuses` | `azure_rm_servicebus_info` |
| `storageaccounts` | `azure_rm_storageaccount_info` |
| `subnets` | `azure_rm_subnet_info` |
| `virtual_hubs` | `azure_rm_virtualhub_info` |
| `virtualnetworks` | `azure_rm_virtualnetwork_info` |
| `vms` | `azure_rm_virtualmachine_info` |
| `vpn_sites` | `azure_rm_vpnsite_info` |
| `webapps` | `azure_rm_webapp_info` |

All existing keys are preserved. The chain is now sorted alphabetically for easier maintenance.

## Before/After Example

**Before** -- querying SQL databases with `azure_rm_sqldatabase_info` returns:
```json
{"databases": [{"id": "/subscriptions/.../Microsoft.Sql/servers/srv1/databases/db1", "name": "db1"}]}
```
The chain had `.database` but not `.databases`, so it fell through to `.` (the top-level object). The top-level object has no `.id`, so `select($data.id != null)` dropped it silently. Result: **0 indirect nodes counted**.

**After** -- `.databases` is now in the chain, so it correctly matches the array, iterates over it, and extracts the resource ID. Result: **1 indirect node counted**.

## Discovery Context

This was discovered during testing of AAP 2.7's indirect node counting feature. The `event_query.yml` audit extension is used by the AAP gateway metrics service to track Azure resources managed by Ansible, and the missing keys caused systematic under-counting.

## Test Plan

- [x] YAML parses correctly (validated with Python yaml.safe_load)
- [x] jq expression is syntactically valid (tested with jq CLI)
- [x] jq expression correctly extracts resources from plural-key module output (tested with sample `databases` payload)
- [x] All 26 added keys verified against actual module source code in `plugins/modules/`