### PR TITLE
Fix #2251: `azure_rm_aduser` eventual-consistency crash on create

### DIFF
--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -400,7 +400,7 @@ class AzureRMADUser(AzureRMModuleBase):
 
                         self.results['changed'] = True
 
-                        ad_user = self.get_exisiting_user() or ad_user
+                        ad_user = self.get_exisiting_user()
 
                     else:
                         self.results['changed'] = False

--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -400,6 +400,8 @@ class AzureRMADUser(AzureRMModuleBase):
 
                         self.results['changed'] = True
 
+                        # Get the updated versions of the users to return
+                        # the update method, has no return value so it needs to be explicitely returned in a call
                         ad_user = self.get_exisiting_user()
 
                     else:

--- a/plugins/modules/azure_rm_aduser.py
+++ b/plugins/modules/azure_rm_aduser.py
@@ -400,17 +400,14 @@ class AzureRMADUser(AzureRMModuleBase):
 
                         self.results['changed'] = True
 
-                        # Get the updated versions of the users to return
-                        # the update method, has no return value so it needs to be explicitely returned in a call
-                        ad_user = self.get_exisiting_user()
+                        ad_user = self.get_exisiting_user() or ad_user
 
                     else:
                         self.results['changed'] = False
 
-                else:  # Create, changed
-                    asyncio.get_event_loop().run_until_complete(self.create_user(extension_attributes))
+                else:
+                    ad_user = asyncio.get_event_loop().run_until_complete(self.create_user(extension_attributes))
                     self.results['changed'] = True
-                    ad_user = self.get_exisiting_user()
 
                 self.results['ad_user'] = self.to_dict(ad_user)
 

--- a/tests/integration/targets/azure_rm_aduser/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aduser/tasks/main.yml
@@ -71,6 +71,10 @@
       - "create_user_should_pass['ad_user']['account_enabled'] == True"
       - "get_user_by_upn_should_pass['ad_users'][0]['account_enabled'] == True"
       - "get_user_by_mail_should_pass['ad_users'][0]['account_enabled'] == True"
+      - "create_user_should_pass['ad_user']['object_id'] is defined"
+      - "create_user_should_pass['ad_user']['object_id'] is string"
+      - "create_user_should_pass['ad_user']['object_id'] | length > 0"
+      - "create_user_should_pass['ad_user']['object_id'] is match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')"
 
 - name: Update test user
   azure.azcollection.azure_rm_aduser:


### PR DESCRIPTION
##### SUMMARY
Fix #2251 

`azure_rm_aduser` crashed with `failed to get ad user info 'NoneType' object has no attribute 'id'` on the post-create re-fetch when Microsoft Graph's read replica had not yet replicated the newly created user. The user **was** created in Entra ID, but the module reported failure. 

**Root cause**
1. `POST /users` - Graph returns `201 Created` with the full `User` body (always a populated `id`), served by the primary.
2. `get_existing_user()` then did `GET /users/{user_principal_name}` to re-read what it just wrote.
3. Step 2 can land on a replica that has not yet seen the new user and return `404 Resource '<upn>' does not exist or one of its queried reference-property objects are not present`, `get_existing_user()` has special-case code (`plugins/modules/azure_rm_aduser.py:457-459`) that **silently swallows that exact 404 string and returns `None`**. `to_dict(None)` then dereferences `None.id` -> `AttributeError`, which is wrapped by the outer `except Exception` as the user-visible `'NoneType' object has no attribute 'id'` message.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_aduser.py

##### ADDITIONAL INFORMATION
**References**
- https://learn.microsoft.com/en-us/graph/api/resources/user
- https://learn.microsoft.com/en-us/graph/api/user-post-users
- https://learn.microsoft.com/en-us/graph/api/user-update
- https://github.com/microsoftgraph/msgraph-sdk-python