### PR TITLE
Fix `azure_rm_virtualmachine`: default to managed disks (unmanaged disks retired 2026-03-31)

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -199,24 +199,33 @@ options:
                 type: str
     storage_account_name:
         description:
-            - Name of a storage account that supports creation of VHD blobs.
+            - (Deprecated) Name of a storage account that supports creation of VHD blobs.
             - If not specified for a new VM, a new storage account named <vm name>01 will be created using storage type C(Standard_LRS).
+            - Unmanaged disks were retired by Azure on March 31, 2026. Use I(managed_disk_type) instead.
+            - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
+            - This option will be removed in version 4.0.0.
         type: str
         aliases:
             - storage_account
     storage_container_name:
         description:
-            - Name of the container to use within the storage account to store VHD blobs.
+            - (Deprecated) Name of the container to use within the storage account to store VHD blobs.
             - If not specified, a default container will be created.
+            - Unmanaged disks were retired by Azure on March 31, 2026. Use I(managed_disk_type) instead.
+            - This option will be removed in version 4.0.0.
+            - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
         default: vhds
         type: str
         aliases:
             - storage_container
     storage_blob_name:
         description:
-            - Name of the storage blob used to hold the OS disk image of the VM.
+            - (Deprecated) Name of the storage blob used to hold the OS disk image of the VM.
             - Must end with '.vhd'.
             - If not specified, defaults to the VM name + '.vhd'.
+            - Unmanaged disks were retired by Azure on March 31, 2026. Use I(managed_disk_type) instead.
+            - This option will be removed in version 4.0.0.
+            - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
         type: str
         aliases:
             - storage_blob
@@ -224,7 +233,9 @@ options:
         description:
             - Managed OS disk type.
             - Create OS disk with managed disk if defined.
-            - If not defined, the OS disk will be created with virtual hard disk (VHD).
+            - Defaults to C(Standard_LRS) when no disk options are specified.
+            - Unmanaged disks were retired by Azure on March 31, 2026.
+            - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
         type: str
         choices:
             - Standard_LRS
@@ -307,7 +318,9 @@ options:
             managed_disk_type:
                 description:
                     - Managed data disk type.
-                    - Only used when OS disk created with managed disk.
+                    - Defaults to C(Standard_LRS) when no disk options are specified.
+                      Unmanaged disks were retired by Azure on March 31, 2026.
+                    - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
                 type: str
                 choices:
                     - Standard_LRS
@@ -318,29 +331,32 @@ options:
                     - UltraSSD_LRS
             storage_account_name:
                 description:
-                    - Name of an existing storage account that supports creation of VHD blobs.
+                    - (Deprecated) Name of an existing storage account that supports creation of VHD blobs.
                     - If not specified for a new VM, a new storage account started with I(name) will be created using storage type C(Standard_LRS).
-                    - Only used when OS disk created with virtual hard disk (VHD).
-                    - Used when I(managed_disk_type) not defined.
                     - Cannot be updated unless I(lun) updated.
+                    - Unmanaged disks were retired by Azure on March 31, 2026. Use I(managed_disk_type) instead.
+                    - This option will be removed in version 4.0.0.
+                    - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
                 type: str
             storage_container_name:
                 description:
-                    - Name of the container to use within the storage account to store VHD blobs.
+                    - (Deprecated) Name of the container to use within the storage account to store VHD blobs.
                     - If no name is specified a default container named 'vhds' will created.
-                    - Only used when OS disk created with virtual hard disk (VHD).
-                    - Used when I(managed_disk_type) not defined.
                     - Cannot be updated unless I(lun) updated.
+                    - Unmanaged disks were retired by Azure on March 31, 2026. Use I(managed_disk_type) instead.
+                    - This option will be removed in version 4.0.0.
+                    - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
                 type: str
                 default: vhds
             storage_blob_name:
                 description:
-                    - Name of the storage blob used to hold the OS disk image of the VM.
+                    - (Deprecated) Name of the storage blob used to hold the OS disk image of the VM.
                     - Must end with '.vhd'.
                     - Default to the I(name) + timestamp + I(lun) + '.vhd'.
-                    - Only used when OS disk created with virtual hard disk (VHD).
-                    - Used when I(managed_disk_type) not defined.
                     - Cannot be updated unless I(lun) updated.
+                    - Unmanaged disks were retired by Azure on March 31, 2026. Use I(managed_disk_type) instead.
+                    - This option will be removed in version 4.0.0.
+                    - See U(https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation).
                 type: str
             caching:
                 description:
@@ -1580,6 +1596,25 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                 if not self.plan.get('name') or not self.plan.get('product') or not self.plan.get('publisher'):
                     self.fail("parameter error: plan must include name, product, and publisher")
 
