### PR TITLE
Fix #2248: Align `azure_rm_adapplication` with Microsoft Graph create contract

### DIFF
--- a/plugins/modules/azure_rm_adapplication.py
+++ b/plugins/modules/azure_rm_adapplication.py
@@ -265,8 +265,8 @@ options:
               only retrievable from that response; there is no way to fetch it later.
             - Mutually exclusive with C(key_value).
             - Has no effect when C(state=absent) or C(native_app=true).
-            - On an update that triggers a PATCH, this will replace existing client secrets; for ongoing
-              secret rotation, prefer I(azure.azcollection.azure_rm_adpassword).
+            - On an update, this parameter is ignored with a warning. Microsoft Graph does not allow adding password
+              credentials via PATCH /applications. For ongoing secret rotation, use I(azure.azcollection.azure_rm_adpassword).
         type: bool
         default: false
 

--- a/plugins/modules/azure_rm_adapplication.py
+++ b/plugins/modules/azure_rm_adapplication.py
@@ -688,9 +688,9 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 )
             ),
             password=dict(type='str', no_log=True),
-            password_display_name=dict(type='str'),
-            key_display_name=dict(type='str'),
-            request_password=dict(type='bool', default=False),
+            password_display_name=dict(type='str', no_log=False),
+            key_display_name=dict(type='str', no_log=False),
+            request_password=dict(type='bool', default=False, no_log=False),
             public_client_reply_urls=dict(type='list', elements='str'),
             web_reply_urls=dict(type='list', elements='str', aliases=['reply_urls']),
             spa_reply_urls=dict(type='list', elements='str'),
@@ -792,7 +792,6 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                     request_password=bool(self.request_password),
                     password_display_name=self.password_display_name,
                     key_display_name=self.key_display_name,
-                    for_create=True,
                 )
             if self.required_resource_accesses:
                 required_accesses = self.build_application_accesses(self.required_resource_accesses)
@@ -835,23 +834,26 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
 
     def update_resource(self, old_response):
         try:
-            key_creds, password_creds, required_accesses, app_roles, optional_claims = None, None, None, None, None
-            if self.native_app:
-                if self.identifier_uris:
-                    self.fail("'identifier_uris' is not required for creating a native application")
-            else:
-                password_creds, key_creds = self.build_application_creds(
-                    key_value=self.key_value,
-                    key_type=self.key_type,
-                    key_usage=self.key_usage,
-                    start_date=self.start_date,
-                    end_date=self.end_date,
-                    key_description=self.credential_description,
-                    request_password=bool(self.request_password),
-                    password_display_name=self.password_display_name,
-                    key_display_name=self.key_display_name,
-                    for_create=False,
-                )
+            key_creds, required_accesses, app_roles, optional_claims = None, None, None, None
+            if not self.native_app:
+                if self.key_value:
+                    key_bytes = self._normalize_cert_key_value(self.key_value)
+                    custom_key_id = (self.encode_custom_key_description(self.credential_description)
+                                     if self.credential_description else None)
+                    key_creds = [KeyCredential(
+                        display_name=self.key_display_name,
+                        key=key_bytes,
+                        usage=(self.key_usage or 'Verify'),
+                        type=(self.key_type or 'AsymmetricX509Cert'),
+                        custom_key_identifier=custom_key_id,
+                    )]
+                if self.request_password or self.password:
+                    self.module.warn(
+                        "Ignoring 'request_password'/'password' on update: Microsoft Graph does not "
+                        "allow adding password credentials via PATCH /applications. Use "
+                        "azure.azcollection.azure_rm_adpassword to add or rotate client secrets on an "
+                        "existing application."
+                    )
             if self.required_resource_accesses:
                 required_accesses = self.build_application_accesses(self.required_resource_accesses)
 
@@ -876,7 +878,6 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 identifier_uris=self.identifier_uris,
                 key_credentials=key_creds,
                 notes=self.notes,
-                password_credentials=password_creds,
                 required_resource_access=required_accesses,
                 # allow_guests_sign_in=self.allow_guests_sign_in,
                 app_roles=app_roles,
