### PR TITLE
Fix #2274: Honour `AZURE_TENANT_ID` and caller-supplied `subscription_id` in `azure_rm` workload-identity auth

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -159,7 +159,6 @@ notes:
     - Authentication is also possible using a service principal or Active Directory user.
     - To authenticate via OIDC, pass client_id, tenant and oidc_token or oidc_token_file_path, or set environment
       variables AZURE_CLIENT_ID, AZURE_TENANT and AZURE_FEDERATED_TOKEN or AZURE_FEDERATED_TOKEN_FILE.
-      AZURE_TENANT_ID is also accepted in place of AZURE_TENANT.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -159,6 +159,7 @@ notes:
     - Authentication is also possible using a service principal or Active Directory user.
     - To authenticate via OIDC, pass client_id, tenant and oidc_token or oidc_token_file_path, or set environment
       variables AZURE_CLIENT_ID, AZURE_TENANT and AZURE_FEDERATED_TOKEN or AZURE_FEDERATED_TOKEN_FILE.
+      AZURE_TENANT_ID is also accepted in place of AZURE_TENANT.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and

--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -98,7 +98,6 @@ notes:
     - Authentication is also possible using a service principal.
     - To authenticate via OIDC, pass client_id, tenant and oidc_token or oidc_token_file_path, or set environment
       variables AZURE_CLIENT_ID, AZURE_TENANT and AZURE_FEDERATED_TOKEN or AZURE_FEDERATED_TOKEN_FILE.
-      AZURE_TENANT_ID is also accepted in place of AZURE_TENANT.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - "Alternatively, credentials can be stored in ~/.azure/credentials. This is an ini file containing

--- a/plugins/doc_fragments/azure_plugin.py
+++ b/plugins/doc_fragments/azure_plugin.py
@@ -36,9 +36,11 @@ options:
     tenant:
         description:
             - Azure tenant ID. Use when authenticating with a Service Principal.
+            - C(AZURE_TENANT_ID) is honoured as a fallback.
         type: str
         env:
           - name: AZURE_TENANT
+          - name: AZURE_TENANT_ID
     oidc_token:
         description:
             - Direct OpenID Connect (OIDC) token (JWT) used for workload identity authentication.
@@ -96,6 +98,7 @@ notes:
     - Authentication is also possible using a service principal.
     - To authenticate via OIDC, pass client_id, tenant and oidc_token or oidc_token_file_path, or set environment
       variables AZURE_CLIENT_ID, AZURE_TENANT and AZURE_FEDERATED_TOKEN or AZURE_FEDERATED_TOKEN_FILE.
+      AZURE_TENANT_ID is also accepted in place of AZURE_TENANT.
     - To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - "Alternatively, credentials can be stored in ~/.azure/credentials. This is an ini file containing

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1908,7 +1908,11 @@ class AzureRMAuth(object):
             credentials = self._get_profile(env_credentials['profile'], subscription_id=subscription_id)
             return credentials
 
-        # Merge caller-supplied subscription_id before the no-subscription early-return so inventory/profile values are honoured under workload identity.
+        # Env counts as usable auth only when client_id (SP / OIDC paths) or ad_user (user/password path) is set; otherwise let the auto cascade fall through to credential_file / az-cli.
+        if not env_credentials.get('client_id') and not env_credentials.get('ad_user'):
+            return None
+
+        # Merge caller-supplied subscription_id so workload-identity flows succeed when AZURE_SUBSCRIPTION_ID is not injected.
         if subscription_id is not None:
             env_credentials['subscription_id'] = subscription_id
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -1908,11 +1908,11 @@ class AzureRMAuth(object):
             credentials = self._get_profile(env_credentials['profile'], subscription_id=subscription_id)
             return credentials
 
-        # Env counts as usable auth only when client_id (SP / OIDC paths) or ad_user (user/password path) is set; otherwise let the auto cascade fall through to credential_file / az-cli.
+        # Env counts as usable auth only when client_id or ad_user is set; otherwise fall through to credential_file / az-cli.
         if not env_credentials.get('client_id') and not env_credentials.get('ad_user'):
             return None
 
