### PR TITLE
Add 2.21 to anible test versions

### DIFF
--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -18,6 +18,7 @@ parameters:
       - "2.18"
       - "2.19"
       - "2.20"
+      - "2.21"
       - "devel"
   - name: MODULE_NAME
     displayName: 'Test Module'


### PR DESCRIPTION
##### SUMMARY
Add ansible-core version 2.21 to parameters

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-core

##### ADDITIONAL INFORMATION
How does the pipeline run?  I see the default is to use 2.18 version of ansible-core.  When you do a release do you run against all versions?  I want to make sure we test against 2.21.

Thanks!