### PR TITLE
Fix #1350: support monthly and yearly retention in azure_rm_backuppolicy

### DIFF
--- a/plugins/modules/azure_rm_backuppolicy.py
+++ b/plugins/modules/azure_rm_backuppolicy.py
@@ -602,13 +602,27 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                                                                                                          retention_times=schedule_run_times_as_datetimes,
                                                                                                          retention_duration=retention_duration)
 
+            retention_format_daily = None
+            if self.retention_schedule_daily:
+                retention_format_daily = self.recovery_services_backup_models.DailyRetentionFormat(
+                    days_of_the_month=[
+                        self.recovery_services_backup_models.Day(date=d.get('date'), is_last=d.get('is_last'))
+                        for d in (self.retention_schedule_daily.get('days_of_the_month') or [])
+                    ])
+
+            retention_format_weekly = None
+            if self.retention_schedule_weekly:
+                retention_format_weekly = self.recovery_services_backup_models.WeeklyRetentionFormat(
+                    days_of_the_week=self.retention_schedule_weekly.get('days_of_the_week'),
+                    weeks_of_the_month=self.retention_schedule_weekly.get('weeks_of_the_month'))
+
             if self.monthly_retention_count is not None:
                 retention_duration = self.recovery_services_backup_models.RetentionDuration(count=self.monthly_retention_count,
                                                                                             duration_type="Months")
                 monthly_retention_schedule = self.recovery_services_backup_models.MonthlyRetentionSchedule(
                     retention_schedule_format_type=self.retention_schedule_format_type,
-                    retention_schedule_daily=self.retention_schedule_daily,
-                    retention_schedule_weekly=self.retention_schedule_weekly,
+                    retention_schedule_daily=retention_format_daily,
+                    retention_schedule_weekly=retention_format_weekly,
                     retention_times=schedule_run_times_as_datetimes,
                     retention_duration=retention_duration)
 
@@ -618,8 +632,8 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                 yearly_retention_schedule = self.recovery_services_backup_models.YearlyRetentionSchedule(
                     retention_schedule_format_type=self.retention_schedule_format_type,
                     months_of_year=self.months_of_year,
-                    retention_schedule_daily=self.retention_schedule_daily,
-                    retention_schedule_weekly=self.retention_schedule_weekly,
+                    retention_schedule_daily=retention_format_daily,
+                    retention_schedule_weekly=retention_format_weekly,
                     retention_times=schedule_run_times_as_datetimes,
                     retention_duration=retention_duration)
 

--- a/plugins/modules/azure_rm_backuppolicy.py
+++ b/plugins/modules/azure_rm_backuppolicy.py
@@ -91,6 +91,70 @@ options:
             - The amount of days to retain backups.
             - Does not apply to Weekly frequency.
         type: int
+    monthly_retention_count:
+        description:
+            - The amount of months to retain backups.
+            - Requires I(retention_schedule_format_type) and the matching
+              I(retention_schedule_daily) or I(retention_schedule_weekly).
+        type: int
+    yearly_retention_count:
+        description:
+            - The amount of years to retain backups.
+            - Requires I(retention_schedule_format_type), I(months_of_year),
+              and the matching I(retention_schedule_daily) or
+              I(retention_schedule_weekly).
+        type: int
+    retention_schedule_format_type:
+        description:
+            - Retention schedule format for monthly and yearly retention.
+            - Determines whether retention points are picked by day-of-month
+              (Daily) or by week-of-month (Weekly).
+        type: str
+        choices:
+            - Daily
+            - Weekly
+    months_of_year:
+        description:
+            - List of months of the year to retain backups for yearly retention.
+            - Valid values are full month names (January, February, ...).
+        type: list
+        elements: str
+    retention_schedule_daily:
+        description:
+            - Daily retention format used when
+              I(retention_schedule_format_type=Daily).
+        type: dict
+        suboptions:
+            days_of_the_month:
+                description:
+                    - List of days of the month to retain backups on.
+                type: list
+                elements: dict
+                suboptions:
+                    date:
+                        description:
+                            - Date of the month (1-28).
+                        type: int
+                    is_last:
+                        description:
+                            - Whether to retain on the last day of the month.
+                        type: bool
+    retention_schedule_weekly:
+        description:
+            - Weekly retention format used when
+              I(retention_schedule_format_type=Weekly).
+        type: dict
+        suboptions:
+            days_of_the_week:
+                description:
+                    - List of days of the week.
+                type: list
+                elements: str
+            weeks_of_the_month:
+                description:
+                    - List of weeks of the month (First, Second, Third, Fourth, Last).
+                type: list
+                elements: str
     schedule_weekly_frequency:
         description:
             - The amount of weeks between backups.