-        # Merge caller-supplied subscription_id so workload-identity flows succeed when AZURE_SUBSCRIPTION_ID is not injected.
+        # Merge caller subscription_id so workload-identity flows succeed when AZURE_SUBSCRIPTION_ID is not injected.
         if subscription_id is not None:
             env_credentials['subscription_id'] = subscription_id
 

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -72,6 +72,11 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
     oidc_token_file_path='AZURE_FEDERATED_TOKEN_FILE'
 )
 
+# Fallback env-var names honoured when the primary is unset (e.g. AKS workload-identity webhook uses AZURE_TENANT_ID).
+AZURE_CREDENTIAL_ENV_MAPPING_FALLBACK = dict(
+    tenant='AZURE_TENANT_ID',
+)
+
 
 class SDKProfile(object):  # pylint: disable=too-few-public-methods
 
@@ -1796,8 +1801,13 @@ class AzureRMAuth(object):
         raise AzureRMAuthException(msg)
 
     def _get_env(self, module_key, default=None):
-        "Read envvar matching module parameter"
-        return os.environ.get(AZURE_CREDENTIAL_ENV_MAPPING[module_key], default)
+        "Read envvar matching module parameter, honouring fallback aliases."
+        value = os.environ.get(AZURE_CREDENTIAL_ENV_MAPPING[module_key])
+        if value is None:
+            fallback_name = AZURE_CREDENTIAL_ENV_MAPPING_FALLBACK.get(module_key)
+            if fallback_name:
+                value = os.environ.get(fallback_name)
+        return value if value is not None else default
 
     def _get_profile(self, profile="default", subscription_id=None):
         path = expanduser("~/.azure/credentials")
@@ -1891,18 +1901,19 @@ class AzureRMAuth(object):
 
     def _get_env_credentials(self, subscription_id=None):
         env_credentials = dict()
-        for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
-            env_credentials[attribute] = os.environ.get(env_variable, None)
+        for attribute in AZURE_CREDENTIAL_ENV_MAPPING:
+            env_credentials[attribute] = self._get_env(attribute)
 
         if env_credentials['profile']:
             credentials = self._get_profile(env_credentials['profile'], subscription_id=subscription_id)
             return credentials
 
-        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
-            return None
-
+        # Merge caller-supplied subscription_id before the no-subscription early-return so inventory/profile values are honoured under workload identity.
         if subscription_id is not None:
             env_credentials['subscription_id'] = subscription_id
+
+        if env_credentials.get('subscription_id') is None and not self.is_ad_resource:
+            return None
 
         return env_credentials
 


### PR DESCRIPTION
##### SUMMARY
Fix #2274.

The `azure_rm` modules and the `azure_rm` inventory plugin did not pick up the environment variables injected by the AKS workload-identity webhook (and used by the `azure-identity` SDK), so OIDC auth failed out-of-the-box on AKS workloads until the user manually re-exported `AZURE_TENANT=$AZURE_TENANT_ID`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/azure_rm_common.py
plugins/doc_fragments/azure_plugin.py

##### ADDITIONAL INFORMATION
1. `AZURE_TENANT_ID` honoured as a fallback for `tenant`
    - New `AZURE_CREDENTIAL_ENV_MAPPING_FALLBACK = {'tenant': 'AZURE_TENANT_ID'}`.
    - `_get_env()` returns the primary env var when set, otherwise the fallback.
    - `_get_env_credentials()` now routes through `_get_env()` so the alias applies there too.
    - `AZURE_TENANT` remains the primary name (back-compat with existing pipelines and `~/.azure/credentials` profiles).
2. `_get_env_credentials()` early-return reordered
    - Caller-supplied `subscription_id` is merged into `env_credentials` *before* the "no subscription return `None`" check, so a value from an `azure_rm.yml` inventory config or `~/.azure/credentials` profile is honoured under workload identity (where the webhook does not inject `AZURE_SUBSCRIPTION_ID`).
3. Auto cascade guard against env without auth material
    - `_get_env_credentials()` now returns `None` when the env has neither `client_id` (SP / OIDC paths) nor `ad_user` (user/password path), even if a caller-supplied `subscription_id` is present.
    - Without this guard, the change in (2) would cause `auth_source=auto` to short-circuit on a subscription-only env dict, skipping the documented `credential_file` -> `az-cli` fallbacks.
    - The guard preserves the #2274 fix because the AKS webhook always injects `AZURE_CLIENT_ID` alongside `AZURE_TENANT_ID` and `AZURE_FEDERATED_TOKEN_FILE`.
