### PR TITLE
Fix: typo in README.md + exclude .ansible-lint in galaxy.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ See the [Changelog](https://github.com/ansible-collections/azure/blob/dev/CHANGE
 ## Related Information
 
 * [Ansible Official Documentation](https://docs.ansible.com/): A comprehensive Ansible user guide.
-* [azure.azcolleciton Documentation](https://docs.ansible.com/ansible/latest/collections/azure/azcollection/index.html): Detailed information about the collection.
+* [azure.azcollection Documentation](https://docs.ansible.com/ansible/latest/collections/azure/azcollection/index.html): Detailed information about the collection.
 * [Azure Documentation](https://learn.microsoft.com/en-us/azure)
 
 ## License Information

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -72,3 +72,4 @@ build_ignore:
   - 'tests'
   - "*cloud-config-azure.ini"
   - "*cloud-config-azure.yml"
+  - '.ansible-lint'


### PR DESCRIPTION
##### SUMMARY
No functionality change. 

Fix typo and added `.ansible-lint` to the `build_ignore` list in `galaxy.yml` so it is excluded from the published collection artifact.

##### COMPONENT NAME
README.md
galaxy.yml