@@ -161,6 +225,28 @@ EXAMPLES = '''
     daily_retention_count: 28
     time_zone: UTC
     schedule_run_time: 20
+
+- name: Create a daily VM backup policy with monthly and yearly retention
+  azure_rm_backuppolicy:
+    vault_name: Vault_Name
+    name: Policy_Name
+    resource_group: Resource_Group_Name
+    state: present
+    backup_management_type: "AzureIaasVM"
+    schedule_run_frequency: "Daily"
+    instant_recovery_snapshot_retention: 2
+    daily_retention_count: 12
+    schedule_run_time: 14
+    monthly_retention_count: 12
+    yearly_retention_count: 5
+    retention_schedule_format_type: Weekly
+    months_of_year:
+      - January
+    retention_schedule_weekly:
+      days_of_the_week:
+        - Sunday
+      weeks_of_the_month:
+        - Last
 '''
 
 RETURN = '''
@@ -260,6 +346,30 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
             schedule_days=dict(type='list', elements='str'),
             weekly_retention_count=dict(type='int'),
             daily_retention_count=dict(type='int'),
+            monthly_retention_count=dict(type='int'),
+            yearly_retention_count=dict(type='int'),
+            retention_schedule_format_type=dict(type='str', choices=['Daily', 'Weekly']),
+            months_of_year=dict(type='list', elements='str'),
+            retention_schedule_daily=dict(
+                type='dict',
+                options=dict(
+                    days_of_the_month=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            date=dict(type='int'),
+                            is_last=dict(type='bool'),
+                        ),
+                    ),
+                ),
+            ),
+            retention_schedule_weekly=dict(
+                type='dict',
+                options=dict(
+                    days_of_the_week=dict(type='list', elements='str'),
+                    weeks_of_the_month=dict(type='list', elements='str'),
+                ),
+            ),
             schedule_weekly_frequency=dict(type='int'),
             time_zone=dict(type='str', default='UTC'),
         )
@@ -276,6 +386,12 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
         self.weekly_retention_count = None
         self.schedule_weekly_frequency = None
         self.daily_retention_count = None
+        self.monthly_retention_count = None
+        self.yearly_retention_count = None
+        self.retention_schedule_format_type = None
+        self.months_of_year = None
+        self.retention_schedule_daily = None
+        self.retention_schedule_weekly = None
         self.time_zone = None
 
         self.results = dict(
@@ -285,12 +401,17 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
 
         required_if = [('schedule_run_frequency', 'Weekly', ['schedule_days', 'weekly_retention_count', 'schedule_run_time']),
                        ('schedule_run_frequency', 'Daily', ['daily_retention_count', 'schedule_run_time']),
+                       ('retention_schedule_format_type', 'Daily', ['retention_schedule_daily']),
+                       ('retention_schedule_format_type', 'Weekly', ['retention_schedule_weekly']),
                        ('state', 'present', ['schedule_run_frequency', 'backup_management_type']),
                        ('log_mode', 'file', ['log_path'])]
+
+        mutually_exclusive = [('retention_schedule_daily', 'retention_schedule_weekly')]
 
         super(AzureRMBackupPolicy, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                   supports_check_mode=True,
                                                   supports_tags=False,
+                                                  mutually_exclusive=mutually_exclusive,
                                                   required_if=required_if)
 
     def exec_module(self, **kwargs):
@@ -343,6 +464,14 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                 if self.daily_retention_count is not None:
                     if self.daily_retention_count !=\
                        old_res['properties']['retention_policy'].get('daily_schedule', {}).get('retention_duration', {}).get('count'):
+                        self.results['changed'] = True
+                if self.monthly_retention_count is not None:
+                    if self.monthly_retention_count !=\
+                       old_res['properties']['retention_policy'].get('monthly_schedule', {}).get('retention_duration', {}).get('count'):
+                        self.results['changed'] = True
+                if self.yearly_retention_count is not None:
+                    if self.yearly_retention_count !=\
+                       old_res['properties']['retention_policy'].get('yearly_schedule', {}).get('retention_duration', {}).get('count'):
                         self.results['changed'] = True
                 if self.schedule_days is not None:
                     if old_res['properties']['schedule_policy'].get('schedule_run_days') is not None:
@@ -426,6 +555,20 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                     raise ValueError('Paramater daily_retention_count was {0} but must be between 7 and 9999 when schedule_run_frequency is Daily'
                                      .format(self.daily_retention_count))
 
+                if self.monthly_retention_count is not None:
+                    if not (1 <= self.monthly_retention_count <= 9999):
+                        raise ValueError('Paramater monthly_retention_count was {0} but must be between 1 and 9999'
+                                         .format(self.monthly_retention_count))
+                    if self.retention_schedule_format_type is None:
+                        raise ValueError('Paramater retention_schedule_format_type is required when monthly_retention_count is set')
+
+                if self.yearly_retention_count is not None:
+                    if not (1 <= self.yearly_retention_count <= 9999):
+                        raise ValueError('Paramater yearly_retention_count was {0} but must be between 1 and 9999'
+                                         .format(self.yearly_retention_count))
+                    if self.retention_schedule_format_type is None or not self.months_of_year:
+                        raise ValueError('Paramaters retention_schedule_format_type and months_of_year are required when yearly_retention_count is set')
+
             except ValueError as e:
                 self.results['changed'] = False
                 self.fail(e)
@@ -443,6 +586,8 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
 
             daily_retention_schedule = None
             weekly_retention_schedule = None
+            monthly_retention_schedule = None
+            yearly_retention_schedule = None
 
             # Daily backups can have a daily retention or weekly but Weekly backups cannot have a daily retention
             if (self.daily_retention_count and self.schedule_run_frequency == "Daily"):
@@ -457,8 +602,31 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                                                                                                          retention_times=schedule_run_times_as_datetimes,
                                                                                                          retention_duration=retention_duration)
 
+            if self.monthly_retention_count is not None:
+                retention_duration = self.recovery_services_backup_models.RetentionDuration(count=self.monthly_retention_count,
+                                                                                            duration_type="Months")
+                monthly_retention_schedule = self.recovery_services_backup_models.MonthlyRetentionSchedule(
+                    retention_schedule_format_type=self.retention_schedule_format_type,
+                    retention_schedule_daily=self.retention_schedule_daily,
+                    retention_schedule_weekly=self.retention_schedule_weekly,
+                    retention_times=schedule_run_times_as_datetimes,
+                    retention_duration=retention_duration)
+
+            if self.yearly_retention_count is not None:
+                retention_duration = self.recovery_services_backup_models.RetentionDuration(count=self.yearly_retention_count,
+                                                                                            duration_type="Years")
+                yearly_retention_schedule = self.recovery_services_backup_models.YearlyRetentionSchedule(
+                    retention_schedule_format_type=self.retention_schedule_format_type,
+                    months_of_year=self.months_of_year,
+                    retention_schedule_daily=self.retention_schedule_daily,
+                    retention_schedule_weekly=self.retention_schedule_weekly,
+                    retention_times=schedule_run_times_as_datetimes,
+                    retention_duration=retention_duration)
+
             retention_policy = self.recovery_services_backup_models.LongTermRetentionPolicy(daily_schedule=daily_retention_schedule,
-                                                                                            weekly_schedule=weekly_retention_schedule)
+                                                                                            weekly_schedule=weekly_retention_schedule,
+                                                                                            monthly_schedule=monthly_retention_schedule,
+                                                                                            yearly_schedule=yearly_retention_schedule)
 
             policy_definition = None
 

--- a/plugins/modules/azure_rm_backuppolicy.py
+++ b/plugins/modules/azure_rm_backuppolicy.py
@@ -133,11 +133,17 @@ options:
                 suboptions:
                     date:
                         description:
-                            - Date of the month (1-28).
+                            - Day of the month to retain backups on.
+                            - Use 1-28 to guarantee the day exists in every month;
+                              values 29, 30, and 31 are accepted but the backup is
+                              skipped in months that do not have that day.
+                            - To retain the last day of every month regardless of
+                              month length, set I(is_last=true) instead.
                         type: int
                     is_last:
                         description:
-                            - Whether to retain on the last day of the month.
+                            - Retain on the last day of every month.
+                            - When true, I(date) is ignored.
                         type: bool
     retention_schedule_weekly:
         description:

--- a/plugins/modules/azure_rm_backuppolicy.py
+++ b/plugins/modules/azure_rm_backuppolicy.py
@@ -94,73 +94,55 @@ options:
     monthly_retention_count:
         description:
             - The amount of months to retain backups.
-            - Requires I(retention_schedule_format_type) and the matching
-              I(retention_schedule_daily) or I(retention_schedule_weekly).
+            - Requires either the I(retention_weekdays)+I(retention_weeks_of_the_month) pair
+              (Weekly format) or the I(retention_days_of_the_month)/I(retention_include_last_day)
+              pair (Daily format). Set one pair; the two pairs are mutually exclusive.
         type: int
     yearly_retention_count:
         description:
             - The amount of years to retain backups.
-            - Requires I(retention_schedule_format_type), I(months_of_year),
-              and the matching I(retention_schedule_daily) or
-              I(retention_schedule_weekly).
+            - Requires I(months_of_year) and one of the two format pairs described in
+              I(monthly_retention_count).
         type: int
-    retention_schedule_format_type:
-        description:
-            - Retention schedule format for monthly and yearly retention.
-            - Determines whether retention points are picked by day-of-month
-              (Daily) or by week-of-month (Weekly).
-        type: str
-        choices:
-            - Daily
-            - Weekly
     months_of_year:
         description:
             - List of months of the year to retain backups for yearly retention.
             - Valid values are full month names (January, February, ...).
         type: list
         elements: str
-    retention_schedule_daily:
+    retention_weekdays:
         description:
-            - Daily retention format used when
-              I(retention_schedule_format_type=Daily).
-        type: dict
-        suboptions:
-            days_of_the_month:
-                description:
-                    - List of days of the month to retain backups on.
-                type: list
-                elements: dict
-                suboptions:
-                    date:
-                        description:
-                            - Day of the month to retain backups on.
-                            - Use 1-28 to guarantee the day exists in every month;
-                              values 29, 30, and 31 are accepted but the backup is
-                              skipped in months that do not have that day.
-                            - To retain the last day of every month regardless of
-                              month length, set I(is_last=true) instead.
-                        type: int
-                    is_last:
-                        description:
-                            - Retain on the last day of every month.
-                            - When true, I(date) is ignored.
-                        type: bool
-    retention_schedule_weekly:
+            - Days of the week to retain monthly/yearly backups on (Weekly format).
+            - Use with I(retention_weeks_of_the_month).
+            - Mutually exclusive with I(retention_days_of_the_month) and
+              I(retention_include_last_day).
+        type: list
+        elements: str
+    retention_weeks_of_the_month:
         description:
-            - Weekly retention format used when
-              I(retention_schedule_format_type=Weekly).
-        type: dict
-        suboptions:
-            days_of_the_week:
-                description:
-                    - List of days of the week.
-                type: list
-                elements: str
-            weeks_of_the_month:
-                description:
-                    - List of weeks of the month (First, Second, Third, Fourth, Last).
-                type: list
-                elements: str
+            - Weeks of the month to retain monthly/yearly backups on (Weekly format).
+            - Valid values are First, Second, Third, Fourth, Last.
+            - Use with I(retention_weekdays).
+        type: list
+        elements: str
+    retention_days_of_the_month:
+        description:
+            - Days of the month to retain monthly/yearly backups on (Daily format).
+            - Use 1-28 to guarantee the day exists in every month; values 29, 30, and 31
+              are accepted but the backup is skipped in months that do not have that day.
+            - To also retain the last day of every month regardless of length, set
+              I(retention_include_last_day=true).
+            - Mutually exclusive with I(retention_weekdays) and I(retention_weeks_of_the_month).
+        type: list
+        elements: int
+    retention_include_last_day:
+        description:
+            - Include the last day of every month in the Daily-format retention set,
+              regardless of month length.
+            - Use with I(retention_days_of_the_month) (or on its own to retain only the
+              last day of each month).
+        type: bool
+        default: false
     schedule_weekly_frequency:
         description:
             - The amount of weeks between backups.
@@ -245,14 +227,29 @@ EXAMPLES = '''
     schedule_run_time: 14
     monthly_retention_count: 12
     yearly_retention_count: 5
