### PR TITLE
Feature #2255: Add Smart, Cold and Premium access_tier support to azure_rm_storageaccount

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -242,6 +242,7 @@ try:
     from azure.mgmt.managementgroups import ManagementGroupsAPI as ManagementGroupsClient
     from azure.mgmt.resource.subscriptions import SubscriptionClient
     from azure.mgmt.storage import StorageManagementClient
+    import azure.mgmt.storage.models as StorageModels
     from azure.mgmt.compute import ComputeManagementClient
     from azure.mgmt.dns import DnsManagementClient
     from azure.mgmt.privatedns import PrivateDnsManagementClient
@@ -587,14 +588,25 @@ class AzureRMModuleBase(object):
 
     def serialize_obj(self, obj, class_name, enum_modules=None):
         '''
-        Return a JSON representation of an Azure object.
+        Return a JSON representation of an Azure object with snake_case keys.
+
+        Prefers ``azure.core.serialization.as_attribute_dict`` so that
+        newer hybrid-model SDKs keep emitting snake_case keys for back-compat (``obj.as_dict()`` on
+        hybrid models returns camelCase). Falls back to ``obj.as_dict()`` when the shim is unavailable
+        or the input is not an Azure model.
 
         :param obj: Azure object
         :param class_name: Name of the object's class
         :param enum_modules: List of module names to build enum dependencies from.
         :return: serialized result
         '''
-        return obj.as_dict()
+        if obj is None:
+            return None
+        try:
+            from azure.core.serialization import as_attribute_dict
+            return as_attribute_dict(obj)
+        except (ImportError, TypeError, AttributeError):
+            return obj.as_dict() if hasattr(obj, 'as_dict') else obj
 
     def get_poller_result(self, poller, wait=5):
         '''
@@ -686,7 +698,7 @@ class AzureRMModuleBase(object):
                                                                   client_secret=self.azure_auth.credentials.get('secret'))
             else:
                 account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name=resource_group_name, account_name=storage_account_name)
-                credential = account_keys.keys[0].value
+                credential = account_keys.keys_property[0].value
         except Exception as exc:
             self.fail("Error getting storage account detail for {0}: {1}".format(storage_account_name, str(exc)))
 
@@ -711,7 +723,7 @@ class AzureRMModuleBase(object):
                                                                           account_name=storage_account_name)
         except Exception as exc:
             self.fail("Error getting storage account detail for {0}: {1}".format(storage_account_name, str(exc)))
-        return account.primary_endpoints.file, account_keys.keys[0].value
+        return account.primary_endpoints.file, account_keys.keys_property[0].value
 
     def get_share_directory_client(self, resource_group_name, storage_account_name, share_name, directory_path):
         '''
@@ -1063,12 +1075,12 @@ class AzureRMModuleBase(object):
         if not self._storage_client:
             self._storage_client = self.get_mgmt_svc_client(StorageManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version='2023-05-01')
+                                                            api_version='2025-08-01')
         return self._storage_client
 
     @property
     def storage_models(self):
-        return StorageManagementClient.models("2023-05-01")
+        return StorageModels
 
     @property
     def authorization_client(self):

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -597,17 +597,6 @@ class AzureRMModuleBase(object):
         '''
         return obj.as_dict()
 
-    def to_snake_dict(self, obj):
-        '''
-        Return a snake_case dict from a hybrid-model SDK instance via
-        ``azure.core.serialization.as_attribute_dict`` (requires
-        ``azure-core >= 1.35.0``). For non-hybrid SDKs, use ``serialize_obj``.
-        '''
-        if obj is None:
-            return None
-        from azure.core.serialization import as_attribute_dict
-        return as_attribute_dict(obj)
-
     def get_poller_result(self, poller, wait=5):
         '''
         Consistent method of waiting on and retrieving results from Azure's long poller

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -588,25 +588,25 @@ class AzureRMModuleBase(object):
 
     def serialize_obj(self, obj, class_name, enum_modules=None):
         '''
-        Return a JSON representation of an Azure object with snake_case keys.
-
-        Prefers ``azure.core.serialization.as_attribute_dict`` so that
-        newer hybrid-model SDKs keep emitting snake_case keys for back-compat (``obj.as_dict()`` on
-        hybrid models returns camelCase). Falls back to ``obj.as_dict()`` when the shim is unavailable
-        or the input is not an Azure model.
+        Return a JSON representation of an Azure object.
 
         :param obj: Azure object
         :param class_name: Name of the object's class
         :param enum_modules: List of module names to build enum dependencies from.
         :return: serialized result
         '''
