### PR TITLE
Follow-up #2237: Raise `azure_rm` filter exclusion log verbosity from `-v` to `-vv`

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -434,10 +434,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             display.vvvv(f"Populate {inventory_hostname}")
 
             if self._filter_exclude_host(inventory_hostname, hostvars):
-                display.v(f"azure_rm inventory: host '{inventory_hostname}' excluded by exclude_host_filters/default_host_filters")
+                display.vv(f"azure_rm inventory: host '{inventory_hostname}' excluded by exclude_host_filters/default_host_filters")
                 continue
             if not self._filter_include_host(inventory_hostname, hostvars):
-                display.v(f"azure_rm inventory: host '{inventory_hostname}' excluded by include_host_filters (no include rule matched)")
+                display.vv(f"azure_rm inventory: host '{inventory_hostname}' excluded by include_host_filters (no include rule matched)")
                 continue
 
             try:
@@ -469,7 +469,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 conditional = trust_as_template(conditional)
             try:
                 if boolean(self.templar.template(conditional)):
-                    display.v(f"azure_rm inventory: host '{inventory_hostname}' matched filter: {condition}")
+                    display.vv(f"azure_rm inventory: host '{inventory_hostname}' matched filter: {condition}")
                     return True
             except Exception as e:
                 if boolean(self.get_option('fail_on_template_errors')):


### PR DESCRIPTION
##### SUMMARY
Follow-up to #2237.

Raises the per-host filter-exclusion log verbosity in the `azure_rm` inventory plugin from `display.v` (`-v`) to `display.vv` (`-vv`).

##### ISSUE TYPE
- Enhancement

##### COMPONENT NAME
plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION
Suggested by: @TiTi https://github.com/ansible-collections/azure/pull/2237#issuecomment-4590979911