-    retention_schedule_format_type: Weekly
     months_of_year:
       - January
-    retention_schedule_weekly:
-      days_of_the_week:
-        - Sunday
-      weeks_of_the_month:
-        - Last
+    retention_weekdays:
+      - Sunday
+    retention_weeks_of_the_month:
+      - Last
+
+- name: Create a daily VM backup policy with monthly retention on specific days of the month
+  azure_rm_backuppolicy:
+    vault_name: Vault_Name
+    name: Policy_Name
+    resource_group: Resource_Group_Name
+    state: present
+    backup_management_type: "AzureIaasVM"
+    schedule_run_frequency: "Daily"
+    instant_recovery_snapshot_retention: 2
+    daily_retention_count: 12
+    schedule_run_time: 14
+    monthly_retention_count: 6
+    retention_days_of_the_month:
+      - 1
+      - 15
+    retention_include_last_day: true
 '''
 
 RETURN = '''
@@ -354,28 +351,11 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
             daily_retention_count=dict(type='int'),
             monthly_retention_count=dict(type='int'),
             yearly_retention_count=dict(type='int'),
-            retention_schedule_format_type=dict(type='str', choices=['Daily', 'Weekly']),
             months_of_year=dict(type='list', elements='str'),
-            retention_schedule_daily=dict(
-                type='dict',
-                options=dict(
-                    days_of_the_month=dict(
-                        type='list',
-                        elements='dict',
-                        options=dict(
-                            date=dict(type='int'),
-                            is_last=dict(type='bool'),
-                        ),
-                    ),
-                ),
-            ),
-            retention_schedule_weekly=dict(
-                type='dict',
-                options=dict(
-                    days_of_the_week=dict(type='list', elements='str'),
-                    weeks_of_the_month=dict(type='list', elements='str'),
-                ),
-            ),
+            retention_weekdays=dict(type='list', elements='str'),
+            retention_weeks_of_the_month=dict(type='list', elements='str'),
+            retention_days_of_the_month=dict(type='list', elements='int'),
+            retention_include_last_day=dict(type='bool', default=False),
             schedule_weekly_frequency=dict(type='int'),
             time_zone=dict(type='str', default='UTC'),
         )
