### PR TITLE
New Modules #358: Add `azure_rm_storagesharedirectory` modules to manage directories inside an Azure file share

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -252,6 +252,7 @@ try:
     from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
     from azure.mgmt.trafficmanager import TrafficManagerManagementClient
     from azure.storage.blob import BlobServiceClient
+    from azure.storage.fileshare import ShareDirectoryClient, ShareClient, ShareFileClient
     from azure.mgmt.authorization import AuthorizationManagementClient
     from azure.mgmt.sql import SqlManagementClient
     from azure.mgmt.servicebus import ServiceBusManagementClient
@@ -697,6 +698,64 @@ class AzureRMModuleBase(object):
             )
         except Exception as exc:
             self.fail("Error creating blob service client for storage account {0} - {1}".format(storage_account_name, str(exc)))
+
+    def _get_file_share_endpoint_credential(self, resource_group_name, storage_account_name):
+        '''
+        Resolve the file share data-plane endpoint and account-key credential for the
+        given storage account. Used by the file-share directory/file helpers.
+        '''
+        try:
+            account = self.storage_client.storage_accounts.get_properties(resource_group_name=resource_group_name,
+                                                                          account_name=storage_account_name)
+            account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name,
+                                                                          account_name=storage_account_name)
+        except Exception as exc:
+            self.fail("Error getting storage account detail for {0}: {1}".format(storage_account_name, str(exc)))
+        return account.primary_endpoints.file, account_keys.keys[0].value
+
+    def get_share_directory_client(self, resource_group_name, storage_account_name, share_name, directory_path):
+        '''
+        Build a ShareDirectoryClient for the given directory path inside a file share,
+        using the storage account key resolved from the management plane.
+        '''
+        account_url, credential = self._get_file_share_endpoint_credential(resource_group_name, storage_account_name)
+        try:
+            return ShareDirectoryClient(account_url=account_url,
+                                        share_name=share_name,
+                                        directory_path=directory_path,
+                                        credential=credential)
+        except Exception as exc:
+            self.fail("Error creating share directory client for {0}/{1}/{2}: {3}".format(
+                storage_account_name, share_name, directory_path, str(exc)))
+
+    def get_share_client(self, resource_group_name, storage_account_name, share_name):
+        '''
+        Build a ShareClient for the given file share, using the storage account key
+        resolved from the management plane.
+        '''
+        account_url, credential = self._get_file_share_endpoint_credential(resource_group_name, storage_account_name)
+        try:
+            return ShareClient(account_url=account_url,
+                               share_name=share_name,
+                               credential=credential)
+        except Exception as exc:
+            self.fail("Error creating share client for {0}/{1}: {2}".format(
+                storage_account_name, share_name, str(exc)))
+
+    def get_share_file_client(self, resource_group_name, storage_account_name, share_name, file_path):
+        '''
+        Build a ShareFileClient for the given file path inside a file share, using
+        the storage account key resolved from the management plane.
+        '''
+        account_url, credential = self._get_file_share_endpoint_credential(resource_group_name, storage_account_name)
+        try:
+            return ShareFileClient(account_url=account_url,
+                                   share_name=share_name,
+                                   file_path=file_path,
+                                   credential=credential)
+        except Exception as exc:
+            self.fail("Error creating share file client for {0}/{1}/{2}: {3}".format(
+                storage_account_name, share_name, file_path, str(exc)))
 
     def create_default_pip(self, resource_group, location, public_ip_name, allocation_method='Dynamic', sku=None):
         '''

--- a/plugins/modules/azure_rm_storagesharedirectory.py
+++ b/plugins/modules/azure_rm_storagesharedirectory.py
@@ -1,0 +1,378 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang Chin, (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_storagesharedirectory
+version_added: "3.19.0"
+short_description: Manage directories inside an Azure file share
+description:
+    - Create, update or delete a directory (folder) inside an Azure Storage file share.
+options:
+    resource_group:
+        description:
+            - Name of the resource group that contains the storage account.
+        required: true
+        type: str
+    account_name:
+        description:
+            - Name of the parent storage account hosting the file share.
+        required: true
+        type: str
+    share_name:
+        description:
+            - Name of the existing file share.
+        required: true
+        type: str
+    name:
+        description:
+            - Path of the directory to manage inside the file share, for example C(foo) or C(foo/bar/baz).
+            - When I(parents=false), the default, the parent path must already exist.
+        required: true
+        type: str
+        aliases:
+            - path
+    metadata:
+        description:
+            - A name-value pair to associate with the directory as metadata.
+            - All existing metadata will be replaced on each update.
+        type: dict
+    parents:
+        description:
+            - When C(true) and C(state=present), missing intermediate directories in C(name) are
+              created.
+            - When C(false), the default, the module fails if any parent segment does not exist.
+        type: bool
+        default: false
+    force:
+        description:
+            - When C(true) and C(state=absent), recursively delete the contents of the directory
+              before deleting the directory itself.
+            - When C(false), the default, the module fails if the directory is not empty.
+        type: bool
+        default: false
+    state:
+        description:
+            - State of the directory. Use C(present) to create or update and C(absent) to delete.
+        default: present
+        type: str
+        choices:
+            - absent
+            - present
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang Chin (@zunyangc)
+'''
+
+EXAMPLES = '''
+---
+- name: Create a directory at the share root
+  azure.azcollection.azure_rm_storagesharedirectory:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    name: parent
+
+- name: Create a nested directory tree (mkdir -p semantics)
+  azure.azcollection.azure_rm_storagesharedirectory:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    name: parent/child/grandchild
+    parents: true
+    metadata:
+      owner: ansible
+
+- name: Update metadata on an existing directory
+  azure.azcollection.azure_rm_storagesharedirectory:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    name: parent
+    metadata:
+      owner: ansible
+      env: prod
+
+- name: Delete an empty directory
+  azure.azcollection.azure_rm_storagesharedirectory:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    name: parent/child/grandchild
+    state: absent
+
+- name: Delete a directory recursively (including children)
+  azure.azcollection.azure_rm_storagesharedirectory:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    name: parent
+    state: absent
+    force: true
+'''
+
+RETURN = '''
+state:
+    description:
+        - Facts about the current state of the directory.
+    returned: always
+    type: complex
+    contains:
+        name:
+            description:
+                - Name of the directory (the leaf segment of the path).
+            returned: always
+            type: str
+            sample: grandchild
+        path:
+            description:
+                - Full path of the directory within the file share.
+            returned: always
+            type: str
+            sample: parent/child/grandchild
+        share:
+            description:
+                - Name of the parent file share.
+            returned: always
+            type: str
+            sample: myshare
+        account:
+            description:
+                - Name of the parent storage account.
+            returned: always
+            type: str
+            sample: myStorageAccount
+        etag:
+            description:
+                - The directory entity tag.
+            returned: when the directory exists
+            type: str
+            sample: '"0x8D75E4BA3E275F1"'
+        last_modified:
+            description:
+                - The time the directory was last modified.
+            returned: when the directory exists
+            type: str
+            sample: '2026-05-14T03:11:22+00:00'
+        metadata:
+            description:
+                - Name-value pairs associated with the directory as metadata.
+            returned: when the directory exists
+            type: dict
+            sample: {"owner": "ansible"}
+'''
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError, ResourceExistsError
+except ImportError:
+    # Handled in azure_rm_common
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+class AzureRMStorageShareDirectory(AzureRMModuleBase):
+    '''
+    Manage a directory inside an Azure Storage file share via the data plane.
+    '''
+
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str', required=True),
+            account_name=dict(type='str', required=True),
+            share_name=dict(type='str', required=True),
+            name=dict(type='str', required=True, aliases=['path']),
+            metadata=dict(type='dict'),
+            parents=dict(type='bool', default=False),
+            force=dict(type='bool', default=False),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+        )
+        self.results = dict(
+            changed=False,
+            state=dict(),
+        )
+
+        self.resource_group = None
+        self.account_name = None
+        self.share_name = None
+        self.name = None
+        self.metadata = None
+        self.parents = False
+        self.force = False
+        self.state = None
+
+        super(AzureRMStorageShareDirectory, self).__init__(
+            self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in list(self.module_arg_spec.keys()):
+            setattr(self, key, kwargs[key])
+
+        # Normalise the path (no leading/trailing slashes).
+        self.name = self.name.strip('/').strip()
+        if not self.name:
+            self.fail("The directory 'name' must not be empty.")
+
+        directory_client = self._get_directory_client(self.name)
+        existing = self._get_directory(directory_client)
+
+        if self.state == 'present':
+            if existing is None:
+                self.results['changed'] = True
+                if not self.check_mode:
+                    self._create_directory(directory_client)
+                    if self.metadata is not None:
+                        directory_client.set_directory_metadata(metadata=self.metadata)
+                    self.results['state'] = self._build_state(self._get_directory(directory_client))
+                else:
+                    self.results['state'] = self._build_state(None)
+            else:
+                if self.metadata is not None and (existing.get('metadata') or {}) != self.metadata:
+                    self.results['changed'] = True
+                    if not self.check_mode:
+                        directory_client.set_directory_metadata(metadata=self.metadata)
+                        existing = self._get_directory(directory_client)
+                self.results['state'] = self._build_state(existing)
+        else:
+            if existing is not None:
+                self.results['changed'] = True
+                if not self.check_mode:
+                    self._delete_directory(directory_client)
+                self.results['state'] = self._build_state(None)
+            else:
+                self.results['state'] = self._build_state(None)
+
+        return self.results
+
+    def _get_directory_client(self, directory_path):
+        return self.get_share_directory_client(resource_group_name=self.resource_group,
+                                               storage_account_name=self.account_name,
+                                               share_name=self.share_name,
+                                               directory_path=directory_path)
+
+    def _get_file_client(self, file_path):
+        return self.get_share_file_client(resource_group_name=self.resource_group,
+                                          storage_account_name=self.account_name,
+                                          share_name=self.share_name,
+                                          file_path=file_path)
+
+    def _get_directory(self, directory_client):
+        try:
+            props = directory_client.get_directory_properties()
+        except ResourceNotFoundError:
+            return None
+        except Exception as exc:
+            self.fail("Error retrieving directory '{0}' on share '{1}': {2}".format(
+                directory_client.directory_path, self.share_name, str(exc)))
+
+        etag = getattr(props, 'etag', None)
+        last_modified = getattr(props, 'last_modified', None)
+        return dict(
+            metadata=getattr(props, 'metadata', None) or {},
+            etag=etag.replace('"', '') if isinstance(etag, str) else etag,
+            last_modified=str(last_modified) if last_modified is not None else None,
+        )
+
+    def _create_directory(self, directory_client):
+        if self.parents:
+            self._create_parents(self.name)
+        try:
+            directory_client.create_directory()
+        except ResourceExistsError:
+            # Race or pre-existing — treat as no-op.
+            pass
+        except Exception as exc:
+            self.fail("Error creating directory '{0}' on share '{1}': {2}".format(
+                self.name, self.share_name, str(exc)))
+
+    def _create_parents(self, full_path):
+        segments = full_path.split('/')
+        accumulated = ''
+        for segment in segments[:-1]:
+            if not segment:
+                continue
+            accumulated = segment if not accumulated else accumulated + '/' + segment
+            parent_client = self._get_directory_client(accumulated)
+            try:
+                parent_client.create_directory()
+            except ResourceExistsError:
+                continue
+            except Exception as exc:
+                self.fail("Error creating parent directory '{0}': {1}".format(accumulated, str(exc)))
+
+    def _delete_directory(self, directory_client):
+        if self.force:
+            self._recursive_delete(directory_client)
+            return
+        try:
+            directory_client.delete_directory()
+        except Exception as exc:
+            self.fail("Error deleting directory '{0}' on share '{1}': {2}".format(
+                self.name, self.share_name, str(exc)))
+
+    def _recursive_delete(self, directory_client):
+        '''
+        Walk the directory client-side, deleting every file and subdirectory before
+        deleting the target directory itself. The REST API has no recursive delete.
+        '''
+        try:
+            entries = list(directory_client.list_directories_and_files())
+        except Exception as exc:
+            self.fail("Error listing contents of directory '{0}': {1}".format(
+                directory_client.directory_path, str(exc)))
+
+        for entry in entries:
+            child_path = directory_client.directory_path + '/' + entry['name']
+            if entry.get('is_directory'):
+                child_client = self._get_directory_client(child_path)
+                self._recursive_delete(child_client)
+            else:
+                file_client = self._get_file_client(child_path)
+                try:
+                    file_client.delete_file()
+                except Exception as exc:
+                    self.fail("Error deleting file '{0}': {1}".format(child_path, str(exc)))
+
+        try:
+            directory_client.delete_directory()
+        except Exception as exc:
+            self.fail("Error deleting directory '{0}' on share '{1}': {2}".format(
+                directory_client.directory_path, self.share_name, str(exc)))
+
+    def _build_state(self, props):
+        leaf = self.name.split('/')[-1]
+        state = dict(
+            name=leaf,
+            path=self.name,
+            share=self.share_name,
+            account=self.account_name,
+        )
+        if props is not None:
+            state.update(dict(
+                etag=props.get('etag'),
+                last_modified=props.get('last_modified'),
+                metadata=props.get('metadata') or {},
+            ))
+        return state
+
+
+def main():
+    AzureRMStorageShareDirectory()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_storagesharedirectory_info.py
+++ b/plugins/modules/azure_rm_storagesharedirectory_info.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang Chin, (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_storagesharedirectory_info
+version_added: "3.19.0"
+short_description: Get information about directories inside an Azure file share
+description:
+    - Get properties for a specific directory inside an Azure Storage file share, or list the
+      directories at a given path (default the share root).
+options:
+    resource_group:
+        description:
+            - Name of the resource group that contains the storage account.
+        required: true
+        type: str
+    account_name:
+        description:
+            - Name of the parent storage account hosting the file share.
+        required: true
+        type: str
+    share_name:
+        description:
+            - Name of the existing file share.
+        required: true
+        type: str
+    name:
+        description:
+            - Path of the directory to return properties for, for example C(foo/bar).
+            - If omitted, the module lists directories under C(path) (defaults to the share root).
+        type: str
+        aliases:
+            - path
+    recursive:
+        description:
+            - When listing directories, walk the tree and return every directory under the start path.
+            - Ignored when C(name) is specified.
+        type: bool
+        default: false
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang Chin (@zunyangc)
+'''
+
+EXAMPLES = '''
+---
+- name: Get a single directory's properties
+  azure.azcollection.azure_rm_storagesharedirectory_info:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    name: parent/child
+
+- name: List directories at the share root
+  azure.azcollection.azure_rm_storagesharedirectory_info:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+
+- name: List every directory in the share recursively
+  azure.azcollection.azure_rm_storagesharedirectory_info:
+    resource_group: myResourceGroup
+    account_name: myStorageAccount
+    share_name: myshare
+    recursive: true
+'''
+
+RETURN = '''
+storagesharedirectories:
+    description:
+        - List of directories matching the request. Always a list, even for a single C(name) lookup.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        name:
+            description:
+                - Leaf name of the directory.
+            returned: always
+            type: str
+            sample: child
+        path:
+            description:
+                - Full path of the directory within the file share.
+            returned: always
+            type: str
+            sample: parent/child
+        share:
+            description:
+                - Name of the parent file share.
+            returned: always
+            type: str
+            sample: myshare
+        account:
+            description:
+                - Name of the parent storage account.
+            returned: always
+            type: str
+            sample: myStorageAccount
+        etag:
+            description:
+                - The directory entity tag.
+            returned: when properties are available
+            type: str
+        last_modified:
+            description:
+                - Time the directory was last modified.
+            returned: when properties are available
+            type: str
+        metadata:
+            description:
+                - Metadata associated with the directory.
+            returned: when properties are available
+            type: dict
+'''
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+except ImportError:
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+class AzureRMStorageShareDirectoryInfo(AzureRMModuleBase):
+
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str', required=True),
+            account_name=dict(type='str', required=True),
+            share_name=dict(type='str', required=True),
+            name=dict(type='str', aliases=['path']),
+            recursive=dict(type='bool', default=False),
+        )
+        self.results = dict(
+            changed=False,
+            storagesharedirectories=[],
+        )
+
+        self.resource_group = None
+        self.account_name = None
+        self.share_name = None
+        self.name = None
+        self.recursive = False
+
+        super(AzureRMStorageShareDirectoryInfo, self).__init__(
+            self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+            facts_module=True,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in list(self.module_arg_spec.keys()):
+            setattr(self, key, kwargs[key])
+
+        if self.name is not None:
+            self.name = self.name.strip('/').strip()
+
+        if self.name:
+            self.results['storagesharedirectories'] = self._get_one(self.name)
+        else:
+            self.results['storagesharedirectories'] = self._list('', recursive=self.recursive)
+
+        return self.results
+
+    def _get_one(self, path):
+        client = self.get_share_directory_client(
+            resource_group_name=self.resource_group,
+            storage_account_name=self.account_name,
+            share_name=self.share_name,
+            directory_path=path,
+        )
+        try:
+            props = client.get_directory_properties()
+        except ResourceNotFoundError:
+            return []
+        except Exception as exc:
+            self.fail("Error retrieving directory '{0}': {1}".format(path, str(exc)))
+        return [self._props_to_dict(path, props)]
+
+    def _list(self, base_path, recursive):
+        share_client = self.get_share_client(
+            resource_group_name=self.resource_group,
+            storage_account_name=self.account_name,
+            share_name=self.share_name,
+        )
+        if base_path:
+            iterable = share_client.get_directory_client(base_path).list_directories_and_files()
+        else:
+            iterable = share_client.list_directories_and_files()
+
+        results = []
+        try:
+            entries = list(iterable)
+        except Exception as exc:
+            self.fail("Error listing share '{0}': {1}".format(self.share_name, str(exc)))
+
+        for entry in entries:
+            if not entry.get('is_directory'):
+                continue
+            child_path = entry['name'] if not base_path else base_path + '/' + entry['name']
+            child_client = self.get_share_directory_client(
+                resource_group_name=self.resource_group,
+                storage_account_name=self.account_name,
+                share_name=self.share_name,
+                directory_path=child_path,
+            )
+            try:
+                props = child_client.get_directory_properties()
+            except Exception:
+                props = None
+            results.append(self._props_to_dict(child_path, props))
+            if recursive:
+                results.extend(self._list(child_path, recursive=True))
+        return results
+
+    def _props_to_dict(self, path, props):
+        leaf = path.split('/')[-1] if path else ''
+        result = dict(
+            name=leaf,
+            path=path,
+            share=self.share_name,
+            account=self.account_name,
+        )
+        if props is not None:
+            etag = getattr(props, 'etag', None)
+            last_modified = getattr(props, 'last_modified', None)
+            result.update(dict(
+                etag=etag.replace('"', '') if isinstance(etag, str) else etag,
+                last_modified=str(last_modified) if last_modified is not None else None,
+                metadata=getattr(props, 'metadata', None) or {},
+            ))
+        return result
+
+
+def main():
+    AzureRMStorageShareDirectoryInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -142,6 +142,7 @@ parameters:
       - "azure_rm_storageaccountmanagementpolicy"
       - "azure_rm_storageblob"
       - "azure_rm_storageshare"
+      - "azure_rm_storagesharedirectory"
       - "azure_rm_subnet"
       - "azure_rm_azure_rm_serviceendpointpolicy"
       - "azure_rm_azure_rm_serviceendpointpolicydefinition"

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ azure-ai-ml==1.31.0
 azure-nspkg==3.0.2
 azure-servicebus==7.14.2
 azure-storage-blob==12.23.0b1
+azure-storage-file-share==12.24.0
 msgraph-sdk==1.6.0
 netaddr>=1.3.0
 oras>=0.2.38

--- a/tests/integration/targets/azure_rm_storagesharedirectory/aliases
+++ b/tests/integration/targets/azure_rm_storagesharedirectory/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+shippable/azure/group2
+destructive

--- a/tests/integration/targets/azure_rm_storagesharedirectory/meta/main.yml
+++ b/tests/integration/targets/azure_rm_storagesharedirectory/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_storagesharedirectory/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storagesharedirectory/tasks/main.yml
@@ -1,0 +1,299 @@
+---
+- name: Create a new resource group for storage share directory test
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}-storagesharedir"
+    location: australiaeast
+
+- name: For storage share directory test
+  block:
+    - name: Set storage account name
+      ansible.builtin.set_fact:
+        storage_account: "sd{{ resource_group | hash('md5') | truncate(22, True, '') }}"
+        share_name: testsharedir
+
+    - name: Create storage account
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        name: "{{ storage_account }}"
+        account_type: Standard_LRS
+        kind: StorageV2
+
+    - name: Create the parent file share
+      azure.azcollection.azure_rm_storageshare:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        name: "{{ share_name }}"
+        quota: 32
+
+    - name: Create a top-level directory (check_mode)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+      check_mode: true
+      register: create_top_check
+
+    - name: Assert check_mode reports change but does not create
+      ansible.builtin.assert:
+        that:
+          - create_top_check is changed
+
+    - name: Confirm check_mode did not actually create the directory
+      azure.azcollection.azure_rm_storagesharedirectory_info:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+      register: check_mode_verify
+
+    - name: Assert directory is still absent after check_mode create
+      ansible.builtin.assert:
+        that:
+          - check_mode_verify.storagesharedirectories | length == 0
+
+    - name: Create a top-level directory
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        metadata:
+          owner: ansible
+      register: create_top
+
+    - name: Assert top-level directory created
+      ansible.builtin.assert:
+        that:
+          - create_top is changed
+          - create_top.state.name == 'parent'
+          - create_top.state.path == 'parent'
+          - create_top.state.metadata.owner == 'ansible'
+
+    - name: Re-run top-level directory create (idempotence)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        metadata:
+          owner: ansible
+      register: create_top_again
+
+    - name: Assert top-level create is idempotent
+      ansible.builtin.assert:
+        that:
+          - create_top_again is not changed
+
+    - name: Update metadata on the top-level directory (check_mode)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        metadata:
+          owner: ansible
+          env: prod
+      check_mode: true
+      register: update_metadata_check
+
+    - name: Assert metadata update is reported in check_mode
+      ansible.builtin.assert:
+        that:
+          - update_metadata_check is changed
+
+    - name: Update metadata on the top-level directory
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        metadata:
+          owner: ansible
+          env: prod
+      register: update_metadata
+
+    - name: Assert metadata update changed the directory
+      ansible.builtin.assert:
+        that:
+          - update_metadata is changed
+          - update_metadata.state.metadata.env == 'prod'
+
+    - name: Re-run metadata update (idempotence)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        metadata:
+          owner: ansible
+          env: prod
+      register: update_metadata_again
+
+    - name: Assert metadata update is idempotent
+      ansible.builtin.assert:
+        that:
+          - update_metadata_again is not changed
+
+    - name: Attempt nested create without parents=true (expect failure)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/missing/leaf
+      register: nested_no_parents
+      failed_when: false
+
+    - name: Assert strict create fails when parent path is missing
+      ansible.builtin.assert:
+        that:
+          - nested_no_parents.failed
+
+    - name: Create a nested directory tree with parents=true (using path alias)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        path: parent/child/grandchild
+        parents: true
+      register: create_nested
+
+    - name: Assert nested create succeeded
+      ansible.builtin.assert:
+        that:
+          - create_nested is changed
+          - create_nested.state.path == 'parent/child/grandchild'
+
+    - name: Re-run nested create (idempotence)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/child/grandchild
+        parents: true
+      register: create_nested_again
+
+    - name: Assert nested create is idempotent
+      ansible.builtin.assert:
+        that:
+          - create_nested_again is not changed
+
+    - name: Get info for a single directory
+      azure.azcollection.azure_rm_storagesharedirectory_info:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/child
+      register: info_one
+
+    - name: Assert single-directory info
+      ansible.builtin.assert:
+        that:
+          - info_one.storagesharedirectories | length == 1
+          - info_one.storagesharedirectories[0].path == 'parent/child'
+
+    - name: List directories recursively
+      azure.azcollection.azure_rm_storagesharedirectory_info:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        recursive: true
+      register: info_all
+
+    - name: Assert recursive listing contains the nested tree
+      ansible.builtin.assert:
+        that:
+          - info_all.storagesharedirectories | map(attribute='path') | list is superset(['parent', 'parent/child', 'parent/child/grandchild'])
+
+    - name: Delete the leaf directory (check_mode)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/child/grandchild
+        state: absent
+      check_mode: true
+      register: delete_leaf_check
+
+    - name: Assert delete is reported in check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_leaf_check is changed
+
+    - name: Confirm check_mode did not actually delete the directory
+      azure.azcollection.azure_rm_storagesharedirectory_info:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/child/grandchild
+      register: leaf_after_check_delete
+
+    - name: Assert directory still present after check_mode delete
+      ansible.builtin.assert:
+        that:
+          - leaf_after_check_delete.storagesharedirectories | length == 1
+
+    - name: Delete the leaf directory
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/child/grandchild
+        state: absent
+      register: delete_leaf
+
+    - name: Assert leaf delete reported a change
+      ansible.builtin.assert:
+        that:
+          - delete_leaf is changed
+
+    - name: Re-run leaf delete (idempotence)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent/child/grandchild
+        state: absent
+      register: delete_leaf_again
+
+    - name: Assert leaf delete is idempotent
+      ansible.builtin.assert:
+        that:
+          - delete_leaf_again is not changed
+
+    - name: Force-delete the remaining tree
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        state: absent
+        force: true
+      register: delete_force
+
+    - name: Assert force delete removed the directory tree
+      ansible.builtin.assert:
+        that:
+          - delete_force is changed
+
+    - name: Re-run force delete (idempotence)
+      azure.azcollection.azure_rm_storagesharedirectory:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        share_name: "{{ share_name }}"
+        name: parent
+        state: absent
+        force: true
+      register: delete_force_again
+
+    - name: Assert force delete is idempotent
+      ansible.builtin.assert:
+        that:
+          - delete_force_again is not changed
+
+  always:
+    - name: Delete resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ resource_group }}-storagesharedir"
+        force_delete_nonempty: true
+        state: absent

--- a/tests/integration/targets/azure_rm_storagesharedirectory/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storagesharedirectory/tasks/main.yml
@@ -292,8 +292,27 @@
         that:
           - delete_force_again is not changed
 
+    - name: Delete share
+      azure.azcollection.azure_rm_storageshare:
+        name: "{{ share_name }}"
+        resource_group: "{{ resource_group }}-storagesharedir"
+        account_name: "{{ storage_account }}"
+        state: absent
+      register: delete_output
+
+    - name: Pause for 3 minutes to waiting delete
+      ansible.builtin.pause:
+        minutes: 3
+      changed_when: true
+
+    - name: Delete storage account
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storagesharedir"
+        name: "{{ storage_account }}"
+        state: absent
+
   always:
-    - name: Delete resource group
+    - name: Force delete resource group
       azure.azcollection.azure_rm_resourcegroup:
         name: "{{ resource_group }}-storagesharedir"
         force_delete_nonempty: true

--- a/tests/integration/targets/azure_rm_storagesharedirectory/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storagesharedirectory/tasks/main.yml
@@ -142,12 +142,13 @@
         share_name: "{{ share_name }}"
         name: parent/missing/leaf
       register: nested_no_parents
-      failed_when: false
+      ignore_errors: true
 
     - name: Assert strict create fails when parent path is missing
       ansible.builtin.assert:
         that:
-          - nested_no_parents.failed
+          - nested_no_parents is failed
+          - "'ParentNotFound' in (nested_no_parents.msg | default(''))"
 
     - name: Create a nested directory tree with parents=true (using path alias)
       azure.azcollection.azure_rm_storagesharedirectory:


### PR DESCRIPTION
##### SUMMARY
Fix #358. 

Adds two modules so users can manage directories inside an Azure Storage file share without shelling out to `az storage directory create`:
- `azure_rm_storagesharedirectory` - create / update metadata / delete a directory (and optionally its parents / contents).
- `azure_rm_storagesharedirectory_info` - get a single directory's properties or list directories under a path, optionally recursive.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_storagesharedirectory.py
plugins/modules/azure_rm_storagesharedirectory_info.py