@@ -1011,7 +1012,9 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
     def build_application_creds(self, key_value=None, key_type=None, key_usage=None,
                                 start_date=None, end_date=None, key_description=None,
                                 request_password=False, password_display_name=None,
-                                key_display_name=None, for_create=False):
+                                key_display_name=None):
+        # Build credential payloads for POST /applications. Microsoft Graph generates
+        # keyId / secretText / hint server-side, so we never send them on create.
         if request_password and key_value:
             self.fail('specify either a password credential (request_password / password) or key_value, but not both.')
 
@@ -1031,48 +1034,24 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
         password_creds = None
         key_creds = None
 
-        if for_create:
-            # Microsoft Graph generates keyId/secretText; client must not supply them.
-            if request_password:
-                password_creds = [PasswordCredential(
-                    display_name=password_display_name,
-                    start_date_time=start_date,
-                    end_date_time=end_date,
-                )]
-            elif key_value:
-                key_bytes = self._normalize_cert_key_value(key_value)
-                custom_key_id = self.encode_custom_key_description(key_description) if key_description else None
-                key_creds = [KeyCredential(
-                    display_name=key_display_name,
-                    start_date_time=start_date,
-                    end_date_time=end_date,
-                    key=key_bytes,
-                    usage=key_usage,
-                    type=key_type,
-                    custom_key_identifier=custom_key_id,
-                )]
-        else:
-            # Update (PATCH) path: legacy behavior preserved for backward compatibility.
-            if request_password:
-                password_creds = [PasswordCredential(
-                    display_name=password_display_name,
-                    start_date_time=start_date,
-                    end_date_time=end_date,
-                    key_id=self.gen_guid(),
-                )]
-            elif key_value:
-                key_bytes = self._normalize_cert_key_value(key_value)
-                custom_key_id = self.encode_custom_key_description(key_description) if key_description else None
-                key_creds = [KeyCredential(
-                    display_name=key_display_name,
-                    start_date_time=start_date,
-                    end_date_time=end_date,
-                    key_id=self.gen_guid(),
-                    key=key_bytes,
-                    usage=key_usage,
-                    type=key_type,
-                    custom_key_identifier=custom_key_id,
-                )]
+        if request_password:
+            password_creds = [PasswordCredential(
+                display_name=password_display_name,
+                start_date_time=start_date,
+                end_date_time=end_date,
+            )]
+        elif key_value:
+            key_bytes = self._normalize_cert_key_value(key_value)
+            custom_key_id = self.encode_custom_key_description(key_description) if key_description else None
+            key_creds = [KeyCredential(
+                display_name=key_display_name,
+                start_date_time=start_date,
+                end_date_time=end_date,
+                key=key_bytes,
+                usage=key_usage,
+                type=key_type,
+                custom_key_identifier=custom_key_id,
+            )]
 
         return password_creds, key_creds
 

--- a/plugins/modules/azure_rm_adapplication.py
+++ b/plugins/modules/azure_rm_adapplication.py
@@ -242,8 +242,33 @@ options:
                         elements: str
     password:
         description:
-            - App password, aka 'client secret'.
+            - (Deprecated). Microsoft Graph generates client secrets server-side and rejects client-supplied values.
+            - When set, the supplied value is ignored and a server-generated secret is created instead.
+            - Prefer C(request_password=true) with C(password_display_name). The generated secret appears in
+              the registered result under C(generated_password_credentials[0].secret_text).
+            - For ongoing rotation/management of secrets, use I(azure.azcollection.azure_rm_adpassword).
         type: str
+    password_display_name:
+        description:
+            - Name for the client secret created on the new application.
+            - Used together with C(request_password=true) (or legacy C(password)).
+        type: str
+    key_display_name:
+        description:
+            - Name for the certificate credential created on the new application.
+            - Used together with C(key_value).
+        type: str
+    request_password:
+        description:
+            - When C(true), ask Microsoft Graph to generate a client secret for the new application.
+            - The generated secret is returned in C(generated_password_credentials[0].secret_text) and is
+              only retrievable from that response; there is no way to fetch it later.
+            - Mutually exclusive with C(key_value).
+            - Has no effect when C(state=absent) or C(native_app=true).
+            - On an update that triggers a PATCH, this will replace existing client secrets; for ongoing
+              secret rotation, prefer I(azure.azcollection.azure_rm_adpassword).
+        type: bool
+        default: false
 
     web_reply_urls:
         description:
