### PR TITLE
Fix: `azure_rm_eventgrid_topic` identity update by using PUT instead of PATCH

### DIFF
--- a/plugins/modules/azure_rm_eventgrid_topic.py
+++ b/plugins/modules/azure_rm_eventgrid_topic.py
@@ -582,9 +582,22 @@ class AzureRMEventgridTopic(AzureRMModuleBaseExt):
                                                    '',
                                                    self.results)
                 if changed and not self.check_mode:
-                    response = self.begin_update_eventgrid_topic(self.resource_group,
-                                                                 self.name,
-                                                                 topic_update_parameters)
+                    topic_info = self.models.Topic(
+                        location=response.get('location', self.location),
+                        tags=self.tags,
+                        input_schema=response.get('input_schema', self.input_schema),
+                        input_schema_mapping=input_schema_mapping,
+                        public_network_access=self.public_network_access,
+                        inbound_ip_rules=inbound_ip_rules,
+                        identity=identity_info,
+                        disable_local_auth=response.get('disable_local_auth', False),
+                        data_residency_boundary=response.get('data_residency_boundary'),
+                        minimum_tls_version_allowed=response.get('minimum_tls_version_allowed'),
+                        kind=self.kind,
+                        extended_location=extended_location)
+                    response = self.begin_create_or_update_eventgrid_topic(self.resource_group,
+                                                                           self.name,
+                                                                           topic_info)
                 if self.regenerate_keys and not self.check_mode:
                     changed = True
                     for key_name in self.regenerate_keys:


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where adding a new user-assigned managed identity to an existing EventGrid Topic via `azure_rm_eventgrid_topic` does not actually persist the new identity on Azure, even though the module returns success.

**Root Cause**
The EventGrid resource provider has a known bug: PATCH operations (`begin_update` with `TopicUpdateParameters`) on `Microsoft.EventGrid/topics` do not reliably persist updates to `identity.userAssignedIdentities`. The PATCH returns success but the new identity is silently dropped server-side. I verified this locally with a diagnostic playbook. After running the update with `[identity-1, identity-2]`, three independent GETs (the module's own response, raw ARM `azure_rm_resource_info`, and SDK  `azure_rm_eventgrid_topic_info`) all confirmed only `identity-1` was persisted on Azure — proving the issue is on the RP side, not in the module's response handling.

**Fix:**
Switch the update path from PATCH (`begin_update`) to PUT (`begin_create_or_update`) with a full `Topic` model.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_eventgrid_topic.py