### PR TITLE
Log success/failure signals for azure_arc role

### DIFF
--- a/roles/azure_arc/README.md
+++ b/roles/azure_arc/README.md
@@ -21,6 +21,7 @@ Role Variables
 * **proxy**: Object used to provide details for proxy setup if needed.  Contains the following:
   - * **hostname**: The hostname of the proxy server.
   - * **port**: The port that the proxy server is listening on.
+* **azure_arc_log_enabled**: Log success / failure to Azure for assistance with debugging (true by default, set to false to disable)
 
 Limitations
 ------------

--- a/roles/azure_arc/defaults/main.yml
+++ b/roles/azure_arc/defaults/main.yml
@@ -7,6 +7,20 @@ azure_arc_cloud: AzureCloud
 # Default url for arc install script download
 azure_arc_azcmagent_install_script_url: https://aka.ms/azcmagent
 
+azure_arc_log_enabled: true
+
+# Resource provider namespace reported in emitted signals.
+azure_arc_provider_namespace: Microsoft.HybridCompute
+
+# HIS (Hybrid Instance Service) endpoints per cloud, used to emit signals.
+azure_arc_his_endpoints:
+  AzureCloud: https://gbl.his.arc.azure.com
+  AzureUSGovernment: https://gbl.his.arc.azure.us
+  AzureChinaCloud: https://gbl.his.arc.azure.cn
+
+# Resolved HIS endpoint for the configured cloud (falls back to public cloud).
+azure_arc_his_endpoint: "{{ azure_arc_his_endpoints[azure_arc_cloud] | default('https://gbl.his.arc.azure.com') }}"
+
 # Mandatory variables for role:
 # azure_arc_resource_group: NoDefault
 # azure_arc_subscription_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/roles/azure_arc/meta/argument_specs.yml
+++ b/roles/azure_arc/meta/argument_specs.yml
@@ -50,3 +50,7 @@ argument_specs:
         description:
           - Alternative download URL for the azcmagent package.
         required: false
+      azure_arc_log_enabled:
+        description:
+          - Enable or disable logging of signals to Azure
+        required: false

--- a/roles/azure_arc/tasks/linux_connect.yml
+++ b/roles/azure_arc/tasks/linux_connect.yml
@@ -22,6 +22,8 @@
       - --correlation-id
       - "{{ azure_arc_correlation_id }}"
       - --json
+  no_log: true
   # If this command is run, it will always change the connection status from unconnected to connected
   changed_when: true
+  failed_when: false
   register: azure_arc_azcmagent_connect_json

--- a/roles/azure_arc/tasks/linux_connect.yml
+++ b/roles/azure_arc/tasks/linux_connect.yml
@@ -19,6 +19,8 @@
       - "{{ azure_arc_processed_tags }}"
       - --access-token
       - "{{ azure_arc_access_token.access_token }}"
+      - --correlation-id
+      - "{{ azure_arc_correlation_id }}"
       - --json
   # If this command is run, it will always change the connection status from unconnected to connected
   changed_when: true

--- a/roles/azure_arc/tasks/linux_install.yml
+++ b/roles/azure_arc/tasks/linux_install.yml
@@ -76,6 +76,15 @@
   changed_when: false
   failed_when: azure_arc_azcmagent_install_cmd.rc != 0
 
+- name: Log successful agent installation
+  when: not azure_arc_azcmagent_installed
+  vars:
+    azure_arc_signal_message_type: info
+    azure_arc_signal_operation: onboarding
+    azure_arc_signal_os_type: linux
+    azure_arc_signal_message: "azcmagent installed successfully via Ansible azure_arc role"
+  ansible.builtin.include_tasks: "log_signal.yml"
+
 - name: Remove temp directory for azcmagent install script
   when: not azure_arc_azcmagent_installed
   become: true

--- a/roles/azure_arc/tasks/linux_install.yml
+++ b/roles/azure_arc/tasks/linux_install.yml
@@ -72,6 +72,19 @@
   become: true
   ansible.builtin.command:
     argv: "{{ azure_arc_azcmagent_install_script_argv }}"