+        return obj.as_dict()
+
+    def to_snake_dict(self, obj):
+        '''
+        Return a snake_case dict from a hybrid-model SDK instance via
+        ``azure.core.serialization.as_attribute_dict`` (requires
+        ``azure-core >= 1.35.0``). For non-hybrid SDKs, use ``serialize_obj``.
+        '''
         if obj is None:
             return None
-        try:
-            from azure.core.serialization import as_attribute_dict
-            return as_attribute_dict(obj)
-        except (ImportError, TypeError, AttributeError):
-            return obj.as_dict() if hasattr(obj, 'as_dict') else obj
+        from azure.core.serialization import as_attribute_dict
+        return as_attribute_dict(obj)
 
     def get_poller_result(self, poller, wait=5):
         '''

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -105,11 +105,6 @@ options:
     access_tier:
         description:
             - The access tier for this storage account. Required when I(kind=BlobStorage).
-            - C(Smart) is a managed tier that automatically moves blobs between
-              C(Hot), C(Cool), and C(Cold) based on access patterns. C(Smart) requires
-              a Standard general-purpose v2 (GPv2) account on zone-redundant storage
-              (ZRS, GZRS, or RA-GZRS); see the Azure docs on smart tier for region
-              availability and prerequisites.
         type: str
         choices:
             - Hot

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -919,7 +919,6 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import env_fallback
-from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 try:
     from azure.mgmt.storage.models import (Identity, UserAssignedIdentity)
@@ -1674,7 +1673,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             self.results['changed'] = True
             if not self.check_mode:
                 parameters = self.storage_models.StorageAccountUpdateParameters(
-                    immutable_storage_with_versioning=snake_dict_to_camel_dict(self.immutable_storage_with_versioning))
+                    immutable_storage_with_versioning=self.build_immutable_storage_model())
                 try:
                     self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
                 except Exception as exc:
@@ -1719,6 +1718,36 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 self.fail("The encryption can't update encryption, encryption info as {0}".format(self.account_dict['encryption']))
         time.sleep(1)
         return self.get_account()
+
+    def build_encryption_model(self):
+        """Construct an Encryption SDK model from the user-supplied dict"""
+        if self.encryption is None:
+            return None
+        services = self.encryption.get('services') or {}
+        kvp = self.encryption.get('key_vault_properties')
+        ei = self.encryption.get('encryption_identity')
+        return self.storage_models.Encryption(
+            key_source=self.encryption.get('key_source'),
+            require_infrastructure_encryption=self.encryption.get('require_infrastructure_encryption'),
+            services=self.storage_models.EncryptionServices(
+                blob=self.storage_models.EncryptionService(**services['blob']) if services.get('blob') else None,
+                file=self.storage_models.EncryptionService(**services['file']) if services.get('file') else None,
+                queue=self.storage_models.EncryptionService(**services['queue']) if services.get('queue') else None,
+                table=self.storage_models.EncryptionService(**services['table']) if services.get('table') else None,
+            ) if services else None,
+            key_vault_properties=self.storage_models.KeyVaultProperties(**kvp) if kvp else None,
+            encryption_identity=self.storage_models.EncryptionIdentity(**ei) if ei else None,
+        )
+
+    def build_immutable_storage_model(self):
+        """Construct an ImmutableStorageAccount SDK model"""
+        if self.immutable_storage_with_versioning is None:
+            return None
+        policy = self.immutable_storage_with_versioning.get('immutability_policy')
+        return self.storage_models.ImmutableStorageAccount(
+            enabled=self.immutable_storage_with_versioning.get('enabled'),
+            immutability_policy=self.storage_models.AccountImmutabilityPolicyProperties(**policy) if policy else None,
+        )
 
     def create_account(self):
         self.log("Creating account {0}".format(self.name))
@@ -1778,15 +1807,14 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                                                                         minimum_tls_version=self.minimum_tls_version,
                                                                         public_network_access=self.public_network_access,
                                                                         allow_blob_public_access=self.allow_blob_public_access,
-                                                                        encryption=snake_dict_to_camel_dict(self.encryption),
+                                                                        encryption=self.build_encryption_model(),
                                                                         is_hns_enabled=self.is_hns_enabled,
                                                                         enable_nfs_v3=self.enable_nfs_v3,
                                                                         access_tier=self.access_tier,
                                                                         allow_shared_key_access=self.allow_shared_key_access,
                                                                         default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                                                                         allow_cross_tenant_replication=self.allow_cross_tenant_replication,
-                                                                        immutable_storage_with_versioning=snake_dict_to_camel_dict(
-                                                                            self.immutable_storage_with_versioning),
+                                                                        immutable_storage_with_versioning=self.build_immutable_storage_model(),
                                                                         large_file_shares_state=self.large_file_shares_state)
         self.log(str(parameters))
         try:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -105,10 +105,18 @@ options:
     access_tier:
         description:
             - The access tier for this storage account. Required when I(kind=BlobStorage).
+            - C(Smart) is a managed tier that automatically moves blobs between
+              C(Hot), C(Cool), and C(Cold) based on access patterns. C(Smart) requires
+              a Standard general-purpose v2 (GPv2) account on zone-redundant storage
+              (ZRS, GZRS, or RA-GZRS); see the Azure docs on smart tier for region
+              availability and prerequisites.
         type: str
         choices:
             - Hot
             - Cool
+            - Cold
+            - Premium
+            - Smart
     force_delete_nonempty:
         description:
             - Attempt deletion if resource already exists and cannot be updated.
@@ -1000,7 +1008,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             force_delete_nonempty=dict(type='bool', default=False, aliases=['force']),
             tags=dict(type='dict'),
             kind=dict(type='str', default='Storage', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
-            access_tier=dict(type='str', choices=['Hot', 'Cool']),
+            access_tier=dict(type='str', choices=['Hot', 'Cool', 'Cold', 'Premium', 'Smart']),
             https_only=dict(type='bool'),
             minimum_tls_version=dict(type='str', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
             public_network_access=dict(type='str', choices=['Enabled', 'Disabled']),

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -922,6 +922,7 @@ from ansible.module_utils.basic import env_fallback
 
 try:
     from azure.mgmt.storage.models import (Identity, UserAssignedIdentity)
+    from azure.core.serialization import as_attribute_dict
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -1273,7 +1274,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=self.to_snake_dict(account_obj.immutable_storage_with_versioning)
+            immutable_storage_with_versioning=as_attribute_dict(account_obj.immutable_storage_with_versioning) if account_obj.immutable_storage_with_versioning else None
         )
         account_dict['custom_domain'] = None
         if account_obj.custom_domain:
@@ -1340,9 +1341,9 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                         tenant_id=rule.tenant_id
                     ))
 
-        account_dict['encryption'] = self.to_snake_dict(account_obj.encryption) or dict()
+        account_dict['encryption'] = as_attribute_dict(account_obj.encryption) if account_obj.encryption else dict()
 
-        account_dict['identity'] = self.to_snake_dict(account_obj.identity) or dict()
+        account_dict['identity'] = as_attribute_dict(account_obj.identity) if account_obj.identity else dict()
 
         return account_dict
 
@@ -1758,7 +1759,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                 allow_cross_tenant_replication=self.allow_cross_tenant_replication,
                 allow_shared_key_access=self.allow_shared_key_access,
-                identity=self.to_snake_dict(self.identity),
+                identity=as_attribute_dict(self.identity) if self.identity else None,
                 immutable_storage_with_versioning=self.immutable_storage_with_versioning,
                 tags=dict()
             )

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1273,7 +1273,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=self.serialize_obj(account_obj.immutable_storage_with_versioning, 'ImmutableStorageAccount')
+            immutable_storage_with_versioning=self.to_snake_dict(account_obj.immutable_storage_with_versioning)
         )
         account_dict['custom_domain'] = None
         if account_obj.custom_domain:
@@ -1340,36 +1340,9 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                         tenant_id=rule.tenant_id
                     ))
 
-        account_dict['encryption'] = dict()
-        if account_obj.encryption:
-            account_dict['encryption']['require_infrastructure_encryption'] = account_obj.encryption.require_infrastructure_encryption
-            account_dict['encryption']['key_source'] = account_obj.encryption.key_source
-            if account_obj.encryption.services:
-                account_dict['encryption']['services'] = dict()
-                if account_obj.encryption.services.file:
-                    account_dict['encryption']['services']['file'] = dict(enabled=True)
-                if account_obj.encryption.services.table:
-                    account_dict['encryption']['services']['table'] = dict(enabled=True)
-                if account_obj.encryption.services.queue:
-                    account_dict['encryption']['services']['queue'] = dict(enabled=True)
-                if account_obj.encryption.services.blob:
-                    account_dict['encryption']['services']['blob'] = dict(enabled=True)
+        account_dict['encryption'] = self.to_snake_dict(account_obj.encryption) or dict()
 
-            if account_obj.encryption.encryption_identity:
-                account_dict['encryption']['encryption_identity'] = dict(
-                    encryption_user_assigned_identity=account_obj.encryption.encryption_identity.encryption_user_assigned_identity)
-            else:
-                account_dict['encryption']['encryption_identity'] = None
-            if account_obj.encryption.key_vault_properties:
-                account_dict['encryption']['key_vault_properties'] = dict(key_vault_uri=account_obj.encryption.key_vault_properties.key_vault_uri,
-                                                                          key_name=account_obj.encryption.key_vault_properties.key_name,
-                                                                          key_version=account_obj.encryption.key_vault_properties.key_version)
-            else:
-                account_dict['encryption']['key_vault_properties'] = None
-
-        account_dict['identity'] = dict()
-        if account_obj.identity:
-            account_dict['identity'] = self.serialize_obj(account_obj.identity, 'Identity')
+        account_dict['identity'] = self.to_snake_dict(account_obj.identity) or dict()
 
         return account_dict
 
@@ -1673,7 +1646,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             self.results['changed'] = True
             if not self.check_mode:
                 parameters = self.storage_models.StorageAccountUpdateParameters(
-                    immutable_storage_with_versioning=self.build_immutable_storage_model())
+                    immutable_storage_with_versioning=self._build_immutable_storage_payload())
                 try:
                     self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
                 except Exception as exc:
@@ -1719,8 +1692,10 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         time.sleep(1)
         return self.get_account()
 
-    def build_encryption_model(self):
-        """Construct an Encryption SDK model from the user-supplied dict"""
+    def _build_encryption_payload(self):
+        '''
+        Build an Encryption SDK model with all nested fields explicitly typed.
+        '''
         if self.encryption is None:
             return None
         services = self.encryption.get('services') or {}
@@ -1739,8 +1714,10 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             encryption_identity=self.storage_models.EncryptionIdentity(**ei) if ei else None,
         )
 
-    def build_immutable_storage_model(self):
-        """Construct an ImmutableStorageAccount SDK model"""
+    def _build_immutable_storage_payload(self):
+        '''
+        Build an ImmutableStorageAccount SDK model with the nested policy typed.
+        '''
         if self.immutable_storage_with_versioning is None:
             return None
         policy = self.immutable_storage_with_versioning.get('immutability_policy')
@@ -1781,7 +1758,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                 allow_cross_tenant_replication=self.allow_cross_tenant_replication,
                 allow_shared_key_access=self.allow_shared_key_access,
-                identity=self.serialize_obj(self.identity, 'Identity'),
+                identity=self.to_snake_dict(self.identity),
                 immutable_storage_with_versioning=self.immutable_storage_with_versioning,
                 tags=dict()
             )
@@ -1807,14 +1784,14 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                                                                         minimum_tls_version=self.minimum_tls_version,
                                                                         public_network_access=self.public_network_access,
                                                                         allow_blob_public_access=self.allow_blob_public_access,
-                                                                        encryption=self.build_encryption_model(),
+                                                                        encryption=self._build_encryption_payload(),
                                                                         is_hns_enabled=self.is_hns_enabled,
                                                                         enable_nfs_v3=self.enable_nfs_v3,
                                                                         access_tier=self.access_tier,
                                                                         allow_shared_key_access=self.allow_shared_key_access,
                                                                         default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                                                                         allow_cross_tenant_replication=self.allow_cross_tenant_replication,
-                                                                        immutable_storage_with_versioning=self.build_immutable_storage_model(),
+                                                                        immutable_storage_with_versioning=self._build_immutable_storage_payload(),
                                                                         large_file_shares_state=self.large_file_shares_state)
         self.log(str(parameters))
         try:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -919,6 +919,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 try:
     from azure.mgmt.storage.models import (Identity, UserAssignedIdentity)
@@ -1186,7 +1187,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             self.update_identity, identity_result = self.update_single_managed_identity(curr_identity=curr_identity,
                                                                                         new_identity=self.identity,
                                                                                         patch_support=True)
-            self.identity = self.serialize_obj(identity_result, 'Identity')
+            self.identity = identity_result
 
         if self.state == 'present' and self.account_dict and \
            self.account_dict['provisioning_state'] != AZURE_SUCCESS_STATE:
@@ -1672,7 +1673,8 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         if not self.default_compare({}, self.immutable_storage_with_versioning, self.account_dict['immutable_storage_with_versioning'], '', dict(compare=[])):
             self.results['changed'] = True
             if not self.check_mode:
-                parameters = self.storage_models.StorageAccountUpdateParameters(immutable_storage_with_versioning=self.immutable_storage_with_versioning)
+                parameters = self.storage_models.StorageAccountUpdateParameters(
+                    immutable_storage_with_versioning=snake_dict_to_camel_dict(self.immutable_storage_with_versioning))
                 try:
                     self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
                 except Exception as exc:
@@ -1750,7 +1752,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                 allow_cross_tenant_replication=self.allow_cross_tenant_replication,
                 allow_shared_key_access=self.allow_shared_key_access,
-                identity=self.identity,
+                identity=self.serialize_obj(self.identity, 'Identity'),
                 immutable_storage_with_versioning=self.immutable_storage_with_versioning,
                 tags=dict()
             )
@@ -1776,14 +1778,15 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                                                                         minimum_tls_version=self.minimum_tls_version,
                                                                         public_network_access=self.public_network_access,
                                                                         allow_blob_public_access=self.allow_blob_public_access,
-                                                                        encryption=self.encryption,
+                                                                        encryption=snake_dict_to_camel_dict(self.encryption),
                                                                         is_hns_enabled=self.is_hns_enabled,
                                                                         enable_nfs_v3=self.enable_nfs_v3,
                                                                         access_tier=self.access_tier,
                                                                         allow_shared_key_access=self.allow_shared_key_access,
                                                                         default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                                                                         allow_cross_tenant_replication=self.allow_cross_tenant_replication,
-                                                                        immutable_storage_with_versioning=self.immutable_storage_with_versioning,
+                                                                        immutable_storage_with_versioning=snake_dict_to_camel_dict(
+                                                                            self.immutable_storage_with_versioning),
                                                                         large_file_shares_state=self.large_file_shares_state)
         self.log(str(parameters))
         try:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1280,7 +1280,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         if account_obj.custom_domain:
             account_dict['custom_domain'] = dict(
                 name=account_obj.custom_domain.name,
-                use_sub_domain=account_obj.custom_domain.use_sub_domain
+                use_sub_domain=account_obj.custom_domain.use_sub_domain_name
             )
 
         account_dict['primary_endpoints'] = None
@@ -1618,7 +1618,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
             if self.results['changed'] and not self.check_mode:
                 new_domain = self.storage_models.CustomDomain(name=self.custom_domain['name'],
-                                                              use_sub_domain=self.custom_domain['use_sub_domain'])
+                                                              use_sub_domain_name=self.custom_domain['use_sub_domain'])
                 parameters = self.storage_models.StorageAccountUpdateParameters(custom_domain=new_domain)
                 try:
                     self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1186,7 +1186,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             self.update_identity, identity_result = self.update_single_managed_identity(curr_identity=curr_identity,
                                                                                         new_identity=self.identity,
                                                                                         patch_support=True)
-            self.identity = identity_result.as_dict()
+            self.identity = self.serialize_obj(identity_result, 'Identity')
 
         if self.state == 'present' and self.account_dict and \
            self.account_dict['provisioning_state'] != AZURE_SUCCESS_STATE:
@@ -1273,7 +1273,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=account_obj.immutable_storage_with_versioning.as_dict() if account_obj.immutable_storage_with_versioning else None
+            immutable_storage_with_versioning=self.serialize_obj(account_obj.immutable_storage_with_versioning, 'ImmutableStorageAccount')
         )
         account_dict['custom_domain'] = None
         if account_obj.custom_domain:
@@ -1369,7 +1369,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
         account_dict['identity'] = dict()
         if account_obj.identity:
-            account_dict['identity'] = account_obj.identity.as_dict()
+            account_dict['identity'] = self.serialize_obj(account_obj.identity, 'Identity')
 
         return account_dict
 

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -809,7 +809,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         if account_obj.custom_domain:
             account_dict['custom_domain'] = dict(
                 name=account_obj.custom_domain.name,
-                use_sub_domain=account_obj.custom_domain.use_sub_domain
+                use_sub_domain=account_obj.custom_domain.use_sub_domain_name
             )
 
         account_dict['network_acls'] = None

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -315,6 +315,7 @@ storageaccounts:
         access_tier:
             description:
                 - The access tier for this storage account.
+                - One of C(Hot), C(Cool), C(Cold), C(Premium), or C(Smart).
             returned: always
             type: str
             sample: Hot

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -791,7 +791,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=account_obj.immutable_storage_with_versioning.as_dict() if account_obj.immutable_storage_with_versioning else None
+            immutable_storage_with_versioning=self.serialize_obj(account_obj.immutable_storage_with_versioning, 'ImmutableStorageAccount')
         )
 
         account_dict['geo_replication_stats'] = None
@@ -911,7 +911,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
 
         account_dict['identity'] = dict()
         if account_obj.identity:
-            account_dict['identity'] = account_obj.identity.as_dict()
+            account_dict['identity'] = self.serialize_obj(account_obj.identity, 'Identity')
 
         return account_dict
 
@@ -953,7 +953,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
             cred = self.storage_client.storage_accounts.list_keys(resource_group, name)
             # get the following try catch from CLI
             try:
-                keys = [cred.keys[0].value, cred.keys[1].value]
+                keys = [cred.keys_property[0].value, cred.keys_property[1].value]
             except AttributeError:
                 keys = [cred.key1, cred.key2]
         except Exception:

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -645,9 +645,14 @@ storageaccounts:
 '''
 
 
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import env_fallback
+try:
+    from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+    from ansible.module_utils._text import to_native
+    from ansible.module_utils.basic import env_fallback
+    from azure.core.serialization import as_attribute_dict
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
 
 
 AZURE_OBJECT_CLASS = 'StorageAccount'