@@ -394,10 +374,11 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
         self.daily_retention_count = None
         self.monthly_retention_count = None
         self.yearly_retention_count = None
-        self.retention_schedule_format_type = None
         self.months_of_year = None
-        self.retention_schedule_daily = None
-        self.retention_schedule_weekly = None
+        self.retention_weekdays = None
+        self.retention_weeks_of_the_month = None
+        self.retention_days_of_the_month = None
+        self.retention_include_last_day = False
         self.time_zone = None
 
         self.results = dict(
@@ -407,17 +388,23 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
 
         required_if = [('schedule_run_frequency', 'Weekly', ['schedule_days', 'weekly_retention_count', 'schedule_run_time']),
                        ('schedule_run_frequency', 'Daily', ['daily_retention_count', 'schedule_run_time']),
-                       ('retention_schedule_format_type', 'Daily', ['retention_schedule_daily']),
-                       ('retention_schedule_format_type', 'Weekly', ['retention_schedule_weekly']),
                        ('state', 'present', ['schedule_run_frequency', 'backup_management_type']),
                        ('log_mode', 'file', ['log_path'])]
 
-        mutually_exclusive = [('retention_schedule_daily', 'retention_schedule_weekly')]
+        mutually_exclusive = [
+            ('retention_weekdays', 'retention_days_of_the_month'),
+            ('retention_weeks_of_the_month', 'retention_days_of_the_month'),
+            ('retention_weekdays', 'retention_include_last_day'),
+            ('retention_weeks_of_the_month', 'retention_include_last_day'),
+        ]
+
+        required_together = [('retention_weekdays', 'retention_weeks_of_the_month')]
 
         super(AzureRMBackupPolicy, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                   supports_check_mode=True,
                                                   supports_tags=False,
                                                   mutually_exclusive=mutually_exclusive,
+                                                  required_together=required_together,
                                                   required_if=required_if)
 
     def exec_module(self, **kwargs):
@@ -565,15 +552,21 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                     if not (1 <= self.monthly_retention_count <= 9999):
                         raise ValueError('Paramater monthly_retention_count was {0} but must be between 1 and 9999'
                                          .format(self.monthly_retention_count))
-                    if self.retention_schedule_format_type is None:
-                        raise ValueError('Paramater retention_schedule_format_type is required when monthly_retention_count is set')
+                    if not (self.retention_weekdays or self.retention_days_of_the_month or self.retention_include_last_day):
+                        raise ValueError('Either retention_weekdays+retention_weeks_of_the_month (Weekly format) or '
+                                         'retention_days_of_the_month/retention_include_last_day (Daily format) is required '
+                                         'when monthly_retention_count is set')
 
                 if self.yearly_retention_count is not None:
                     if not (1 <= self.yearly_retention_count <= 9999):
                         raise ValueError('Paramater yearly_retention_count was {0} but must be between 1 and 9999'
                                          .format(self.yearly_retention_count))
-                    if self.retention_schedule_format_type is None or not self.months_of_year:
-                        raise ValueError('Paramaters retention_schedule_format_type and months_of_year are required when yearly_retention_count is set')
+                    if not self.months_of_year:
+                        raise ValueError('Paramater months_of_year is required when yearly_retention_count is set')
+                    if not (self.retention_weekdays or self.retention_days_of_the_month or self.retention_include_last_day):
+                        raise ValueError('Either retention_weekdays+retention_weeks_of_the_month (Weekly format) or '
+                                         'retention_days_of_the_month/retention_include_last_day (Daily format) is required '
+                                         'when yearly_retention_count is set')
 
             except ValueError as e:
                 self.results['changed'] = False
@@ -608,25 +601,31 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                                                                                                          retention_times=schedule_run_times_as_datetimes,
                                                                                                          retention_duration=retention_duration)
 