+  # The install script's log_failure reads these as environment variables, so
+  # its failure telemetry is correlated with the rest of this run.
+  environment: >-
+    {{
+      (azure_arc_proxy_environment | default({})) | combine({
+        'correlationId': azure_arc_correlation_id,
+        'subscriptionId': azure_arc_subscription_id | default(''),
+        'resourceGroup': azure_arc_resource_group | default(''),
+        'tenantId': azure_arc_tenant_id | default(''),
+        'location': azure_arc_location | default(''),
+        'cloud': azure_arc_cloud | default('')
+      })
+    }}
   register: azure_arc_azcmagent_install_cmd
   changed_when: false
   failed_when: azure_arc_azcmagent_install_cmd.rc != 0
@@ -80,8 +93,6 @@
   when: not azure_arc_azcmagent_installed
   vars:
     azure_arc_signal_message_type: info
-    azure_arc_signal_operation: onboarding
-    azure_arc_signal_os_type: linux
     azure_arc_signal_message: "azcmagent installed successfully via Ansible azure_arc role"
   ansible.builtin.include_tasks: "log_signal.yml"
 

--- a/roles/azure_arc/tasks/log_signal.yml
+++ b/roles/azure_arc/tasks/log_signal.yml
@@ -2,33 +2,50 @@
 # Caller-provided variables:
 #   azure_arc_signal_message_type : signal type, e.g. "info" or "error" (required)
 #   azure_arc_signal_message      : free-form message, truncated to 500 chars (required)
-#   azure_arc_signal_operation    : operation name, defaults to "onboarding"
-#   azure_arc_signal_os_type      : "linux" or "windows", defaults to azure_arc_os_type
-#   azure_arc_signal_correlation_id : optional correlation id
-#   azure_arc_signal_auth_type    : optional auth type, defaults to "token"
-- name: "Log signal"
-  delegate_to: localhost
+- name: Build signal body
   when: azure_arc_log_enabled | default(true) | bool
-  ansible.builtin.uri:
-    url: "{{ azure_arc_his_endpoint }}/log"
-    method: PUT
-    body_format: json
-    body:
+  ansible.builtin.set_fact:
+    __azure_arc_signal_body:
       subscriptionId: "{{ azure_arc_subscription_id | default('') }}"
       resourceGroup: "{{ azure_arc_resource_group | default('') }}"
       tenantId: "{{ azure_arc_tenant_id | default('') }}"
       location: "{{ azure_arc_location | default('') }}"
-      correlationId: "{{ azure_arc_signal_correlation_id | default('') }}"
-      authType: "{{ azure_arc_signal_auth_type | default('token') }}"
-      operation: "{{ azure_arc_signal_operation | default('onboarding') }}"
+      correlationId: "{{ azure_arc_correlation_id | default('') }}"
+      authType: token
+      operation: onboarding
       namespace: "{{ azure_arc_provider_namespace | default('Microsoft.HybridCompute') }}"
-      osType: "{{ azure_arc_signal_os_type | default(azure_arc_os_type) }}"
+      osType: "{{ azure_arc_os_type }}"
       messageType: "{{ azure_arc_signal_message_type }}"
       message: "{{ azure_arc_signal_message | default('') | string | truncate(500, True, '') }}"
+
+- name: "Log signal (Linux)"
+  when:
+    - azure_arc_log_enabled | default(true) | bool
+    - azure_arc_os_type == 'linux'
+  ansible.builtin.uri:
+    url: "{{ azure_arc_his_endpoint }}/log"
+    method: PUT
+    body_format: json
+    body: "{{ __azure_arc_signal_body }}"
     status_code: [200, 201, 202, 204]
-  # Route the request through the proxy (when configured), mirroring the
-  # log_failure behavior of the azcmagent install script.
   environment: "{{ {'http_proxy': azure_arc_proxy_url, 'https_proxy': azure_arc_proxy_url} if azure_arc_proxy_url is defined else {} }}"
   register: azure_arc_signal_result
+  failed_when: false
+  changed_when: false
+
+- name: "Log signal (Windows)"
+  when:
+    - azure_arc_log_enabled | default(true) | bool
+    - azure_arc_os_type == 'windows'
+  ansible.builtin.raw: >-
+    $ErrorActionPreference = 'SilentlyContinue';
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+    try {
+    Invoke-RestMethod -Uri '{{ azure_arc_his_endpoint }}/log' -Method Put
+    -ContentType 'application/json'
+    -Body '{{ __azure_arc_signal_body | to_json | replace("'", "''") }}'
+    {{ "-Proxy '" + azure_arc_proxy_url + "'" if azure_arc_proxy_url is defined else "" }} | Out-Null
+    } catch { }
+  register: azure_arc_signal_result_win
   failed_when: false
   changed_when: false

