### PR TITLE
Feature #2257: List active certificates in `azure_rm_keyvaultcertificate_info` when name is omitted

### DIFF
--- a/plugins/modules/azure_rm_keyvaultcertificate_info.py
+++ b/plugins/modules/azure_rm_keyvaultcertificate_info.py
@@ -23,7 +23,9 @@ options:
         type: str
     name:
         description:
-            - Certificate name. If not set, will list all certificates in vault_uri.
+            - Certificate name.
+            - If not set, when I(show_deleted_certificate=false) (the default) the module returns the list of all active certificates in I(vault_uri).
+            - If not set and I(show_deleted_certificate=true), the module returns the list of all deleted certificates in I(vault_uri).
         type: str
     version:
         description:
@@ -34,6 +36,14 @@ options:
             - Set to I(show_delete_certificate=true) to show deleted certificates. Set to I(show_deleted_certificate=false) to show not deleted certificates.
         type: bool
         default: false
+    include_pending:
+        description:
+            - When listing all active certificates (I(name) omitted and I(show_deleted_certificate=false)),
+              include certificates that are not yet completely provisioned.
+            - Only honoured by the Key Vault REST API v7.0 and above. If omitted, Key Vault treats this as C(false).
+            - Has no effect when I(name) is specified or when I(show_deleted_certificate=true).
+        type: bool
+        version_added: "3.20.0"
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
@@ -71,6 +81,15 @@ EXAMPLES = '''
   azure_rm_keyvaultcertificate_info:
     vault_uri: "https://myVault.vault.azure.net"
     show_deleted_certificate: true
+
+- name: List all active certificates in the key vault
+  azure.azcollection.azure_rm_keyvaultcertificate_info:
+    vault_uri: "https://myVault.vault.azure.net"
+
+- name: List all active certificates including pending ones
+  azure.azcollection.azure_rm_keyvaultcertificate_info:
+    vault_uri: "https://myVault.vault.azure.net"
+    include_pending: true
 '''
 
 RETURN = '''
@@ -487,12 +506,14 @@ class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
                                     name=dict(type='str'),
                                     vault_uri=dict(type='str', required=True),
                                     show_deleted_certificate=dict(type='bool', default=False),
+                                    include_pending=dict(type='bool'),
                                     tags=dict(type='list', elements='str'))
 
         self.vault_uri = None
         self.name = None
         self.version = None
         self.show_deleted_certificate = False
+        self.include_pending = None
         self.tags = None
 
         self.results = dict(changed=False)
@@ -524,6 +545,8 @@ class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
         else:
             if self.show_deleted_certificate:
                 self.results['certificates'] = self.list_deleted_certificates()
+            else:
+                self.results['certificates'] = self.list_certificates()
 
         return self.results
 
@@ -617,6 +640,43 @@ class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
                     item = deleted_certificatebundle_to_dict(item)
                     if self.has_tags(item['properties'].get('tags'), self.tags):
                         results.append(item)
+        except Exception as e:
+            self.fail("Did not find certificate in current key vault {0}.".format(str(e)))
+        return results
+
+    def list_certificates(self):
+        '''
+        Lists all active certificates in the specific key vault.
+
+        :return: deserialized certificates, includes certificate identifier, attributes, policy and tags.
+        '''
+        self.log("List all active certificates in the key vault")
+
+        results = []
+        list_kwargs = {}
+        if self.include_pending is not None:
+            list_kwargs['include_pending'] = self.include_pending
+
+        try:
+            response = self._client.list_properties_of_certificates(**list_kwargs)
+            self.log("Response : {0}".format(response))
+
+            if response:
+                for item in response:
+                    # Skip confirmed-disabled certs
+                    if item.enabled is False:
+                        continue
+                    try:
+                        bundle = self._client.get_certificate(certificate_name=item.name)
+                    except ResourceNotFoundError as ec:
+                        self.log("Certificate {0} disappeared between list and get: {1}".format(item.name, str(ec)))
+                        continue
+                    except Exception as ec2:
+                        self.log("Skipping certificate {0} due to error: {1}".format(item.name, str(ec2)))
+                        continue
+                    cert = certificatebundle_to_dict(bundle)
+                    if self.has_tags(cert['properties'].get('tags'), self.tags):
+                        results.append(cert)
         except Exception as e:
             self.fail("Did not find certificate in current key vault {0}.".format(str(e)))
         return results

--- a/plugins/modules/azure_rm_keyvaultcertificate_info.py
+++ b/plugins/modules/azure_rm_keyvaultcertificate_info.py
@@ -652,34 +652,39 @@ class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
         '''
         self.log("List all active certificates in the key vault")
 
