### PR TITLE
Use httpxyz library instead of httpx

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -14,6 +14,7 @@ import copy
 import inspect
 import traceback
 import json
+import sys
 
 from os.path import expanduser
 
@@ -288,6 +289,7 @@ try:
     from azure.mgmt.resourcehealth import ResourceHealthMgmtClient
     from azure.mgmt.cdn import CdnManagementClient
     from azure.mgmt.hybridcompute import HybridComputeManagementClient
+    import httpxyz as httpx
 
 except ImportError as exc:
     AZURE_IMPORT_ERROR = traceback.format_exc()
@@ -308,6 +310,10 @@ try:
     from azure.cli.core import cloud as azure_cloud
 except ImportError:
     CLIError = Exception
+
+
+def httpx_is_loaded():
+    return sys.modules['httpx'] == httpx
 
 
 def azure_id_to_dict(id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,3 +66,4 @@ packaging>=25.0
 pandas>=2.3.3
 requests>=2.32.5
 xmltodict>=1.0.2
+httpxyz


### PR DESCRIPTION
##### SUMMARY
The maintainer of the httpx library has gone AWOL and is not accepting patches or discussions.  httpxyz has forked the httpx library and is accepting patches.  This version of the library fixes a no_proxy issue when specifying IPv6 addresses.

https://codeberg.org/httpxyz/httpxyz/pulls/47

I've also opened issues in the upstream libraries that use this import but so far they have not responded.

https://github.com/microsoftgraph/msgraph-sdk-python/issues/1464 https://github.com/microsoft/kiota-python/issues/533

Fixes: #2268 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/azure_rm_common.py

##### ADDITIONAL INFORMATION
By importing the httpxyz as httpx in the azure_rm_common code it should override the httpx library in the dependent packages.