@@ -788,7 +793,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=self.to_snake_dict(account_obj.immutable_storage_with_versioning)
+            immutable_storage_with_versioning=as_attribute_dict(account_obj.immutable_storage_with_versioning) if account_obj.immutable_storage_with_versioning else None
         )
 
         account_dict['geo_replication_stats'] = None
@@ -878,9 +883,9 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 error_document404_path=static_website.error_document404_path,
             )
 
-        account_dict['encryption'] = self.to_snake_dict(account_obj.encryption) or dict()
+        account_dict['encryption'] = as_attribute_dict(account_obj.encryption) if account_obj.encryption else dict()
 
-        account_dict['identity'] = self.to_snake_dict(account_obj.identity) or dict()
+        account_dict['identity'] = as_attribute_dict(account_obj.identity) if account_obj.identity else dict()
 
         return account_dict
 

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -752,9 +752,6 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
     def filter_tag(self, raw):
         return [item for item in raw if self.has_tags(item.tags, self.tags)]
 
-    def serialize(self, raw):
-        return [self.serialize_obj(item, AZURE_OBJECT_CLASS) for item in raw]
-
     def format_to_dict(self, raw):
         return [self.account_obj_to_dict(item) for item in raw]
 
@@ -791,7 +788,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=self.serialize_obj(account_obj.immutable_storage_with_versioning, 'ImmutableStorageAccount')
+            immutable_storage_with_versioning=self.to_snake_dict(account_obj.immutable_storage_with_versioning)
         )
 
         account_dict['geo_replication_stats'] = None