-        results = []
         list_kwargs = {}
         if self.include_pending is not None:
             list_kwargs['include_pending'] = self.include_pending
 
+        results = []
         try:
             response = self._client.list_properties_of_certificates(**list_kwargs)
             self.log("Response : {0}".format(response))
-
-            if response:
-                for item in response:
-                    # Skip confirmed-disabled certs
-                    if item.enabled is False:
-                        continue
-                    try:
-                        bundle = self._client.get_certificate(certificate_name=item.name)
-                    except ResourceNotFoundError as ec:
-                        self.log("Certificate {0} disappeared between list and get: {1}".format(item.name, str(ec)))
-                        continue
-                    except Exception as ec2:
-                        self.log("Skipping certificate {0} due to error: {1}".format(item.name, str(ec2)))
-                        continue
-                    cert = certificatebundle_to_dict(bundle)
-                    if self.has_tags(cert['properties'].get('tags'), self.tags):
-                        results.append(cert)
+            for item in response or []:
+                cert = self._fetch_active_certificate(item)
+                if cert is not None and self.has_tags(cert['properties'].get('tags'), self.tags):
+                    results.append(cert)
         except Exception as e:
             self.fail("Did not find certificate in current key vault {0}.".format(str(e)))
         return results
+
+    def _fetch_active_certificate(self, item):
+        '''
+        Fetch one cert bundle; return None to skip disabled/deleted/inaccessible.
+
+        :return: deserialized certificate dict, or None if the certificate should be skipped.
+        '''
+        if item.enabled is False:
+            return None
+        try:
+            bundle = self._client.get_certificate(certificate_name=item.name)
+        except ResourceNotFoundError as ec:
+            self.log("Certificate {0} disappeared between list and get: {1}".format(item.name, str(ec)))
+            return None
+        except Exception as ec2:
+            self.log("Skipping certificate {0} due to error: {1}".format(item.name, str(ec2)))
+            return None
+        return certificatebundle_to_dict(bundle)
 
 
 def main():

--- a/plugins/modules/azure_rm_keyvaultcertificate_info.py
+++ b/plugins/modules/azure_rm_keyvaultcertificate_info.py
@@ -500,6 +500,31 @@ def deleted_certificatebundle_to_dict(certificate):
     return response
 
 
+def certificateproperties_to_dict(properties):
+    '''
+    Convert a brief ``CertificateProperties`` item (as yielded by ``list_properties_of_certificates``) to a dict.
+    No ``policy`` or ``cert_data`` is included.
+
+    :return: dict with ``name`` and a ``properties`` sub-dict (attributes, id, vault_id, x509_thumbprint, tags).
+    '''
+    response = dict(properties=dict())
+    response['name'] = properties.name
+    response['properties']['attributes'] = dict(enabled=properties._attributes.enabled,
+                                                not_before=properties._attributes.not_before,
+                                                expires=properties._attributes.expires,
+                                                created=properties._attributes.created,
+                                                updated=properties._attributes.updated,
+                                                recovery_level=properties._attributes.recovery_level)
+    response['properties']['id'] = properties._id
+    response['properties']['vault_id'] = properties._vault_id.vault_url if properties._vault_id is not None else None
+    if properties._x509_thumbprint is not None:
+        response['properties']['x509_thumbprint'] = base64.b64encode(properties._x509_thumbprint).decode('utf-8')
+    else:
+        response['properties']['x509_thumbprint'] = None
+    response['properties']['tags'] = properties._tags
+    return response
+
+
 class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
     def __init__(self):
         self.module_arg_spec = dict(version=dict(type='str'),
@@ -648,7 +673,7 @@ class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
         '''
         Lists all active certificates in the specific key vault.
 
-        :return: deserialized certificates, includes certificate identifier, attributes, policy and tags.
+        :return: deserialized brief properties (name, attributes, id, vault_id, x509_thumbprint, tags) for each active certificate.
         '''
         self.log("List all active certificates in the key vault")
 
@@ -660,31 +685,17 @@ class AzureRMKeyVaultCertificateInfo(AzureRMModuleBase):
         try:
             response = self._client.list_properties_of_certificates(**list_kwargs)
             self.log("Response : {0}".format(response))
-            for item in response or []:
-                cert = self._fetch_active_certificate(item)
-                if cert is not None and self.has_tags(cert['properties'].get('tags'), self.tags):
-                    results.append(cert)
+
+            if response:
+                for item in response:
+                    if item.enabled is False:
+                        continue
+                    cert = certificateproperties_to_dict(item)
+                    if self.has_tags(cert['properties'].get('tags'), self.tags):
+                        results.append(cert)
         except Exception as e:
             self.fail("Did not find certificate in current key vault {0}.".format(str(e)))
         return results
-
-    def _fetch_active_certificate(self, item):
-        '''
-        Fetch one cert bundle; return None to skip disabled/deleted/inaccessible.
-
-        :return: deserialized certificate dict, or None if the certificate should be skipped.
-        '''
-        if item.enabled is False:
-            return None
-        try:
-            bundle = self._client.get_certificate(certificate_name=item.name)
-        except ResourceNotFoundError as ec:
-            self.log("Certificate {0} disappeared between list and get: {1}".format(item.name, str(ec)))
-            return None
-        except Exception as ec2:
-            self.log("Skipping certificate {0} due to error: {1}".format(item.name, str(ec2)))
-            return None
-        return certificatebundle_to_dict(bundle)
 
 
 def main():

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -15,10 +15,11 @@
 
     - name: Lookup service principal object id
       ansible.builtin.set_fact:
-        object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
-                       azure_client_id=azure_client_id,
-                       azure_secret=azure_secret,
-                       azure_tenant=tenant_id) }}"
+        object_id:
+          "{{ lookup('azure.azcollection.azure_service_principal_attribute',
+          azure_client_id=azure_client_id,
+          azure_secret=azure_secret,
+          azure_tenant=tenant_id) }}"
       register: object_id_facts
 
     - name: Create instance of Key Vault