--- a/roles/azure_arc/tasks/log_signal.yml
+++ b/roles/azure_arc/tasks/log_signal.yml
@@ -26,6 +26,9 @@
       messageType: "{{ azure_arc_signal_message_type }}"
       message: "{{ azure_arc_signal_message | default('') | string | truncate(500, True, '') }}"
     status_code: [200, 201, 202, 204]
+  # Route the request through the proxy (when configured), mirroring the
+  # log_failure behavior of the azcmagent install script.
+  environment: "{{ {'http_proxy': azure_arc_proxy_url, 'https_proxy': azure_arc_proxy_url} if azure_arc_proxy_url is defined else {} }}"
   register: azure_arc_signal_result
   failed_when: false
   changed_when: false

--- a/roles/azure_arc/tasks/log_signal.yml
+++ b/roles/azure_arc/tasks/log_signal.yml
@@ -33,19 +33,26 @@
   failed_when: false
   changed_when: false
 
-- name: "Log signal (Windows)"
+- name: "Build signal (Windows)"
   when:
     - azure_arc_log_enabled | default(true) | bool
     - azure_arc_os_type == 'windows'
-  ansible.builtin.raw: >-
-    $ErrorActionPreference = 'SilentlyContinue';
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-    try {
-    Invoke-RestMethod -Uri '{{ azure_arc_his_endpoint }}/log' -Method Put
-    -ContentType 'application/json'
-    -Body '{{ __azure_arc_signal_body | to_json | replace("'", "''") }}'
-    {{ "-Proxy '" + azure_arc_proxy_url + "'" if azure_arc_proxy_url is defined else "" }} | Out-Null
-    } catch { }
+  ansible.builtin.set_fact:
+    __azure_arc_signal_ps: >-
+      $ErrorActionPreference = 'SilentlyContinue';
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+      try {
+      Invoke-RestMethod -Uri '{{ azure_arc_his_endpoint }}/log' -Method Put
+      -ContentType 'application/json'
+      -Body '{{ __azure_arc_signal_body | to_json | replace("'", "''") }}'
+      {{ "-Proxy '" + azure_arc_proxy_url + "'" if azure_arc_proxy_url is defined else "" }} | Out-Null
+      } catch { }
+
+- name: "Send signal (Windows)"
+  when:
+    - azure_arc_log_enabled | default(true) | bool
+    - azure_arc_os_type == 'windows'
+  ansible.builtin.raw: "{{ __azure_arc_signal_ps }}"
   register: azure_arc_signal_result_win
   failed_when: false
   changed_when: false

--- a/roles/azure_arc/tasks/log_signal.yml
+++ b/roles/azure_arc/tasks/log_signal.yml
@@ -1,0 +1,31 @@
+---
+# Caller-provided variables:
+#   azure_arc_signal_message_type : signal type, e.g. "info" or "error" (required)
+#   azure_arc_signal_message      : free-form message, truncated to 500 chars (required)
+#   azure_arc_signal_operation    : operation name, defaults to "onboarding"
+#   azure_arc_signal_os_type      : "linux" or "windows", defaults to azure_arc_os_type
+#   azure_arc_signal_correlation_id : optional correlation id
+#   azure_arc_signal_auth_type    : optional auth type, defaults to "token"
+- name: "Log {{ azure_arc_signal_message_type }} ({{ azure_arc_signal_operation | default('onboarding') }})"
+  delegate_to: localhost
+  when: azure_arc_log_enabled | default(true) | bool
+  ansible.builtin.uri:
+    url: "{{ azure_arc_his_endpoint }}/log"
+    method: PUT
+    body_format: json
+    body:
+      subscriptionId: "{{ azure_arc_subscription_id | default('') }}"
+      resourceGroup: "{{ azure_arc_resource_group | default('') }}"
+      tenantId: "{{ azure_arc_tenant_id | default('') }}"
+      location: "{{ azure_arc_location | default('') }}"
+      correlationId: "{{ azure_arc_signal_correlation_id | default('') }}"
+      authType: "{{ azure_arc_signal_auth_type | default('token') }}"
+      operation: "{{ azure_arc_signal_operation | default('onboarding') }}"
+      namespace: "{{ azure_arc_provider_namespace | default('Microsoft.HybridCompute') }}"
+      osType: "{{ azure_arc_signal_os_type | default(azure_arc_os_type) }}"
+      messageType: "{{ azure_arc_signal_message_type }}"
+      message: "{{ azure_arc_signal_message | default('') | string | truncate(500, True, '') }}"
+    status_code: [200, 201, 202, 204]
+  register: azure_arc_signal_result
+  failed_when: false
+  changed_when: false