@@ -881,37 +878,9 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 error_document404_path=static_website.error_document404_path,
             )
 
-        account_dict['encryption'] = dict()
-        if account_obj.encryption:
-            account_dict['encryption']['require_infrastructure_encryption'] = account_obj.encryption.require_infrastructure_encryption
-            account_dict['encryption']['key_source'] = account_obj.encryption.key_source
+        account_dict['encryption'] = self.to_snake_dict(account_obj.encryption) or dict()
 
-            if account_obj.encryption.services:
-                account_dict['encryption']['services'] = dict()
-
-                if account_obj.encryption.services.file:
-                    account_dict['encryption']['services']['file'] = dict(enabled=True)
-                if account_obj.encryption.services.table:
-                    account_dict['encryption']['services']['table'] = dict(enabled=True)
-                if account_obj.encryption.services.queue:
-                    account_dict['encryption']['services']['queue'] = dict(enabled=True)
-                if account_obj.encryption.services.blob:
-                    account_dict['encryption']['services']['blob'] = dict(enabled=True)
-            if account_obj.encryption.encryption_identity:
-                account_dict['encryption']['encryption_identity'] = dict(
-                    encryption_user_assigned_identity=account_obj.encryption.encryption_identity.encryption_user_assigned_identity)
-            else:
-                account_dict['encryption']['encryption_identity'] = None
-            if account_obj.encryption.key_vault_properties:
-                account_dict['encryption']['key_vault_properties'] = dict(key_vault_uri=account_obj.encryption.key_vault_properties.key_vault_uri,
-                                                                          key_name=account_obj.encryption.key_vault_properties.key_name,
-                                                                          key_version=account_obj.encryption.key_vault_properties.key_version)
-            else:
-                account_dict['encryption']['key_vault_properties'] = None
-
-        account_dict['identity'] = dict()
-        if account_obj.identity:
-            account_dict['identity'] = self.serialize_obj(account_obj.identity, 'Identity')
+        account_dict['identity'] = self.to_snake_dict(account_obj.identity) or dict()
 
         return account_dict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ azure-mgmt-resourcehealth==1.0.0b6
 azure-mgmt-search==9.2.0b2
 azure-mgmt-servicebus==8.2.1
 azure-mgmt-sql==4.0.0b19
