### PR TITLE
Prevents plugin failure while looping on a vm currently being created

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -886,7 +886,7 @@ class AzureHost(object):
                 id=self._vmss['id'],
                 name=self._vmss['name'],
             ) if self._vmss else {},
-            virtual_machine_size=self._vm_model['properties']['hardwareProfile']['vmSize'] if self._vm_model['properties'].get('hardwareProfile') else None,
+            virtual_machine_size=self._vm_model['properties']['hardwareProfile'].get('vmSize') if self._vm_model['properties'].get('hardwareProfile') else None,
             plan=self._vm_model['properties']['plan']['name'] if self._vm_model['properties'].get('plan') else None,
             resource_group=parse_resource_id(self._vm_model['id']).get('resource_group').lower(),
             default_inventory_hostname=self.default_inventory_hostname,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We had an issue were the azure_rm inventory plugin fails catastrophically (exception) with this message:
`[WARNING]: Failed to parse inventory with 'auto' plugin: 'vmSize'`

This is happening when a new arc vm is being created in the targetted resource groups.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
After troubleshooting, all our arc objects were ok when building the inventory, but one:
This is the content of its hardwareProfile: `{'dynamicMemoryConfig': {}}`. It's missing **vmSize** thus the code fails.
For others arc objects, we typically have:
`{'vmSize': 'Custom', 'processors': 2, 'memoryMB': 8192, 'dynamicMemoryConfig': {}}`
Note: all the arc objects I'm talking about are Azure Stack HCI vm

Exemple of inventory used:
```
---

plugin: azure.azcollection.azure_rm
auth_source: auto
include_vm_resource_groups: []
include_hcivm_resource_groups:
  - "*"
subscription_id: ....
plain_host_names: true
default_host_filters:
  - powerstate != 'running'
  - provisioning_state != 'succeeded'
```