@@ -366,6 +391,19 @@ EXAMPLES = '''
   key_value: "{{ cert_file.content }}" # slurp gives base64 of the file; module normalizes to DER bytes
   tenant: "{{ tenant_id }}"
   subscription_id: "{{ subscription_id }}"
+
+- name: Create ad application and request a server-generated client secret
+  azure_rm_adapplication:
+    display_name: "{{ display_name }}"
+    request_password: true
+    password_display_name: "ansible-managed-secret"
+  register: app
+  no_log: true
+
+- name: Show the generated secret (only available on this create response)
+  ansible.builtin.debug:
+    msg: "{{ app.generated_password_credentials[0].secret_text }}"
+  no_log: true
 '''
 
 RETURN = '''
@@ -456,6 +494,82 @@ optional_claims:
             type: list
             returned: always
             sample: ['name': 'acct', 'source': null, 'essential': false, 'additional_properties': []]
+password_credentials:
+    description:
+        - Client secret credentials on the application (without secret values).
+        - For newly-generated secrets on create, see C(generated_password_credentials).
+    type: list
+    elements: dict
+    returned: always
+    contains:
+        key_id:
+            description: Unique identifier (GUID) of the secret.
+            type: str
+        display_name:
+            description: Name of the secret.
+            type: str
+        hint:
+            description: First three characters of the secret value.
+            type: str
+        start_date_time:
+            description: When the secret becomes valid.
+            type: str
+        end_date_time:
+            description: When the secret expires.
+            type: str
+key_credentials:
+    description:
+        - Certificate credentials on the application (without raw key bytes).
+    type: list
+    elements: dict
+    returned: always
+    contains:
+        key_id:
+            description: Unique identifier (GUID) of the credential.
+            type: str
+        display_name:
+            description: Name of the credential.
+            type: str
+        type:
+            description: Credential type (e.g. C(AsymmetricX509Cert)).
+            type: str
+        usage:
+            description: Credential usage (e.g. C(Verify)).
+            type: str
+        start_date_time:
+            description: When the credential becomes valid.
+            type: str
+        end_date_time:
+            description: When the credential expires.
+            type: str
+generated_password_credentials:
+    description:
+        - Newly-generated client secrets returned on create. Each entry includes C(secret_text), the only
+          opportunity to retrieve the generated password value.
+        - Treat C(secret_text) as sensitive and register the task with C(no_log) when consuming it.
+        - Empty/absent when the module did not request a new secret or when called on update.
+    type: list
+    elements: dict
+    returned: on create when a password credential was requested
+    contains:
+        key_id:
+            description: Unique identifier (GUID) of the new secret.
+            type: str
+        display_name:
+            description: Name of the new secret.
+            type: str
+        hint:
+            description: First three characters of the secret value.
+            type: str
+        secret_text:
+            description: The generated secret value. Only present on initial create.
+            type: str
+        start_date_time:
+            description: When the secret becomes valid.
+            type: str
+        end_date_time:
+            description: When the secret expires.
+            type: str
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
@@ -574,6 +688,9 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 )
             ),
             password=dict(type='str', no_log=True),
+            password_display_name=dict(type='str'),
+            key_display_name=dict(type='str'),
+            request_password=dict(type='bool', default=False),
             public_client_reply_urls=dict(type='list', elements='str'),
             web_reply_urls=dict(type='list', elements='str', aliases=['reply_urls']),
             spa_reply_urls=dict(type='list', elements='str'),
@@ -598,6 +715,9 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
         self.oauth2_allow_implicit_flow = None
         self.optional_claims = None
         self.password = None
+        self.password_display_name = None
+        self.key_display_name = None
+        self.request_password = None
         self.public_client_reply_urls = None
         self.spa_reply_urls = None
         self.web_reply_urls = None
@@ -615,8 +735,30 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
 
     def exec_module(self, **kwargs):
         self._client = self.get_msgraph_client()
+
+        # Guard against the AZURE_COMMON_ARGS 'password' (user-password auth) leaking in via module_defaults.
+        if kwargs.get('password') and kwargs.get('ad_user'):
+            self.module.warn(
+                "Ignoring 'password' on azure_rm_adapplication because 'ad_user' is also set; the value "
+                "appears to come from Azure user-password authentication rather than an explicit app secret. "
+            )
+            kwargs['password'] = None
+
         for key in list(self.module_arg_spec.keys()):
             setattr(self, key, kwargs[key])
+
+        # Microsoft Graph generates secrets server-side; the legacy 'password' value is never honored.
+        if self.password and self.state == 'present' and not self.native_app:
+            self.module.deprecate(
+                "Setting 'password' as a client secret value on azure_rm_adapplication is incompatible "
+                "with Microsoft Graph (the value is ignored server-side). Use 'request_password=true' "
+                "with 'password_display_name' and read the generated secret from "
+                "'generated_password_credentials[0].secret_text', or manage secrets with "
+                "azure_rm_adpassword. This parameter will be removed in a future major release.",
+                version='4.0.0',
+                collection_name='azure.azcollection',
+            )
+            self.request_password = True
 
         response = self.get_resource()
         if response:
@@ -640,10 +782,18 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 if self.identifier_uris:
                     self.fail("'identifier_uris' is not required for creating a native application")
             else:
-                password_creds, key_creds = self.build_application_creds(self.password, self.key_value, self.key_type,
-                                                                         self.key_usage,
-                                                                         self.start_date, self.end_date,
-                                                                         self.credential_description)
+                password_creds, key_creds = self.build_application_creds(
+                    key_value=self.key_value,
+                    key_type=self.key_type,
+                    key_usage=self.key_usage,
+                    start_date=self.start_date,
+                    end_date=self.end_date,
+                    key_description=self.credential_description,
+                    request_password=bool(self.request_password),
+                    password_display_name=self.password_display_name,
+                    key_display_name=self.key_display_name,
+                    for_create=True,
+                )
             if self.required_resource_accesses:
                 required_accesses = self.build_application_accesses(self.required_resource_accesses)
 
@@ -677,6 +827,8 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
             response = asyncio.get_event_loop().run_until_complete(self.create_application(create_app))
             self.results['changed'] = True
             self.results.update(self.to_dict(response))
+            # Capture the server-generated secret values; only available on the create response.
+            self.results['generated_password_credentials'] = self._extract_generated_passwords(response)
             return response
         except Exception as ge:
             self.fail("Error creating application, display_name: {0} - {1}".format(self.display_name, str(ge)))
@@ -688,10 +840,18 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
                 if self.identifier_uris:
                     self.fail("'identifier_uris' is not required for creating a native application")
             else:
-                password_creds, key_creds = self.build_application_creds(self.password, self.key_value, self.key_type,
-                                                                         self.key_usage,
-                                                                         self.start_date, self.end_date,
-                                                                         self.credential_description)
+                password_creds, key_creds = self.build_application_creds(
+                    key_value=self.key_value,
+                    key_type=self.key_type,
+                    key_usage=self.key_usage,
+                    start_date=self.start_date,
+                    end_date=self.end_date,
+                    key_description=self.credential_description,
+                    request_password=bool(self.request_password),
+                    password_display_name=self.password_display_name,
+                    key_display_name=self.key_display_name,
+                    for_create=False,
+                )
             if self.required_resource_accesses:
                 required_accesses = self.build_application_accesses(self.required_resource_accesses)
 
@@ -800,13 +960,60 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
             # allow_guests_sign_in=object.allow_guests_sign_in,
             web_reply_urls=object.web.redirect_uris,
             spa_reply_urls=object.spa.redirect_uris,
-            public_client_reply_urls=object.public_client.redirect_uris
+            public_client_reply_urls=object.public_client.redirect_uris,
+            password_credentials=self._summarize_password_credentials(object.password_credentials),
+            key_credentials=self._summarize_key_credentials(object.key_credentials),
         )
 
-    def build_application_creds(self, password=None, key_value=None, key_type=None, key_usage=None,
-                                start_date=None, end_date=None, key_description=None):
-        if password and key_value:
-            self.fail('specify either password or key_value, but not both.')
+    @staticmethod
+    def _summarize_password_credentials(creds):
+        if not creds:
+            return []
+        return [{
+            'key_id': str(c.key_id) if c.key_id is not None else None,
+            'display_name': c.display_name,
+            'hint': c.hint,
+            'start_date_time': str(c.start_date_time) if c.start_date_time is not None else None,
+            'end_date_time': str(c.end_date_time) if c.end_date_time is not None else None,
+        } for c in creds]
+
+    @staticmethod
+    def _summarize_key_credentials(creds):
+        if not creds:
+            return []
+        return [{
+            'key_id': str(c.key_id) if c.key_id is not None else None,
+            'display_name': c.display_name,
+            'type': c.type,
+            'usage': c.usage,
+            'start_date_time': str(c.start_date_time) if c.start_date_time is not None else None,
+            'end_date_time': str(c.end_date_time) if c.end_date_time is not None else None,
+        } for c in creds]
+
+    @staticmethod
+    def _extract_generated_passwords(application):
+        # Pull server-generated secret_text from the create response; only returned once by Graph.
+        creds = getattr(application, 'password_credentials', None) or []
+        out = []
+        for c in creds:
+            if not getattr(c, 'secret_text', None):
+                continue
+            out.append({
+                'key_id': str(c.key_id) if c.key_id is not None else None,
+                'display_name': c.display_name,
+                'hint': c.hint,
+                'secret_text': c.secret_text,
+                'start_date_time': str(c.start_date_time) if c.start_date_time is not None else None,
+                'end_date_time': str(c.end_date_time) if c.end_date_time is not None else None,
+            })
+        return out
+
+    def build_application_creds(self, key_value=None, key_type=None, key_usage=None,
+                                start_date=None, end_date=None, key_description=None,
+                                request_password=False, password_display_name=None,
+                                key_display_name=None, for_create=False):
+        if request_password and key_value:
+            self.fail('specify either a password credential (request_password / password) or key_value, but not both.')
 
         if not start_date:
             start_date = datetime.datetime.utcnow()
@@ -818,24 +1025,54 @@ class AzureRMADApplication(AzureRMModuleBaseExt):
         elif isinstance(end_date, str):
             end_date = dateutil.parser.parse(end_date)
 
-        custom_key_id = None
-        if key_description and password:
-            custom_key_id = self.encode_custom_key_description(key_description)
-
         key_type = key_type or 'AsymmetricX509Cert'
         key_usage = key_usage or 'Verify'
 
         password_creds = None
         key_creds = None
-        if password:
-            password_creds = [PasswordCredential(start_date_time=start_date, end_date_time=end_date,
-                                                 key_id=self.gen_guid(), secret_text=password,
-                                                 custom_key_identifier=custom_key_id)]  # value ? secret_text
-        elif key_value:
-            key_bytes = self._normalize_cert_key_value(key_value)
-            key_creds = [KeyCredential(start_date_time=start_date, end_date_time=end_date,
-                                       key_id=self.gen_guid(), key=key_bytes, usage=key_usage,
-                                       type=key_type, custom_key_identifier=custom_key_id)]
+
+        if for_create:
+            # Microsoft Graph generates keyId/secretText; client must not supply them.
+            if request_password:
+                password_creds = [PasswordCredential(
+                    display_name=password_display_name,
+                    start_date_time=start_date,
+                    end_date_time=end_date,
+                )]
+            elif key_value:
+                key_bytes = self._normalize_cert_key_value(key_value)
+                custom_key_id = self.encode_custom_key_description(key_description) if key_description else None
+                key_creds = [KeyCredential(
+                    display_name=key_display_name,
+                    start_date_time=start_date,
+                    end_date_time=end_date,
+                    key=key_bytes,
+                    usage=key_usage,
+                    type=key_type,
+                    custom_key_identifier=custom_key_id,
+                )]
+        else:
+            # Update (PATCH) path: legacy behavior preserved for backward compatibility.
+            if request_password:
+                password_creds = [PasswordCredential(
+                    display_name=password_display_name,
+                    start_date_time=start_date,
+                    end_date_time=end_date,
+                    key_id=self.gen_guid(),
+                )]
+            elif key_value:
+                key_bytes = self._normalize_cert_key_value(key_value)
+                custom_key_id = self.encode_custom_key_description(key_description) if key_description else None
+                key_creds = [KeyCredential(
+                    display_name=key_display_name,
+                    start_date_time=start_date,
+                    end_date_time=end_date,
+                    key_id=self.gen_guid(),
+                    key=key_bytes,
+                    usage=key_usage,
+                    type=key_type,
+                    custom_key_identifier=custom_key_id,
+                )]
 
         return password_creds, key_creds
 

--- a/tests/integration/targets/azure_rm_adapplication/aliases
+++ b/tests/integration/targets/azure_rm_adapplication/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group10
+disabled
 destructive

--- a/tests/integration/targets/azure_rm_adapplication/aliases
+++ b/tests/integration/targets/azure_rm_adapplication/aliases
@@ -1,4 +1,3 @@
 cloud/azure
 shippable/azure/group10
-disabled
 destructive

--- a/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_adapplication/tasks/main.yml
@@ -125,6 +125,7 @@
     key_type: AsymmetricX509Cert
     key_usage: Verify
     key_value: "{{ cert_file.content }}"
+    key_display_name: "ansible-integration-test-cert"
   register: cert_app_output
 
 - name: Assert certificate app created successfully
@@ -132,6 +133,94 @@
     that:
       - cert_app_output is changed
       - cert_app_output.object_id is defined
+      - cert_app_output.key_credentials | length == 1
+      - cert_app_output.key_credentials[0].display_name == "ansible-integration-test-cert"
+      - cert_app_output.key_credentials[0].type == "AsymmetricX509Cert"
+      - cert_app_output.key_credentials[0].usage == "Verify"
+      - cert_app_output.generated_password_credentials | default([]) | length == 0
+
+- name: Create application requesting a generated client secret
+  azure.azcollection.azure_rm_adapplication:
+    display_name: "{{ display_name }}_secret"
+    request_password: true
+    password_display_name: "ansible-integration-test"
+  register: secret_app_output
+  no_log: true
+
+- name: Assert generated secret is returned
+  ansible.builtin.assert:
+    that:
+      - secret_app_output is changed
+      - secret_app_output.object_id is defined
+      - secret_app_output.password_credentials | length == 1
+      - secret_app_output.password_credentials[0].display_name == "ansible-integration-test"
+      - secret_app_output.password_credentials[0].key_id is defined
+      - secret_app_output.generated_password_credentials | length == 1
+      - secret_app_output.generated_password_credentials[0].secret_text | length >= 16
+      - secret_app_output.generated_password_credentials[0].key_id == secret_app_output.password_credentials[0].key_id
+
+- name: Re-run secret application creation (idempotency)
+  azure.azcollection.azure_rm_adapplication:
+    app_id: "{{ secret_app_output.app_id }}"
+    display_name: "{{ display_name }}_secret"
+    request_password: true
+    password_display_name: "ansible-integration-test"
+  register: secret_app_rerun
+  no_log: true
+
+- name: Assert idempotent re-run did not create a new secret
+  ansible.builtin.assert:
+    that:
+      - secret_app_rerun is not changed
+      - secret_app_rerun.generated_password_credentials | default([]) | length == 0
+
+- name: Legacy password=<value> still works but emits deprecation warning
+  azure.azcollection.azure_rm_adapplication:
+    display_name: "{{ display_name }}_legacy"
+    password: "{{ password }}"
+    password_display_name: "ansible-integration-test-legacy"
+  register: legacy_app_output
+  no_log: true
+
+- name: Assert legacy path produced a server-generated secret and a deprecation warning
+  ansible.builtin.assert:
+    that:
+      - legacy_app_output is changed
+      - legacy_app_output.generated_password_credentials | length == 1
+      - legacy_app_output.generated_password_credentials[0].secret_text | length >= 16
+      - legacy_app_output.deprecations | default([]) | selectattr('msg', 'search', "azure_rm_adapplication") | list | length >= 1
+
+- name: Mutually exclusive request_password + key_value must fail
+  azure.azcollection.azure_rm_adapplication:
+    display_name: "{{ display_name }}_conflict"
+    request_password: true
+    key_value: "{{ cert_file.content }}"
+  register: conflict_output
+  ignore_errors: true
+
+- name: Assert mutual-exclusion error was raised
+  ansible.builtin.assert:
+    that:
+      - conflict_output is failed
+      - "'specify either a password credential' in conflict_output.msg"
+
+- name: Delete legacy-password application
+  azure.azcollection.azure_rm_adapplication:
+    app_id: "{{ legacy_app_output.app_id }}"
+    display_name: "{{ display_name }}_legacy"
+    state: absent
+
+- name: Delete generated-secret application
+  azure.azcollection.azure_rm_adapplication:
+    app_id: "{{ secret_app_output.app_id }}"
+    display_name: "{{ display_name }}_secret"
+    state: absent
+
+- name: Delete certificate application
+  azure.azcollection.azure_rm_adapplication:
+    app_id: "{{ cert_app_output.app_id }}"
+    display_name: "{{ display_name }}_cert"
+    state: absent
 
 - name: Delete ad app by app_id
   azure.azcollection.azure_rm_adapplication:


### PR DESCRIPTION
##### SUMMARY
**FUTURE ACTION NEEDED:**
- Remove `password` 


Fix #2248. This PR aligns the Create path with the Graph contract, exposes the server-generated secret to the playbook, deprecates the broken `password=<value>` parameter while keeping it functionally backward-compatible, and adds defensive handling for the auth-collision pattern that triggered the report.

**Root cause**
- Microsoft Graph rejects POST `/applications` whenever the request body contains client-supplied `passwordCredential.keyId` or `keyCredential.keyId` (server-generated properties). The same resource also documents `passwordCredential.customKeyIdentifier` as **Do Not Use**, and `secretText` as a server-generated, read-only value returned only once in the create operations. The module's Create path was violating these.
- `build_application_creds()` stamped a client-generated `keyId` (`gen_guid()`) onto every `PasswordCredential` and `KeyCredential` on Create, and assigned the user-supplied `password` to `secretText` (a read-only server-managed field). Graph rejects this with HTTP 400.
- `password` argument collision. The module's `password` arg (intended as the new app's client secret) shadows the common Azure auth `password` arg defined in `AZURE_COMMON_ARGS` (user-password auth). Any `module_defaults` setting `password` for auth would silently activate the buggy Create-credential path.
- The MS Graph migration in #1325 preserved field-level compatibility but did not adopt the new API's contract. The regression went unnoticed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_adapplication.py

##### ADDITIONAL INFORMATION
- **Create-path `PasswordCredential`** body now contains only `display_name`, `start_date_time`, `end_date_time` — no `key_id`, no `secret_text`, no `custom_key_identifier`.
- **Create-path `KeyCredential`** body retains user-writable fields (`key`, `type`, `usage`, `custom_key_identifier`) but no longer includes `key_id`.
- **Update (PATCH) path** `passwordCredentials` is no longer sent (Graph forbids adding secrets via PATCH). Module warns and directs users to `azure_rm_adpassword` for rotation. `keyCredentials` on update also drops client-supplied `keyId`.
- **Capture generated secret** from the POST response into `generated_password_credentials[0].secret_text` — the only retrievable moment for the value.
- Added three new params: `request_password`, `password_display_name`, `key_display_name`
- The `module.deprecate(version='4.0.0') on legacy `password=`
- The new `generated_password_credentials` return field (the only way to retrieve the secret)
- The `ad_user`/`password` arg-collision warn-and-clear guard

----
**References**
- [`application` resource type](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0)
- [POST `/applications` (Create application)](https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http) — see Example 2 for the canonical "create app with password" pattern.
- [PATCH `/applications/{id}` (Update application)](https://learn.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http)
- [`passwordCredential` resource type](https://learn.microsoft.com/en-us/graph/api/resources/passwordcredential?view=graph-rest-1.0) — documents `customKeyIdentifier` = "Do not use", `secretText` and `hint` as Read-only/server-generated.
- [`keyCredential` resource type](https://learn.microsoft.com/en-us/graph/api/resources/keycredential?view=graph-rest-1.0)
- [`application: addPassword`](https://learn.microsoft.com/en-us/graph/api/application-addpassword?view=graph-rest-1.0&tabs=http)
- [`application: removePassword`](https://learn.microsoft.com/en-us/graph/api/application-removepassword?view=graph-rest-1.0&tabs=http)
- [`application: addKey`](https://learn.microsoft.com/en-us/graph/api/application-addkey?view=graph-rest-1.0&tabs=http)
- [`application: removeKey`](https://learn.microsoft.com/en-us/graph/api/application-removekey?view=graph-rest-1.0&tabs=http)
- [Add a certificate to an app using Microsoft Graph](https://learn.microsoft.com/en-us/graph/applications-how-to-add-certificate)
- [`msgraph-sdk-python`](https://github.com/microsoftgraph/msgraph-sdk-python) — the SDK used by `self._client = self.get_msgraph_client()`.