-azure-mgmt-storage==21.2.1
+azure-mgmt-storage==25.0.0
 azure-mgmt-trafficmanager==1.1.0
 azure-mgmt-web==7.3.1
 azure-mgmt-eventgrid==10.4.0

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -61,11 +61,15 @@
         - "{{ storage_account_name_default }}02"
         - "{{ storage_account_name_default }}03"
         - "{{ storage_account_name_default }}04"
+        - "{{ storage_account_name_default }}05"
         - "{{ storage_account_name_default }}06"
         - "{{ storage_account_name_default }}07"
         - "{{ storage_account_name_default }}08"
         - "{{ storage_account_name_default }}09"
         - "{{ storage_account_name_default }}10"
+        - "{{ storage_account_name_default }}11"
+        - "{{ storage_account_name_default }}12"
+        - "{{ storage_account_name_default }}13"
 
     - name: Create new storage account with defaults (omitted parameters)
       azure.azcollection.azure_rm_storageaccount:
@@ -513,6 +517,62 @@
           - smart_tier_idem is not changed
           - smart_tier_idem.state.access_tier == 'Smart'
 
+    - name: Create storage account with Cold access_tier
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}12"
+        account_type: Standard_LRS
+        kind: StorageV2
+        access_tier: Cold
+      register: cold_tier_output
+    - name: Assert Cold access_tier applied
+      ansible.builtin.assert:
+        that:
+          - cold_tier_output is changed
+          - cold_tier_output.state.access_tier == 'Cold'
+
+    - name: Create storage account with Cold access_tier (idempotence)
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}12"
+        account_type: Standard_LRS
+        kind: StorageV2
+        access_tier: Cold
+      register: cold_tier_idem
+    - name: Assert Cold access_tier idempotent
+      ansible.builtin.assert:
+        that:
+          - cold_tier_idem is not changed
+          - cold_tier_idem.state.access_tier == 'Cold'
+
+    - name: Create storage account with Premium access_tier
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+        account_type: Premium_LRS
+        kind: BlockBlobStorage
+        access_tier: Premium
+      register: premium_tier_output
+    - name: Assert Premium access_tier applied
+      ansible.builtin.assert:
+        that:
+          - premium_tier_output is changed
+          - premium_tier_output.state.access_tier == 'Premium'
+
+    - name: Create storage account with Premium access_tier (idempotence)
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+        account_type: Premium_LRS
+        kind: BlockBlobStorage
+        access_tier: Premium
+      register: premium_tier_idem
+    - name: Assert Premium access_tier idempotent
+      ansible.builtin.assert:
+        that:
+          - premium_tier_idem is not changed
+          - premium_tier_idem.state.access_tier == 'Premium'
+
     - name: Update existing storage account (idempotence)
       azure.azcollection.azure_rm_storageaccount:
         access_tier: Hot