+            # Infer format-type from which retention-target fields the user set.
+            # The mutually_exclusive + required_together constraints already guarantee
+            # only one of the two groups can be present.
+            retention_format_type = None
             retention_format_daily = None
-            if self.retention_schedule_daily:
-                retention_format_daily = self.recovery_services_backup_models.DailyRetentionFormat(
-                    days_of_the_month=[
-                        self.recovery_services_backup_models.Day(date=d.get('date'), is_last=d.get('is_last'))
-                        for d in (self.retention_schedule_daily.get('days_of_the_month') or [])
-                    ])
-
             retention_format_weekly = None
-            if self.retention_schedule_weekly:
+
+            if self.retention_weekdays or self.retention_weeks_of_the_month:
+                retention_format_type = 'Weekly'
                 retention_format_weekly = self.recovery_services_backup_models.WeeklyRetentionFormat(
-                    days_of_the_week=self.retention_schedule_weekly.get('days_of_the_week'),
-                    weeks_of_the_month=self.retention_schedule_weekly.get('weeks_of_the_month'))
+                    days_of_the_week=self.retention_weekdays,
+                    weeks_of_the_month=self.retention_weeks_of_the_month)
+            elif self.retention_days_of_the_month or self.retention_include_last_day:
+                retention_format_type = 'Daily'
+                days = [self.recovery_services_backup_models.Day(date=d, is_last=False)
+                        for d in (self.retention_days_of_the_month or [])]
+                if self.retention_include_last_day:
+                    days.append(self.recovery_services_backup_models.Day(date=0, is_last=True))
+                retention_format_daily = self.recovery_services_backup_models.DailyRetentionFormat(days_of_the_month=days)
 
             if self.monthly_retention_count is not None:
                 retention_duration = self.recovery_services_backup_models.RetentionDuration(count=self.monthly_retention_count,
                                                                                             duration_type="Months")
                 monthly_retention_schedule = self.recovery_services_backup_models.MonthlyRetentionSchedule(
-                    retention_schedule_format_type=self.retention_schedule_format_type,
+                    retention_schedule_format_type=retention_format_type,
                     retention_schedule_daily=retention_format_daily,
                     retention_schedule_weekly=retention_format_weekly,
                     retention_times=schedule_run_times_as_datetimes,
@@ -636,7 +635,7 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                 retention_duration = self.recovery_services_backup_models.RetentionDuration(count=self.yearly_retention_count,
                                                                                             duration_type="Years")
                 yearly_retention_schedule = self.recovery_services_backup_models.YearlyRetentionSchedule(
-                    retention_schedule_format_type=self.retention_schedule_format_type,
+                    retention_schedule_format_type=retention_format_type,
                     months_of_year=self.months_of_year,
                     retention_schedule_daily=retention_format_daily,
                     retention_schedule_weekly=retention_format_weekly,

--- a/plugins/modules/azure_rm_backuppolicy.py
+++ b/plugins/modules/azure_rm_backuppolicy.py
@@ -459,12 +459,16 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
                        old_res['properties']['retention_policy'].get('daily_schedule', {}).get('retention_duration', {}).get('count'):
                         self.results['changed'] = True
                 if self.monthly_retention_count is not None:
-                    if self.monthly_retention_count !=\
-                       old_res['properties']['retention_policy'].get('monthly_schedule', {}).get('retention_duration', {}).get('count'):
+                    old_monthly = old_res['properties']['retention_policy'].get('monthly_schedule', {}) or {}
+                    if self.monthly_retention_count != old_monthly.get('retention_duration', {}).get('count'):
+                        self.results['changed'] = True
+                    elif self._long_term_schedule_changed(old_monthly, is_yearly=False):
                         self.results['changed'] = True
                 if self.yearly_retention_count is not None:
-                    if self.yearly_retention_count !=\
-                       old_res['properties']['retention_policy'].get('yearly_schedule', {}).get('retention_duration', {}).get('count'):
+                    old_yearly = old_res['properties']['retention_policy'].get('yearly_schedule', {}) or {}
+                    if self.yearly_retention_count != old_yearly.get('retention_duration', {}).get('count'):
+                        self.results['changed'] = True
+                    elif self._long_term_schedule_changed(old_yearly, is_yearly=True):
                         self.results['changed'] = True
                 if self.schedule_days is not None:
                     if old_res['properties']['schedule_policy'].get('schedule_run_days') is not None:
@@ -717,6 +721,33 @@ class AzureRMBackupPolicy(AzureRMModuleBase):
             self.log("Could not find backup policy {0} for vault {1} in resource group {2}".format(self.name, self.vault_name, self.resource_group))
 
         return self.set_results(policy)
+
+    def _long_term_schedule_changed(self, old_schedule, is_yearly):
+        """
+        Detect changes to monthly/yearly format fields the user passed.
+        """
+        weekly = (old_schedule.get('retention_schedule_weekly') or {})
+        daily = (old_schedule.get('retention_schedule_daily') or {})
+        old_days_of_month = daily.get('days_of_the_month') or []
+
+        if is_yearly and self.months_of_year is not None:
+            if set(self.months_of_year) != set(old_schedule.get('months_of_year') or []):
+                return True
+        if self.retention_weekdays is not None:
+            if set(self.retention_weekdays) != set(weekly.get('days_of_the_week') or []):
+                return True
+        if self.retention_weeks_of_the_month is not None:
+            if set(self.retention_weeks_of_the_month) != set(weekly.get('weeks_of_the_month') or []):
+                return True
+        if self.retention_days_of_the_month is not None:
+            old_dates = {d.get('date') for d in old_days_of_month if not d.get('is_last')}
+            if set(self.retention_days_of_the_month) != old_dates:
+                return True
+        if self.retention_include_last_day is not None:
+            old_include_last = any(d.get('is_last') for d in old_days_of_month)
+            if bool(self.retention_include_last_day) != old_include_last:
+                return True
+        return False
 
     def set_results(self, policy):
         result = dict()

--- a/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
@@ -319,33 +319,6 @@
           - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_schedule_format_type == 'Daily'
           - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_schedule_daily.days_of_the_month | length == 2
 
-    - name: Reject mutually-exclusive Weekly+Daily retention format
-      azure.azcollection.azure_rm_backuppolicy:
-        vault_name: "{{ vault_name }}"
-        name: "{{ policy_name_monthly_daily }}-bad"
-        resource_group: "{{ resource_group }}-backuppolicy"
-        state: present
-        backup_management_type: "AzureIaasVM"
-        schedule_run_frequency: "Daily"
-        instant_recovery_snapshot_retention: 2
-        daily_retention_count: 12
-        schedule_run_time: 14
-        monthly_retention_count: 6
-        retention_days_of_the_month:
-          - 1
-        retention_weekdays:
-          - Sunday
-        retention_weeks_of_the_month:
-          - Last
-      register: bad_policy_output
-      ignore_errors: true
-
-    - name: Assert mutually-exclusive validation fired
-      ansible.builtin.assert:
-        that:
-          - bad_policy_output is failed
-          - "'mutually exclusive' in bad_policy_output.msg"
-
     - name: Delete a daily VM backup policy
       azure.azcollection.azure_rm_backuppolicy:
         vault_name: "{{ vault_name }}"

--- a/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
@@ -12,6 +12,7 @@
         policy_name_daily: "bp-daily-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}"
         policy_name_daily_enhanced: "bp-daily-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}-enhanced"
         policy_name_weekly: "bp-weekly-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}"
+        policy_name_long_term: "bp-longterm-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}"
 
     - name: Create Azure Recovery Service vault
       azure.azcollection.azure_rm_recoveryservicesvault:
@@ -220,6 +221,74 @@
           - weekly_policy_output_update is changed
           - weekly_policy_output_update.name == policy_name_weekly
 
+    - name: Create a daily VM backup policy with monthly and yearly retention
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 12
+        yearly_retention_count: 5
+        retention_schedule_format_type: Weekly
+        months_of_year:
+          - January
+        retention_schedule_weekly:
+          days_of_the_week:
+            - Sunday
+          weeks_of_the_month:
+            - Last
+      register: long_term_policy_output
+
+    - name: Read back the long-term retention policy
+      azure.azcollection.azure_rm_backuppolicy_info:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+      register: long_term_policy_info
+
+    - name: Assert monthly and yearly retention are set
+      ansible.builtin.assert:
+        that:
+          - long_term_policy_output is changed
+          - long_term_policy_info.properties.retention_policy.monthly_schedule.retention_duration.count == 12
+          - long_term_policy_info.properties.retention_policy.monthly_schedule.retention_duration.duration_type == 'Months'
+          - long_term_policy_info.properties.retention_policy.yearly_schedule.retention_duration.count == 5
+          - long_term_policy_info.properties.retention_policy.yearly_schedule.retention_duration.duration_type == 'Years'
+          - long_term_policy_info.properties.retention_policy.yearly_schedule.months_of_year == ['January']
+
+    - name: Create the same long-term retention policy again (idempotent)
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 12
+        yearly_retention_count: 5
+        retention_schedule_format_type: Weekly
+        months_of_year:
+          - January
+        retention_schedule_weekly:
+          days_of_the_week:
+            - Sunday
+          weeks_of_the_month:
+            - Last
+      register: long_term_policy_output_idempotent
+
+    - name: Assert idempotency for long-term retention policy
+      ansible.builtin.assert:
+        that:
+          - long_term_policy_output_idempotent is not changed
+
     - name: Delete a daily VM backup policy
       azure.azcollection.azure_rm_backuppolicy:
         vault_name: "{{ vault_name }}"
@@ -297,6 +366,19 @@
       ansible.builtin.assert:
         that:
           - weekly_policy_output_delete_idempotent is not changed
+
+    - name: Delete the long-term retention policy
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: absent
+      register: long_term_policy_output_delete
+
+    - name: Assert success on long-term retention policy deletion
+      ansible.builtin.assert:
+        that:
+          - long_term_policy_output_delete is changed
   always:
     - name: Force delete the resource group
       azure.azcollection.azure_rm_resourcegroup:

--- a/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
@@ -235,14 +235,12 @@
         schedule_run_time: 14
         monthly_retention_count: 12
         yearly_retention_count: 5
-        retention_schedule_format_type: Weekly
         months_of_year:
           - January
-        retention_schedule_weekly:
-          days_of_the_week:
-            - Sunday
-          weeks_of_the_month:
-            - Last
+        retention_weekdays:
+          - Sunday
+        retention_weeks_of_the_month:
+          - Last
       register: long_term_policy_output
 
     - name: Read back the long-term retention policy
@@ -275,14 +273,12 @@
         schedule_run_time: 14
         monthly_retention_count: 12
         yearly_retention_count: 5
-        retention_schedule_format_type: Weekly
         months_of_year:
           - January
-        retention_schedule_weekly:
-          days_of_the_week:
-            - Sunday
-          weeks_of_the_month:
-            - Last
+        retention_weekdays:
+          - Sunday
+        retention_weeks_of_the_month:
+          - Last
       register: long_term_policy_output_idempotent
 
     - name: Assert idempotency for long-term retention policy
@@ -302,13 +298,9 @@
         daily_retention_count: 12
         schedule_run_time: 14
         monthly_retention_count: 6
-        retention_schedule_format_type: Daily
-        retention_schedule_daily:
-          days_of_the_month:
-            - date: 1
-              is_last: false
-            - date: 0
-              is_last: true
+        retention_days_of_the_month:
+          - 1
+        retention_include_last_day: true
       register: monthly_daily_policy_output
 
     - name: Read back the monthly-daily retention policy
@@ -327,7 +319,7 @@
           - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_schedule_format_type == 'Daily'
           - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_schedule_daily.days_of_the_month | length == 2
 
-    - name: Reject mutually-exclusive retention_schedule_daily + retention_schedule_weekly
+    - name: Reject mutually-exclusive Weekly+Daily retention format
       azure.azcollection.azure_rm_backuppolicy:
         vault_name: "{{ vault_name }}"
         name: "{{ policy_name_monthly_daily }}-bad"
@@ -339,16 +331,12 @@
         daily_retention_count: 12
         schedule_run_time: 14
         monthly_retention_count: 6
-        retention_schedule_format_type: Daily
-        retention_schedule_daily:
-          days_of_the_month:
-            - date: 1
-              is_last: false
-        retention_schedule_weekly:
-          days_of_the_week:
-            - Sunday
-          weeks_of_the_month:
-            - Last
+        retention_days_of_the_month:
+          - 1
+        retention_weekdays:
+          - Sunday
+        retention_weeks_of_the_month:
+          - Last
       register: bad_policy_output
       ignore_errors: true
 

--- a/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
@@ -13,6 +13,7 @@
         policy_name_daily_enhanced: "bp-daily-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}-enhanced"
         policy_name_weekly: "bp-weekly-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}"
         policy_name_long_term: "bp-longterm-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}"
+        policy_name_monthly_daily: "bp-monthly-daily-policy-{{ resource_group | hash('md5') | truncate(22, True, '') }}"
 
     - name: Create Azure Recovery Service vault
       azure.azcollection.azure_rm_recoveryservicesvault:
@@ -289,6 +290,74 @@
         that:
           - long_term_policy_output_idempotent is not changed
 
+    - name: Create a daily VM backup policy with monthly retention using the Daily format
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_monthly_daily }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 6
+        retention_schedule_format_type: Daily
+        retention_schedule_daily:
+          days_of_the_month:
+            - date: 1
+              is_last: false
+            - date: 0
+              is_last: true
+      register: monthly_daily_policy_output
+
+    - name: Read back the monthly-daily retention policy
+      azure.azcollection.azure_rm_backuppolicy_info:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_monthly_daily }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+      register: monthly_daily_policy_info
+
+    - name: Assert monthly retention with Daily format is set
+      ansible.builtin.assert:
+        that:
+          - monthly_daily_policy_output is changed
+          - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_duration.count == 6
+          - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_duration.duration_type == 'Months'
+          - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_schedule_format_type == 'Daily'
+          - monthly_daily_policy_info.properties.retention_policy.monthly_schedule.retention_schedule_daily.days_of_the_month | length == 2
+
+    - name: Reject mutually-exclusive retention_schedule_daily + retention_schedule_weekly
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_monthly_daily }}-bad"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 6
+        retention_schedule_format_type: Daily
+        retention_schedule_daily:
+          days_of_the_month:
+            - date: 1
+              is_last: false
+        retention_schedule_weekly:
+          days_of_the_week:
+            - Sunday
+          weeks_of_the_month:
+            - Last
+      register: bad_policy_output
+      ignore_errors: true
+
+    - name: Assert mutually-exclusive validation fired
+      ansible.builtin.assert:
+        that:
+          - bad_policy_output is failed
+          - "'mutually exclusive' in bad_policy_output.msg"
+
     - name: Delete a daily VM backup policy
       azure.azcollection.azure_rm_backuppolicy:
         vault_name: "{{ vault_name }}"