--- a/roles/azure_arc/tasks/log_signal.yml
+++ b/roles/azure_arc/tasks/log_signal.yml
@@ -6,7 +6,7 @@
 #   azure_arc_signal_os_type      : "linux" or "windows", defaults to azure_arc_os_type
 #   azure_arc_signal_correlation_id : optional correlation id
 #   azure_arc_signal_auth_type    : optional auth type, defaults to "token"
-- name: "Log {{ azure_arc_signal_message_type }} ({{ azure_arc_signal_operation | default('onboarding') }})"
+- name: "Log signal"
   delegate_to: localhost
   when: azure_arc_log_enabled | default(true) | bool
   ansible.builtin.uri:

--- a/roles/azure_arc/tasks/main.yml
+++ b/roles/azure_arc/tasks/main.yml
@@ -119,6 +119,15 @@
       ansible.builtin.include_tasks: "windows_connect.yml"
       when: ansible_os_family == 'Windows'
 
+    # The connect task is no_log (its command line carries an access token), so
+    # surface only stderr here to keep failures debuggable without leaking the token.
+    - name: Fail if azcmagent connect was unsuccessful
+      when: azure_arc_azcmagent_connect_json.rc != 0
+      ansible.builtin.fail:
+        msg: >-
+          azcmagent connect failed (rc={{ azure_arc_azcmagent_connect_json.rc }}):
+          {{ azure_arc_azcmagent_connect_json.stderr | default('') }}
+
     - name: Log onboarding success
       vars:
         azure_arc_signal_message_type: info

--- a/roles/azure_arc/tasks/main.yml
+++ b/roles/azure_arc/tasks/main.yml
@@ -7,6 +7,10 @@
   ansible.builtin.set_fact:
     azure_arc_os_type: "{{ 'windows' if ansible_os_family == 'Windows' else 'linux' }}"
 
+- name: Generate correlation id
+  ansible.builtin.set_fact:
+    azure_arc_correlation_id: "{{ (2 ** 64) | random | to_uuid }}"
+
 - name: Generate tags string
   ansible.builtin.set_fact:
     azure_arc_processed_tags: |-
@@ -118,7 +122,6 @@
     - name: Log onboarding success
       vars:
         azure_arc_signal_message_type: info
-        azure_arc_signal_operation: onboarding
         azure_arc_signal_message: "azcmagent connect succeeded via Ansible azure_arc role"
       ansible.builtin.include_tasks: "log_signal.yml"
 
@@ -133,7 +136,6 @@
     - name: Log onboarding failure
       vars:
         azure_arc_signal_message_type: error
-        azure_arc_signal_operation: onboarding
         azure_arc_signal_message: >-
           azcmagent connect failed:
           {{ ansible_failed_result.msg | default(ansible_failed_result.stderr | default('unknown error')) }}

--- a/roles/azure_arc/tasks/main.yml
+++ b/roles/azure_arc/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Generate correlation id
   ansible.builtin.set_fact:
-    azure_arc_correlation_id: "{{ (2 ** 64) | random | to_uuid }}"
+    azure_arc_correlation_id: "{{ (2**64) | random | to_uuid }}"
 
 - name: Generate tags string
   ansible.builtin.set_fact:

--- a/roles/azure_arc/tasks/main.yml
+++ b/roles/azure_arc/tasks/main.yml
@@ -3,6 +3,10 @@
   ansible.builtin.setup:
   when: ansible_system is not defined
 
+- name: Set helper fact for OS type reported in logs
+  ansible.builtin.set_fact:
+    azure_arc_os_type: "{{ 'windows' if ansible_os_family == 'Windows' else 'linux' }}"
+
 - name: Generate tags string
   ansible.builtin.set_fact:
     azure_arc_processed_tags: |-