@@ -876,6 +936,34 @@
           - output.storageaccounts[0].encryption.key_vault_properties.key_name == 'testkey'
           - output.storageaccounts[0].encryption.encryption_identity |length == 1
 
+    - name: Re-apply CMK storage account (idempotence)
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}05"
+        account_type: Standard_RAGRS
+        kind: StorageV2
+        identity:
+          type: UserAssigned
+          user_assigned_identity: "{{ managed_identity_ids[0] }}"
+        encryption:
+          services:
+            blob:
+              enabled: true
+            file:
+              enabled: true
+          require_infrastructure_encryption: false
+          key_source: Microsoft.Keyvault
+          key_vault_properties:
+            key_vault_uri: https://vault{{ rpfx }}.vault.azure.net
+            key_name: testkey
+          encryption_identity:
+            encryption_user_assigned_identity: "{{ managed_identity_ids[0] }}"
+      register: encryption_idem
+    - name: Assert CMK storage account idempotent
+      ansible.builtin.assert:
+        that:
+          - encryption_idem is not changed
+
     - name: Create a storage account with allow_shared_key_access
       azure.azcollection.azure_rm_storageaccount:
         resource_group: "{{ resource_group }}-storageaccount"
@@ -963,6 +1051,11 @@
         - "{{ storage_account_name_default }}06"
         - "{{ storage_account_name_default }}07"
         - "{{ storage_account_name_default }}08"