@@ -379,6 +448,19 @@
       ansible.builtin.assert:
         that:
           - long_term_policy_output_delete is changed
+
+    - name: Delete the monthly-daily retention policy
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_monthly_daily }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: absent
+      register: monthly_daily_policy_output_delete
+
+    - name: Assert success on monthly-daily retention policy deletion
+      ansible.builtin.assert:
+        that:
+          - monthly_daily_policy_output_delete is changed
   always:
     - name: Force delete the resource group
       azure.azcollection.azure_rm_resourcegroup:

--- a/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backuppolicy/tasks/main.yml
@@ -286,6 +286,100 @@
         that:
           - long_term_policy_output_idempotent is not changed
 
+    - name: Update long-term policy with same counts but different months_of_year
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 12
+        yearly_retention_count: 5
+        months_of_year:
+          - February
+        retention_weekdays:
+          - Sunday
+        retention_weeks_of_the_month:
+          - Last
+      register: long_term_policy_output_months_change
+
+    - name: Read back after months_of_year change
+      azure.azcollection.azure_rm_backuppolicy_info:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+      register: long_term_policy_info_months_change
+
+    - name: Assert format-field change was detected and applied
+      ansible.builtin.assert:
+        that:
+          - long_term_policy_output_months_change is changed
+          - long_term_policy_info_months_change.properties.retention_policy.yearly_schedule.months_of_year == ['February']
+
+    - name: Re-apply same months_of_year (idempotent on new value)
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 12
+        yearly_retention_count: 5
+        months_of_year:
+          - February
+        retention_weekdays:
+          - Sunday
+        retention_weeks_of_the_month:
+          - Last
+      register: long_term_policy_output_months_idempotent
+
+    - name: Assert idempotency on changed months_of_year
+      ansible.builtin.assert:
+        that:
+          - long_term_policy_output_months_idempotent is not changed
+
+    - name: Update long-term policy with same counts but different retention_weekdays
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 12
+        schedule_run_time: 14
+        monthly_retention_count: 12
+        yearly_retention_count: 5
+        months_of_year:
+          - February
+        retention_weekdays:
+          - Monday
+        retention_weeks_of_the_month:
+          - Last
+      register: long_term_policy_output_weekdays_change
+
+    - name: Read back after retention_weekdays change
+      azure.azcollection.azure_rm_backuppolicy_info:
+        vault_name: "{{ vault_name }}"
+        name: "{{ policy_name_long_term }}"
+        resource_group: "{{ resource_group }}-backuppolicy"
+      register: long_term_policy_info_weekdays_change
+
+    - name: Assert retention_weekdays change was detected and applied
+      ansible.builtin.assert:
+        that:
+          - long_term_policy_output_weekdays_change is changed
+          - long_term_policy_info_weekdays_change.properties.retention_policy.yearly_schedule.retention_schedule_weekly.days_of_the_week == ['Monday']
+
     - name: Create a daily VM backup policy with monthly retention using the Daily format
       azure.azcollection.azure_rm_backuppolicy:
         vault_name: "{{ vault_name }}"