+            # When the caller specifies no disk options at all, default to a managed
+            # Standard_LRS OS disk instead of the legacy unmanaged-VHD path. Also
+            # default delete_option to 'Delete'.
+            if (not self.managed_disk_type
+                    and not self.storage_blob_name
+                    and not self.storage_account_name):
+                self.managed_disk_type = 'Standard_LRS'
+                if not self.os_disk_delete_option:
+                    self.os_disk_delete_option = 'Delete'
+            elif not self.managed_disk_type:
+                self.module.deprecate(
+                    "Unmanaged disks (VHD page blobs attached to VMs) were retired by Azure on "
+                    "2026-03-31. The 'storage_blob_name', 'storage_account_name' and "
+                    "'storage_container_name' options for the OS disk are deprecated; use "
+                    "'managed_disk_type' instead. See "
+                    "https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation",
+                    version='4.0.0',
+                    collection_name='azure.azcollection')
+
             if not self.storage_blob_name and not self.managed_disk_type:
                 self.storage_blob_name = self.name + '.vhd'
             elif self.managed_disk_type:
@@ -2252,6 +2287,28 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 count += 1
                             else:
                                 create_option = self.compute_models.DiskCreateOptionTypes.empty
+
+                                # If the caller specified no disk options at all, default to managed Standard_LRS
+                                # and set delete_option=Delete.
+                                # If the caller explicitly opted into the unmanaged-disk path
+                                # (storage_blob_name / storage_account_name / storage_container_name),
+                                # emit a deprecation warning.
+                                if (not data_disk.get('managed_disk_type')
+                                        and not data_disk.get('storage_blob_name')
+                                        and not data_disk.get('storage_account_name')
+                                        and not data_disk.get('storage_container_name')):
+                                    data_disk['managed_disk_type'] = 'Standard_LRS'
+                                    if not data_disk.get('delete_option'):
+                                        data_disk['delete_option'] = 'Delete'
+                                elif not data_disk.get('managed_disk_type'):
+                                    self.module.deprecate(
+                                        "Unmanaged disks (VHD page blobs attached to VMs) were retired "
+                                        "by Azure on 2026-03-31. The 'storage_blob_name', "
+                                        "'storage_account_name' and 'storage_container_name' suboptions "
+                                        "of 'data_disks' are deprecated; use 'managed_disk_type' instead. "
+                                        "See https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation",
+                                        version='4.0.0',
+                                        collection_name='azure.azcollection')
 
                                 if not data_disk.get('managed_disk_type'):
                                     if not data_disk.get('storage_blob_name'):

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_vm_identity.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_vm_identity.yml
@@ -194,11 +194,14 @@
     name: "{{ network_name }}-identity"
     state: absent
 
-- name: Destroy SA of the machine
-  azure.azcollection.azure_rm_storageaccount:
-    resource_group: "{{ resource_group }}-vm01"
-    name: "{{ vm_output.ansible_facts.azure_vm.tags._own_sa_ }}"
-    state: absent
+# Storage account auto-creation only happened on the legacy unmanaged-disk path,
+# which is now retired by Azure (2026-03-31). The module defaults to a managed
+# disk, so no SA is created and the _own_sa_ tag is no longer set on the VM.
+# - name: Destroy SA of the machine
+#   azure.azcollection.azure_rm_storageaccount:
+#     resource_group: "{{ resource_group }}-vm01"
+#     name: "{{ vm_output.ansible_facts.azure_vm.tags._own_sa_ }}"
+#     state: absent
 
 - name: Destroy User Managed Identities
   azure.azcollection.azure_rm_resource:


### PR DESCRIPTION
##### SUMMARY

Azure retired unmanaged disks (VHD page blobs attached to VMs) on **March 31, 2026**. The VM control plane now rejects any create/update that references a VHD blob for the OS or data disks with:
```
(BadRequest) Unmanaged disks have been retired. Please migrate to Managed Disks.
```
`azure_rm_virtualmachine` previously defaulted to the unmanaged code path whenever the caller specified neither `managed_disk_type` nor `storage_blob_name`/ `storage_account_name`. This broke every "minimal VM" task across this collection's integration tests (and every downstream user's playbook that doesn't explicitly opt into managed disks).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachine.py

##### ADDITIONAL INFORMATION
- **OS disk** — when no disk options are provided, default to managed `Standard_LRS` instead of falling back to a VHD blob.
- **Data disks** — same fallback inside the `data_disks` loop, per `data_disk` entry.
- **Deprecation warning** — when the caller explicitly opts into the unmanaged path (passes `storage_blob_name`, `storage_account_name`, or `storage_container_name` at either the OS-disk or `data_disks` level), emit a runtime `module.deprecate(..., version='4.0.0', collection_name='azure.azcollection')` pointing at the Microsoft retirement notice. 
- **DOCUMENTATION** — tagged the six affected parameters with `(Deprecated)` and added the retirement-notice URL as a bullet.


----
**Reference**
- https://learn.microsoft.com/en-us/azure/virtual-machines/unmanaged-disks-deprecation