+        - "{{ storage_account_name_default }}09"
+        - "{{ storage_account_name_default }}10"
+        - "{{ storage_account_name_default }}11"
+        - "{{ storage_account_name_default }}12"
+        - "{{ storage_account_name_default }}13"
 
     - name: Delete user managed identities
       ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -485,6 +485,34 @@
           - resource_acl_info.storageaccounts[0].network_acls.resource_access_rules | length == 2
           - resource_acl_info.storageaccounts[0].network_acls.default_action == "Deny"
 
+    - name: Create storage account with Smart access_tier
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}11"
+        account_type: Standard_ZRS
+        kind: StorageV2
+        access_tier: Smart
+      register: smart_tier_output
+    - name: Assert Smart access_tier applied
+      ansible.builtin.assert:
+        that:
+          - smart_tier_output is changed
+          - smart_tier_output.state.access_tier == 'Smart'
+
+    - name: Create storage account with Smart access_tier (idempotence)
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}11"
+        account_type: Standard_ZRS
+        kind: StorageV2
+        access_tier: Smart
+      register: smart_tier_idem
+    - name: Assert Smart access_tier idempotent
+      ansible.builtin.assert:
+        that:
+          - smart_tier_idem is not changed
+          - smart_tier_idem.state.access_tier == 'Smart'
+
     - name: Update existing storage account (idempotence)
       azure.azcollection.azure_rm_storageaccount:
         access_tier: Hot

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -69,7 +69,6 @@
         - "{{ storage_account_name_default }}10"
         - "{{ storage_account_name_default }}11"
         - "{{ storage_account_name_default }}12"
