### PR TITLE
Fix #2286: `azure_rm_virtualmachinescaleset` update `custom_data`

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1453,6 +1453,9 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     vmss_resource.single_placement_group = self.single_placement_group
                     vmss_resource.tags = self.tags
 
+                    if self.custom_data:
+                        vmss_resource.virtual_machine_profile.os_profile.custom_data = self.custom_data
+
                     if support_lb_change:
                         if self.load_balancer:
                             vmss_resource.virtual_machine_profile.network_profile.network_interface_configurations[0] \

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -489,6 +489,43 @@
       ansible.builtin.assert:
         that: results is changed
 
+    - name: Update VMSS -- change custom_data
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: testVMSS{{ rpfx }}
+        vm_size: Standard_D2s_v3
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        capacity: 1
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Automatic
+        load_balancer: testLB1
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        custom_data: "#cloud-config-updated"
+        single_placement_group: true
+        orchestration_mode: Uniform
+        image:
+          offer: 0001-com-ubuntu-server-focal
+          publisher: Canonical
+          sku: 20_04-lts
+          version: latest
+        data_disks:
+          - lun: 0
+            disk_size_gb: 64
+            caching: ReadWrite
+            managed_disk_type: Standard_LRS
+      register: results
+
+    - name: Assert that VMSS custom_data update reported changed
+      ansible.builtin.assert:
+        that: results is changed
+
     - name: Retrieve scaleset facts
       azure.azcollection.azure_rm_virtualmachinescaleset_info:
         resource_group: "{{ resource_group }}-vmss01"


### PR DESCRIPTION
##### SUMMARY
Fix #2286.

`azure_rm_virtualmachinescaleset` correctly detected a change in `custom_data` on update (diff at L1166–1170), but the update branch rebuilt `vmss_resource` from a fresh `get_vmss()` and never reassigned `os_profile.custom_data` before calling `create_or_update_vmss`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachinescaleset.py

##### ADDITIONAL INFORMATION
Reapply `self.custom_data` on the rebuilt `vmss_resource` in the update path (truthy-guarded, mirroring the existing diff check).