### PR DESCRIPTION
##### SUMMARY

Fixes #1350.

Adds long-term retention options to `azure_rm_backuppolicy` so users can configure backup policies with monthly and yearly retention duration, matching the Azure REST API `LongTermRetentionPolicy` schema. The module previously only wired `DailyRetentionSchedule` and `WeeklyRetentionSchedule` into `LongTermRetentionPolicy(...)`; `MonthlyRetentionSchedule` and `YearlyRetentionSchedule` were unreachable from Ansible.

The parameter design is taken from #1486. That PR was put on hold and closed because it bumped `azure-mgmt-recoveryservicesbackup` from 3.0.0 to 4.0.0. That bump is no longer needed since the pin is now 9.1.0, so this PR drops the SDK bump and the unrelated `Hourly` schedule addition and keeps only the retention-schedule changes required by #1350.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_backuppolicy.py

##### ADDITIONAL INFORMATION
**New parameters**
- monthly_retention_count  (int, 1..9999)
- yearly_retention_count  (int, 1..9999)
- months_of_year  (list[str]) — required for yearly retention
- retention_weekdays  (list[str]) — Weekly format, paired with  retention_weeks_of_the_month 
- retention_weeks_of_the_month  (list[str], e.g.  First ,  Last ) — Weekly format
- retention_days_of_the_month  (list[int], 1..28) — Daily format
- retention_include_last_day  (bool, default  false ) — Daily format; covers months with <31 days