-        - "{{ storage_account_name_default }}13"
 
     - name: Create new storage account with defaults (omitted parameters)
       azure.azcollection.azure_rm_storageaccount:
@@ -544,34 +543,6 @@
         that:
           - cold_tier_idem is not changed
           - cold_tier_idem.state.access_tier == 'Cold'
-
-    - name: Create storage account with Premium access_tier
-      azure.azcollection.azure_rm_storageaccount:
-        resource_group: "{{ resource_group }}-storageaccount"
-        name: "{{ storage_account_name_default }}13"
-        account_type: Premium_LRS
-        kind: BlockBlobStorage
-        access_tier: Premium
-      register: premium_tier_output
-    - name: Assert Premium access_tier applied
-      ansible.builtin.assert:
-        that:
-          - premium_tier_output is changed
-          - premium_tier_output.state.access_tier == 'Premium'
-
-    - name: Create storage account with Premium access_tier (idempotence)
-      azure.azcollection.azure_rm_storageaccount:
-        resource_group: "{{ resource_group }}-storageaccount"
-        name: "{{ storage_account_name_default }}13"
-        account_type: Premium_LRS
-        kind: BlockBlobStorage
-        access_tier: Premium
-      register: premium_tier_idem
-    - name: Assert Premium access_tier idempotent
-      ansible.builtin.assert:
-        that:
-          - premium_tier_idem is not changed
-          - premium_tier_idem.state.access_tier == 'Premium'
 
     - name: Update existing storage account (idempotence)
       azure.azcollection.azure_rm_storageaccount:
@@ -1055,7 +1026,6 @@
         - "{{ storage_account_name_default }}10"
         - "{{ storage_account_name_default }}11"
         - "{{ storage_account_name_default }}12"
-        - "{{ storage_account_name_default }}13"
 
     - name: Delete user managed identities
       ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"


### PR DESCRIPTION
##### SUMMARY
Fix #2255.

Expose Azure's newer storage `accessTier` values on `azure_rm_storageaccount`:
- **`Smart`**
- **`Cold`**
- **`Premium`**
The `Smart` tier constant was first exposed by the Python SDK in `azure-mgmt-storage 25.0.0` (May 2026 — "Enum `AccessTier` added member `SMART`"), so this PR also bumps the SDK pin from `21.2.1` → `25.0.0` and adapts `azure_rm_storageaccount`, `azure_rm_storageaccount_info`, and the shared `module_utils/azure_rm_common.py` to the SDK 25 hybrid-model layout that the new tier requires.

SDK-25 fallout in unrelated modules (`azure_rm_functionapp`, `azure_rm_storageshare`, `azure_rm_storageaccountmanagementpolicy(+_info)`) is intentionally out of scope and will be handled in a follow-up PR so this one stays issue-focused.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_storageaccount.py
plugins/modules/azure_rm_storageaccount_info.py
plugins/modules/azure_rm_common.py
requirements.txt