### PR TITLE
Test fix: `azure_rm_recoveryservicesvault` integration test failing under Azure secure-by-default

### DIFF
--- a/tests/integration/targets/azure_rm_recoveryservicesvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_recoveryservicesvault/tasks/main.yml
@@ -161,21 +161,24 @@
           - output.properties.soft_delete_feature_state != None
           - output.properties.soft_delete_retention_period_in_days != None
 
-    - name: Turn off Azure Recovery Service Vault Config Soft Delete Settings
-      # Note: this may stop working in the future because of https://learn.microsoft.com/en-us/azure/backup/secure-by-default
-      azure.azcollection.azure_rm_recoveryservicesvaultconfig:
-        resource_group: "{{ resource_group }}-recoveryservicevault"
-        vault_name: "{{ name_rpfx }}"
-        properties:
-          enhanced_security_state: Disabled
-          soft_delete_feature_state: Disabled
-      register: output
-
-    - name: Assert that object has changed
-      ansible.builtin.assert:
-        that:
-          - output.properties.enhanced_security_state == "Disabled"
-          - output.properties.soft_delete_feature_state == "Disabled"
+    # Disabled 2026-06: Azure rejects this with
+    # BMSUserErrorDisablingSoftDeleteStateNotAllowed under the
+    # secure-by-default policy. Re-enable only if Microsoft relaxes this:
+    # https://learn.microsoft.com/en-us/azure/backup/secure-by-default
+    # - name: Turn off Azure Recovery Service Vault Config Soft Delete Settings
+    #   azure.azcollection.azure_rm_recoveryservicesvaultconfig:
+    #     resource_group: "{{ resource_group }}-recoveryservicevault"
+    #     vault_name: "{{ name_rpfx }}"
+    #     properties:
+    #       enhanced_security_state: Disabled
+    #       soft_delete_feature_state: Disabled
+    #   register: output
+    #
+    # - name: Assert that object has changed
+    #   ansible.builtin.assert:
+    #     that:
+    #       - output.properties.enhanced_security_state == "Disabled"
+    #       - output.properties.soft_delete_feature_state == "Disabled"
 
     - name: Change Azure Recovery Service Vault Config Soft Delete Settings to AlwaysON and set retention higher than default
       azure.azcollection.azure_rm_recoveryservicesvaultconfig:


### PR DESCRIPTION
##### SUMMARY
The `azure_rm_recoveryservicesvault` integration [test](https://dev.azure.com/azclitools/internal/_build/results?buildId=326025&view=logs&j=6a492487-ae7c-5c73-f12f-cea8ed54875d&t=b194a1de-dbec-5c8e-d674-583415b75331&l=2761) fails on the "Turn off Azure Recovery Service Vault Config Soft Delete Settings" task because Azure now blocks disabling soft delete / enhanced security state under the [secure-by-default](https://learn.microsoft.com/en-us/azure/backup/secure-by-default)
policy:
```
(BMSUserErrorDisablingSoftDeleteStateNotAllowed) Disabling soft delete or enhanced security state is not allowed for this vault.
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Fix Pull Request

##### COMPONENT NAME
tests/integration/targets/azure_rm_recoveryservicesvault/tasks/main.yml