@@ -32,7 +33,7 @@
           family: A
         access_policies:
           - tenant_id: "{{ tenant_id }}"
-            object_id: '{{ object_id }}'
+            object_id: "{{ object_id }}"
             keys:
               - get
               - list
@@ -62,14 +63,14 @@
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
         name: "cert{{ rpfx }}"
         policy:
-          subject: 'CN=Anhui02'
+          subject: "CN=Anhui02"
           issuer_name: self
           exportable: true
           key_type: RSA
           key_size: 2048
           san_emails:
             - 7170222076@qq.com
-          content_type: 'application/x-pkcs12'
+          content_type: "application/x-pkcs12"
           validity_in_months: 36
           lifetime_actions:
             - action: EmailContacts
@@ -89,14 +90,14 @@
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
         name: "cert{{ rpfx }}"
         policy:
-          subject: 'CN=Anhui02'
+          subject: "CN=Anhui02"
           issuer_name: self
           exportable: true
           key_type: RSA
           key_size: 2048
           san_emails:
             - 7170222076@qq.com
-          content_type: 'application/x-pkcs12'
+          content_type: "application/x-pkcs12"
           validity_in_months: 36
           lifetime_actions:
             - action: EmailContacts
@@ -116,14 +117,14 @@
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
         name: "cert{{ rpfx }}"
         policy:
-          subject: 'CN=Anhui02'
+          subject: "CN=Anhui02"
           issuer_name: self
           exportable: true
           key_type: RSA
           key_size: 2048
           san_emails:
             - 7170222076@qq.com
-          content_type: 'application/x-pkcs12'
+          content_type: "application/x-pkcs12"
           validity_in_months: 38
           lifetime_actions:
             - action: EmailContacts
@@ -160,6 +161,8 @@
         password: "{{ cert_password }}"
         cert_data: "{{ lookup('file', cert_file) }}"
         state: import
+        tags:
+          tracker: trackertag
       register: output
 
     - name: Assert the keyvault certificate imported
@@ -171,7 +174,7 @@
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
       register: list_active_facts
 
-    - name: Assert active certificate listing returns the expected shape
+    - name: Assert active certificate listing returns the expected brief shape
       ansible.builtin.assert:
         that:
           - list_active_facts['certificates'] is defined
@@ -181,32 +184,36 @@
           - list_active_facts['certificates'] | length >= 1
           - "'cert' + rpfx + '-secondary' in (list_active_facts['certificates'] | map(attribute='name') | list)"
           - "'cert' + rpfx not in (list_active_facts['certificates'] | map(attribute='name') | list)"
-          - list_active_facts['certificates'][0]['policy'] is defined
           - list_active_facts['certificates'][0]['properties']['attributes'] is defined
+          - list_active_facts['certificates'][0]['properties']['attributes']['enabled'] is defined
+          - list_active_facts['certificates'][0]['properties']['id'] is defined
+          - list_active_facts['certificates'][0]['properties']['x509_thumbprint'] is defined
+          - list_active_facts['certificates'][0]['properties']['tags'] is defined
 
