### PR TITLE
Fix #2277: Add `Microsoft.ServiceNetworking/trafficControllers` to subnet delegation choices

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -158,6 +158,7 @@ options:
                     - Microsoft.Kusto/clusters
                     - Microsoft.App/environments
                     - Microsoft.Network/applicationGateways
+                    - Microsoft.ServiceNetworking/trafficControllers
             actions:
                 description:
                     - A list of actions.
@@ -398,7 +399,8 @@ delegations_spec = dict(
                  'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.ApiManagement/service', 'Microsoft.Synapse/workspaces',
                  'Microsoft.PowerPlatform/vnetaccesslinks', 'Microsoft.Network/managedResolvers', 'Microsoft.Kusto/clusters',
                  'Microsoft.ContainerService/managedClusters', 'Microsoft.App/environments',
-                 'Microsoft.Network/applicationGateways']
+                 'Microsoft.Network/applicationGateways',
+                 'Microsoft.ServiceNetworking/trafficControllers']
     ),
     actions=dict(
         type='list',


### PR DESCRIPTION
##### SUMMARY
Fix #2277.

Adds `Microsoft.ServiceNetworking/trafficControllers` to the allowed `serviceName` choices in the `delegations` parameter of `azure_rm_subnet`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_subnet.py