@@ -111,6 +115,13 @@
       ansible.builtin.include_tasks: "windows_connect.yml"
       when: ansible_os_family == 'Windows'
 
+    - name: Log onboarding success
+      vars:
+        azure_arc_signal_message_type: info
+        azure_arc_signal_operation: onboarding
+        azure_arc_signal_message: "azcmagent connect succeeded via Ansible azure_arc role"
+      ansible.builtin.include_tasks: "log_signal.yml"
+
     - name: Transform json stdout output to variable
       ansible.builtin.set_fact:
         azure_arc_azcmagent_connect: "{{ azure_arc_azcmagent_connect_json.stdout | ansible.builtin.from_json }}"
@@ -118,3 +129,18 @@
     - name: Set resource id as variable for easy access in other roles (newly registered system in azure arc)
       ansible.builtin.set_fact:
         azure_arc_resource_id: "{{ azure_arc_azcmagent_connect.resourceId }}"
+  rescue:
+    - name: Log onboarding failure
+      vars:
+        azure_arc_signal_message_type: error
+        azure_arc_signal_operation: onboarding
+        azure_arc_signal_message: >-
+          azcmagent connect failed:
+          {{ ansible_failed_result.msg | default(ansible_failed_result.stderr | default('unknown error')) }}
+      ansible.builtin.include_tasks: "log_signal.yml"
+
+    - name: Raise Azure Arc onboarding failure
+      ansible.builtin.fail:
+        msg: >-
+          Azure Arc onboarding (azcmagent connect) failed:
+          {{ ansible_failed_result.msg | default(ansible_failed_result.stderr | default('unknown error')) }}

--- a/roles/azure_arc/tasks/windows_connect.yml
+++ b/roles/azure_arc/tasks/windows_connect.yml
@@ -10,6 +10,7 @@
     --cloud "{{ azure_arc_cloud }}"
     --tags "{{ azure_arc_processed_tags }}"
     --access-token "{{ azure_arc_access_token.access_token }}"
+    --correlation-id "{{ azure_arc_correlation_id }}"
     --json
   # If this command is run, it will always change the connection status from unconnected to connected
   changed_when: true

--- a/roles/azure_arc/tasks/windows_connect.yml
+++ b/roles/azure_arc/tasks/windows_connect.yml
@@ -12,6 +12,8 @@
     --access-token "{{ azure_arc_access_token.access_token }}"
     --correlation-id "{{ azure_arc_correlation_id }}"
     --json
+  no_log: true
   # If this command is run, it will always change the connection status from unconnected to connected
   changed_when: true
+  failed_when: false
   register: azure_arc_azcmagent_connect_json

--- a/roles/azure_arc/tasks/windows_install.yml
+++ b/roles/azure_arc/tasks/windows_install.yml
@@ -50,3 +50,11 @@
         Remove-Item -Recurse -Force '{{ azure_arc_tmpdir_path }}'
       when: azure_arc_tmpdir_path is defined
       changed_when: true
+
+    - name: Log successful agent installation
+      vars:
+        azure_arc_signal_message_type: info
+        azure_arc_signal_operation: onboarding
+        azure_arc_signal_os_type: windows
+        azure_arc_signal_message: "azcmagent installed successfully via Ansible azure_arc role"
+      ansible.builtin.include_tasks: "log_signal.yml"

--- a/roles/azure_arc/tasks/windows_install.yml
+++ b/roles/azure_arc/tasks/windows_install.yml
@@ -54,7 +54,5 @@
     - name: Log successful agent installation
       vars:
         azure_arc_signal_message_type: info
-        azure_arc_signal_operation: onboarding
-        azure_arc_signal_os_type: windows
         azure_arc_signal_message: "azcmagent installed successfully via Ansible azure_arc role"
       ansible.builtin.include_tasks: "log_signal.yml"


### PR DESCRIPTION
##### SUMMARY
Log success/failure signals for the azure_arc role
- Signal for arc agent installation success (failure log already sent by arc agent installation script)
- Signal for arc agent onboarding (azcmagent connect) success/failure

Users can opt out by setting the ```azure_arc_log_enabled``` role parameter to false

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_arc

##### ADDITIONAL INFORMATION
Tested manually; confirmed that success/failure signals were sent.