-    - name: List all active keyvault certificates with include_pending=true
-      azure.azcollection.azure_rm_keyvaultcertificate_info:
-        vault_uri: https://vault{{ rpfx }}.vault.azure.net
-        include_pending: true
-      register: list_active_pending_facts
-
-    - name: Assert include_pending listing succeeds
-      ansible.builtin.assert:
-        that:
-          - list_active_pending_facts['certificates'] is defined
-          - list_active_pending_facts['certificates'] is iterable
-
-    - name: List active certificates with a non-matching tag filter
+    - name: List active certificates filtered by a tag key no certificate has
       azure.azcollection.azure_rm_keyvaultcertificate_info:
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
         tags:
-          - this_tag_does_not_exist
+          - non_matching_tag
       register: list_active_tag_facts
 
     - name: Assert tag filter narrows the listing to zero items
       ansible.builtin.assert:
         that:
           - list_active_tag_facts['certificates'] | length == 0
+
+    - name: List active certificates with a tag filter that matches the imported cert
+      azure.azcollection.azure_rm_keyvaultcertificate_info:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        tags:
+          - tracker
+      register: list_active_match_facts
+
+    - name: Assert matching tag filter returns the tagged secondary certificate
+      ansible.builtin.assert:
+        that:
+          - list_active_match_facts['certificates'] | length >= 1
+          - "'cert' + rpfx + '-secondary' in (list_active_match_facts['certificates'] | map(attribute='name') | list)"
 
     - name: Delete the keyvault certificate
       azure.azcollection.azure_rm_keyvaultcertificate:

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -223,6 +223,9 @@
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
         show_deleted_certificate: true
       register: facts
+      until: facts['certificates'] | length == 2
+      retries: 30
+      delay: 10
 
     - name: Assert certificate facts
       ansible.builtin.assert:
@@ -256,6 +259,9 @@
         vault_uri: https://vault{{ rpfx }}.vault.azure.net
         show_deleted_certificate: true
       register: facts
+      until: facts['certificates'] | length == 0
+      retries: 30
+      delay: 10
 
     - name: Assert certificate facts
       ansible.builtin.assert:

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -166,6 +166,48 @@
       ansible.builtin.assert:
         that: output is changed
 
+    - name: List all active keyvault certificates (no name, default show_deleted_certificate)
+      azure.azcollection.azure_rm_keyvaultcertificate_info:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+      register: list_active_facts
+
+    - name: Assert active certificate listing returns the expected shape
+      ansible.builtin.assert:
+        that:
+          - list_active_facts['certificates'] is defined
+          - list_active_facts['certificates'] is iterable
+          # imported "-secondary" cert is enabled by default and should be present;
+          # the original "cert{{ rpfx }}" is disabled and is intentionally skipped.
+          - list_active_facts['certificates'] | length >= 1
+          - "'cert' + rpfx + '-secondary' in (list_active_facts['certificates'] | map(attribute='name') | list)"
+          - "'cert' + rpfx not in (list_active_facts['certificates'] | map(attribute='name') | list)"
+          - list_active_facts['certificates'][0]['policy'] is defined
+          - list_active_facts['certificates'][0]['properties']['attributes'] is defined
+
+    - name: List all active keyvault certificates with include_pending=true
+      azure.azcollection.azure_rm_keyvaultcertificate_info:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        include_pending: true
+      register: list_active_pending_facts
+
+    - name: Assert include_pending listing succeeds
+      ansible.builtin.assert:
+        that:
+          - list_active_pending_facts['certificates'] is defined
+          - list_active_pending_facts['certificates'] is iterable
+
+    - name: List active certificates with a non-matching tag filter
+      azure.azcollection.azure_rm_keyvaultcertificate_info:
+        vault_uri: https://vault{{ rpfx }}.vault.azure.net
+        tags:
+          - this_tag_does_not_exist
+      register: list_active_tag_facts
+
+    - name: Assert tag filter narrows the listing to zero items
+      ansible.builtin.assert:
+        that:
+          - list_active_tag_facts['certificates'] | length == 0
+
     - name: Delete the keyvault certificate
       azure.azcollection.azure_rm_keyvaultcertificate:
         vault_uri: https://vault{{ rpfx }}.vault.azure.net


### PR DESCRIPTION
##### SUMMARY
Fix #2257.

`azure_rm_keyvaultcertificate_info` already documented that omitting `name` would list all certificates in the vault, but the implementation only honoured that promise when `show_deleted_certificate=true`. With the default `show_deleted_certificate=false`, omitting `name` silently returned no `certificates` key at all — a doc&code mismatch that this PR closes.



##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_keyvaultcertificate_info.py
tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
