### PR TITLE
Follow Up #2256: Fix azure-mgmt-storage 25.0.0 fallout

### DIFF
--- a/plugins/modules/azure_rm_functionapp.py
+++ b/plugins/modules/azure_rm_functionapp.py
@@ -435,7 +435,7 @@ class AzureRMFunctionApp(AzureRMModuleBaseExt):
         return self.storage_client.storage_accounts.list_keys(
             resource_group_name=self.resource_group,
             account_name=self.storage_account
-        ).keys[0].value
+        ).keys_property[0].value
 
 
 def main():

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1274,7 +1274,10 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=as_attribute_dict(account_obj.immutable_storage_with_versioning) if account_obj.immutable_storage_with_versioning else None
+            immutable_storage_with_versioning=(
+                as_attribute_dict(account_obj.immutable_storage_with_versioning)
+                if account_obj.immutable_storage_with_versioning else None
+            ),
         )
         account_dict['custom_domain'] = None
         if account_obj.custom_domain:

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -793,7 +793,10 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
                 index_document=None,
                 error_document404_path=None,
             ),
-            immutable_storage_with_versioning=as_attribute_dict(account_obj.immutable_storage_with_versioning) if account_obj.immutable_storage_with_versioning else None
+            immutable_storage_with_versioning=(
+                as_attribute_dict(account_obj.immutable_storage_with_versioning)
+                if account_obj.immutable_storage_with_versioning else None
+            ),
         )
 
         account_dict['geo_replication_stats'] = None

--- a/plugins/modules/azure_rm_storageaccountmanagementpolicy.py
+++ b/plugins/modules/azure_rm_storageaccountmanagementpolicy.py
@@ -426,8 +426,10 @@ state:
 
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 try:
     from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
 except Exception:
     # This is handled in azure_rm_common
     pass
@@ -634,10 +636,11 @@ class AzureRMStorageAccountManagementPolicy(AzureRMModuleBaseExt):
         self.log("Creating or updating storage account mangement policy")
 
         try:
-            self.storage_client.management_policies.create_or_update(resource_group_name=self.resource_group,
-                                                                     account_name=self.storage_account_name,
-                                                                     management_policy_name='default',
-                                                                     properties=dict(policy=dict(rules=rules)))
+            self.storage_client.management_policies.create_or_update(
+                resource_group_name=self.resource_group,
+                account_name=self.storage_account_name,
+                management_policy_name='default',
+                properties={'properties': {'policy': {'rules': [snake_dict_to_camel_dict(rule) for rule in rules]}}})
         except Exception as e:
             self.log('Error creating or updating storage account management policy.')
             self.fail("Failed to create or updating storage account management policy: {0}".format(str(e)))
@@ -659,7 +662,7 @@ class AzureRMStorageAccountManagementPolicy(AzureRMModuleBaseExt):
         result['last_modified_time'] = obj.last_modified_time
         result['policy'] = dict(rules=[])
         if obj.policy is not None:
-            result['policy'] = obj.policy.as_dict()
+            result['policy'] = as_attribute_dict(obj.policy)
 
         return result
 

--- a/plugins/modules/azure_rm_storageaccountmanagementpolicy_info.py
+++ b/plugins/modules/azure_rm_storageaccountmanagementpolicy_info.py
@@ -173,6 +173,7 @@ state:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 try:
     from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
 except Exception:
     # This is handled in azure_rm_common
     pass
@@ -232,7 +233,7 @@ class AzureRMStorageAccountManagementPolicyInfo(AzureRMModuleBase):
         result['last_modified_time'] = obj.last_modified_time
         result['policy'] = dict(rules=[])
         if obj.policy is not None:
-            result['policy'] = obj.policy.as_dict()
+            result['policy'] = as_attribute_dict(obj.policy)
 
         return result
 

--- a/plugins/modules/azure_rm_storageshare.py
+++ b/plugins/modules/azure_rm_storageshare.py
@@ -336,14 +336,17 @@ class AzureRMStorageShare(AzureRMModuleBase):
         '''
         self.log("Creating fileshare {0}".format(self.name))
         try:
+            file_share = self.storage_models.FileShare(
+                access_tier=self.access_tier,
+                share_quota=self.quota,
+                metadata=self.metadata,
+                root_squash=self.root_squash,
+                enabled_protocols=self.enabled_protocols,
+            )
             self.storage_client.file_shares.create(resource_group_name=self.resource_group,
                                                    account_name=self.account_name,
                                                    share_name=self.name,
-                                                   file_share=dict(access_tier=self.access_tier,
-                                                                   share_quota=self.quota,
-                                                                   metadata=self.metadata,
-                                                                   root_squash=self.root_squash,
-                                                                   enabled_protocols=self.enabled_protocols))
+                                                   file_share=file_share)
         except Exception as e:
             self.fail("Error creating file share {0} : {1}".format(self.name, str(e)))
         return self.get_share()
@@ -355,18 +358,18 @@ class AzureRMStorageShare(AzureRMModuleBase):
         :return: dict with description of the new storage file share
         '''
         self.log("Creating file share {0}".format(self.name))
-        file_share_details = dict(
+        file_share = self.storage_models.FileShare(
             access_tier=self.access_tier if self.access_tier else old_responce.get('access_tier'),
             share_quota=self.quota if self.quota else old_responce.get('share_quota'),
             metadata=self.metadata if self.metadata else old_responce.get('metadata'),
             enabled_protocols=self.enabled_protocols if self.enabled_protocols else old_responce.get('enabled_protocols'),
-            root_squash=self.root_squash if self.root_squash else old_responce.get('self.root_squash')
+            root_squash=self.root_squash if self.root_squash else old_responce.get('root_squash'),
         )
         try:
             self.storage_client.file_shares.update(resource_group_name=self.resource_group,
                                                    account_name=self.account_name,
                                                    share_name=self.name,
-                                                   file_share=file_share_details)
+                                                   file_share=file_share)
         except Exception as e:
             self.fail("Error updating file share {0} : {1}".format(self.name, str(e)))
         return self.get_share()


### PR DESCRIPTION
##### SUMMARY
Follow-up to #2256, which bumped `azure-mgmt-storage` to `25.0.0` (hybrid models). The same SDK upgrade breaks four other modules that share the storage SDK. This PR addresses each one with the minimal targeted fix.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_functionapp.py
plugins/modules/azure_rm_storageaccountmanagementpolicy.py
plugins/modules/azure_rm_storageaccountmanagementpolicy_info.py
plugins/modules/azure_rm_storageshare.py

##### ADDITIONAL INFORMATION
1. **Reserved-name renames** — properties whose name collides with  `dict.keys`/`values`/`items` are renamed (`keys` > `keys_property`).
2. **`.as_dict()` now emits camelCase** (the REST wire shape) instead of snake_case (the previous Python-attribute shape).
3. **Raw dict arguments are serialised as-is** — passing `{"access_tier": "Cool"}` to a typed parameter leaks snake_case keys into the REST payload and the API rejects them. Typed model construction (`FileShare(access_tier="Cool")`) is the supported path.