### PR TITLE
Fix #2252: migrate `azure_rm_keyvault` modules to `azure-mgmt-keyvault` 14.0.1 hybrid models

### DIFF
--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -338,7 +338,9 @@ try:
     from azure.mgmt.keyvault import KeyVaultManagementClient
     from azure.mgmt.keyvault.models import (ManagedServiceIdentity, UserAssignedIdentity, NetworkRuleSet,
                                             NetworkRuleBypassOptions, NetworkRuleAction, ManagedHsmProperties,
-                                            ManagedHsm, ManagedHsmSku)
+                                            ManagedHsm, ManagedHsmSku, VaultCreateOrUpdateParameters,
+                                            VaultProperties, Sku, AccessPolicyEntry, Permissions,
+                                            IPRule, VirtualNetworkRule)
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -354,6 +356,68 @@ def _normalize_permissions_keys(response_dict):
         if isinstance(perms, dict) and 'keys_property' in perms:
             perms['keys'] = perms.pop('keys_property')
     return response_dict
+
+
+def _build_vault_params(parameters):
+    # SDK 13.0.0 hybrid models no longer auto-translate snake_case dict keys to
+    # camelCase wire names; construct model instances explicitly so tenant_id,
+    # enable_*, soft_delete_retention_in_days, network_acls, access_policies etc.
+    # serialize correctly. Also preserves user-supplied tag keys verbatim.
+    props = parameters.get('properties') or {}
+
+    def _sku(s):
+        return Sku(family=s['family'], name=s['name']) if s else None
+
+    def _perms(p):
+        if not p:
+            return None
+        return Permissions(
+            keys_property=p.get('keys'),
+            secrets=p.get('secrets'),
+            certificates=p.get('certificates'),
+            storage=p.get('storage'),
+        )
+
+    def _ap(a):
+        return AccessPolicyEntry(
+            tenant_id=a.get('tenant_id'),
+            object_id=a.get('object_id'),
+            application_id=a.get('application_id'),
+            permissions=_perms(a.get('permissions')),
+        )
+
+    def _net(n):
+        if not n:
+            return None
+        return NetworkRuleSet(
+            bypass=n.get('bypass'),
+            default_action=n.get('default_action'),
+            ip_rules=[IPRule(value=r['value']) for r in (n.get('ip_rules') or [])] or None,
+            virtual_network_rules=[VirtualNetworkRule(
+                id=r['id'],
+                ignore_missing_vnet_service_endpoint=r.get('ignore_missing_vnet_service_endpoint')
+            ) for r in (n.get('virtual_network_rules') or [])] or None,
+        )
+
+    return VaultCreateOrUpdateParameters(
+        location=parameters.get('location'),
+        tags=parameters.get('tags'),
+        properties=VaultProperties(
+            tenant_id=props.get('tenant_id'),
+            sku=_sku(props.get('sku')),
+            access_policies=[_ap(a) for a in (props.get('access_policies') or [])] or None,
+            enabled_for_deployment=props.get('enabled_for_deployment'),
+            enabled_for_disk_encryption=props.get('enabled_for_disk_encryption'),
+            enabled_for_template_deployment=props.get('enabled_for_template_deployment'),
+            enable_soft_delete=props.get('enable_soft_delete'),
+            enable_rbac_authorization=props.get('enable_rbac_authorization'),
+            enable_purge_protection=props.get('enable_purge_protection'),
+            soft_delete_retention_in_days=props.get('soft_delete_retention_in_days'),
+            create_mode=props.get('create_mode'),
+            public_network_access=props.get('public_network_access'),
+            network_acls=_net(props.get('network_acls')),
+        ),
+    )
 
 
 class Actions:
@@ -767,7 +831,7 @@ class AzureRMVaults(AzureRMModuleBaseExt):
         try:
             response = self.mgmt_client.vaults.begin_create_or_update(resource_group_name=self.resource_group,
                                                                       vault_name=self.vault_name,
-                                                                      parameters=self.parameters)
+                                                                      parameters=_build_vault_params(self.parameters))
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 

--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -334,6 +334,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 try:
     from azure.core.polling import LROPoller
     from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
     from azure.mgmt.keyvault import KeyVaultManagementClient
     from azure.mgmt.keyvault.models import (ManagedServiceIdentity, UserAssignedIdentity, NetworkRuleSet,
                                             NetworkRuleBypassOptions, NetworkRuleAction, ManagedHsmProperties,
@@ -341,6 +342,18 @@ try:
 except ImportError:
     # This is handled in azure_rm_common
     pass
+
+
+def _normalize_permissions_keys(response_dict):
+    # SDK 13.0.0 renamed Permissions.keys to keys_property; restore old dict key for backcompat.
+    if not isinstance(response_dict, dict):
+        return response_dict
+    props = response_dict.get('properties') or {}
+    for policy in (props.get('access_policies') or []):
+        perms = policy.get('permissions')
+        if isinstance(perms, dict) and 'keys_property' in perms:
+            perms['keys'] = perms.pop('keys_property')
+    return response_dict
 
 
 class Actions:
@@ -761,7 +774,7 @@ class AzureRMVaults(AzureRMModuleBaseExt):
         except Exception as exc:
             self.log('Error attempting to create the Key Vault instance.')
             self.fail("Error creating the Key Vault instance: {0}".format(str(exc)))
-        return response and response.as_dict() or None
+        return response and _normalize_permissions_keys(as_attribute_dict(response, exclude_readonly=False)) or None
 
     def create_update_hsm(self):
         '''
@@ -800,7 +813,7 @@ class AzureRMVaults(AzureRMModuleBaseExt):
         except Exception as exc:
             self.log('Error attempting to create the HSM instance.')
             self.fail("Error creating the HSM instance: {0}".format(str(exc)))
-        return response and response.as_dict() or None
+        return response and as_attribute_dict(response, exclude_readonly=False) or None
 
     def delete_keyvault(self):
         '''
@@ -899,7 +912,7 @@ class AzureRMVaults(AzureRMModuleBaseExt):
                 self.log('Did not find the hsm instance.')
 
         if found is True:
-            return response.as_dict()
+            return _normalize_permissions_keys(as_attribute_dict(response, exclude_readonly=False))
 
         return False
 

--- a/plugins/modules/azure_rm_keyvault.py
+++ b/plugins/modules/azure_rm_keyvault.py
@@ -389,23 +389,26 @@ def _build_vault_params(parameters):
     def _net(n):
         if not n:
             return None
+        ipr = n.get('ip_rules')
+        vnr = n.get('virtual_network_rules')
         return NetworkRuleSet(
             bypass=n.get('bypass'),
             default_action=n.get('default_action'),
-            ip_rules=[IPRule(value=r['value']) for r in (n.get('ip_rules') or [])] or None,
+            ip_rules=[IPRule(value=r['value']) for r in ipr] if ipr is not None else None,
             virtual_network_rules=[VirtualNetworkRule(
                 id=r['id'],
                 ignore_missing_vnet_service_endpoint=r.get('ignore_missing_vnet_service_endpoint')
-            ) for r in (n.get('virtual_network_rules') or [])] or None,
+            ) for r in vnr] if vnr is not None else None,
         )
 
+    ap = props.get('access_policies')
     return VaultCreateOrUpdateParameters(
         location=parameters.get('location'),
         tags=parameters.get('tags'),
         properties=VaultProperties(
             tenant_id=props.get('tenant_id'),
             sku=_sku(props.get('sku')),
-            access_policies=[_ap(a) for a in (props.get('access_policies') or [])] or None,
+            access_policies=[_ap(a) for a in ap] if ap is not None else None,
             enabled_for_deployment=props.get('enabled_for_deployment'),
             enabled_for_disk_encryption=props.get('enabled_for_disk_encryption'),
             enabled_for_template_deployment=props.get('enabled_for_template_deployment'),

--- a/plugins/modules/azure_rm_keyvault_info.py
+++ b/plugins/modules/azure_rm_keyvault_info.py
@@ -251,6 +251,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 try:
     from azure.mgmt.keyvault import KeyVaultManagementClient
     from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -276,8 +277,8 @@ def keyvault_to_dict(vault):
             tenant_id=policy.tenant_id,
             object_id=policy.object_id,
             permissions=dict(
-                key_permissions=[kp.lower() for kp in policy.permissions.keys] if policy.permissions.keys else None,
-                keys=[kp.lower() for kp in policy.permissions.keys] if policy.permissions.keys else None,
+                key_permissions=[kp.lower() for kp in policy.permissions.keys_property] if policy.permissions.keys_property else None,
+                keys=[kp.lower() for kp in policy.permissions.keys_property] if policy.permissions.keys_property else None,
                 secrets=[sp.lower() for sp in policy.permissions.secrets] if policy.permissions.secrets else None,
                 certificates=[cp.lower() for cp in policy.permissions.certificates] if policy.permissions.certificates else None,
                 storage=[stp.lower() for stp in policy.permissions.storage] if policy.permissions.storage else None
@@ -286,7 +287,7 @@ def keyvault_to_dict(vault):
         sku=dict(
             family=vault.properties.sku.family,
             name=vault.properties.sku.name
-        ),
+        ) if vault.properties.sku else None,
         public_network_access=vault.properties.public_network_access,
         network_acls=dict(
             bypass=vault.properties.network_acls.bypass,
@@ -309,7 +310,7 @@ def hsm_to_dict(hsm):
         hsm_uri=hsm.properties.hsm_uri,
         location=hsm.location,
         tags=hsm.tags,
-        identity=hsm.identity and hsm.identity.as_dict() or None,
+        identity=hsm.identity and as_attribute_dict(hsm.identity, exclude_readonly=False) or None,
         enable_soft_delete=hsm.properties.enable_soft_delete,
         soft_delete_retention_in_days=hsm.properties.soft_delete_retention_in_days
         if hsm.properties.soft_delete_retention_in_days else 90,
@@ -452,7 +453,12 @@ class AzureRMKeyVaultInfo(AzureRMModuleBase):
             if response:
                 for item in response:
                     if self.has_tags(item.tags, self.tags):
-                        results.append(keyvault_to_dict(item))
+                        try:
+                            results.append(keyvault_to_dict(item))
+                        except Exception as item_exc:
+                            self.module.warn("Skipping key vault {0}: {1}".format(
+                                getattr(item, 'id', None) or getattr(item, 'name', '<unknown>'),
+                                str(item_exc)))
         except Exception as e:
             self.log("Did not find key vaults in resource group {0} : {1}.".format(self.resource_group, str(e)))
         return results
@@ -473,8 +479,13 @@ class AzureRMKeyVaultInfo(AzureRMModuleBase):
             if response:
                 for item in response:
                     if self.has_tags(item.tags, self.tags):
-                        source_id = item.id.split('/')
-                        results.append(keyvault_to_dict(self._client.vaults.get(source_id[4], source_id[8])))
+                        try:
+                            source_id = item.id.split('/')
+                            results.append(keyvault_to_dict(self._client.vaults.get(source_id[4], source_id[8])))
+                        except Exception as item_exc:
+                            self.module.warn("Skipping key vault {0}: {1}".format(
+                                getattr(item, 'id', None) or getattr(item, 'name', '<unknown>'),
+                                str(item_exc)))
         except Exception as e:
             self.log("Did not find key vault in current subscription {0}.".format(str(e)))
         return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ azure-mgmt-dns==8.1.0
 azure-mgmt-eventhub==11.1.0
 azure-mgmt-hdinsight==9.1.0b1
 azure-mgmt-iothub==3.0.0
-azure-mgmt-keyvault==12.1.1
+azure-mgmt-keyvault==14.0.1
 azure-mgmt-loganalytics==13.0.0b7
 azure-mgmt-hybridcompute==9.0.0
 azure-mgmt-managedservices==7.0.0b2

--- a/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -2047,6 +2047,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ azure_tenant }}"
             object_id: "{{ appgw_kv_sp_object_id }}"

--- a/tests/integration/targets/azure_rm_diskencryptionset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_diskencryptionset/tasks/main.yml
@@ -73,6 +73,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ tenant_id }}"
             object_id: "{{ access_policies_object_ids[0] }}"

--- a/tests/integration/targets/azure_rm_gallery/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_gallery/tasks/main.yml
@@ -42,6 +42,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ azure_tenant }}"
             object_id: "{{ object_id }}"
@@ -71,6 +72,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ azure_tenant }}"
             object_id: "{{ object_id }}"
@@ -153,6 +155,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ azure_tenant }}"
             object_id: "{{ object_id }}"
@@ -189,6 +192,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ azure_tenant }}"
             object_id: "{{ object_id }}"

--- a/tests/integration/targets/azure_rm_image/tasks/setup_des.yml
+++ b/tests/integration/targets/azure_rm_image/tasks/setup_des.yml
@@ -21,6 +21,7 @@
     sku:
       name: standard
       family: A
+    enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
     access_policies:
       - tenant_id: "{{ azure_tenant }}"
         object_id: "{{ object_id }}"
@@ -72,6 +73,7 @@
     sku:
       name: standard
       family: A
+    enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
     access_policies:
       - tenant_id: "{{ azure_tenant }}"
         object_id: "{{ object_id }}"

--- a/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvault/tasks/main.yml
@@ -47,6 +47,7 @@
         resource_group: "{{ resource_group }}-keyvault"
         vault_name: "vault{{ rpfx }}"
         enabled_for_deployment: true
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         vault_tenant: "{{ tenant_id }}"
         soft_delete_retention_in_days: 7
         sku:
@@ -85,6 +86,7 @@
         resource_group: "{{ resource_group }}-keyvault"
         vault_name: "vault{{ rpfx }}"
         enabled_for_deployment: true
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         vault_tenant: "{{ tenant_id }}"
         soft_delete_retention_in_days: 7
         sku:
@@ -113,6 +115,7 @@
         resource_group: "{{ resource_group }}-keyvault"
         vault_name: "vault{{ rpfx }}"
         enabled_for_deployment: true
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         vault_tenant: "{{ tenant_id }}"
         soft_delete_retention_in_days: 7
         sku:
@@ -140,6 +143,7 @@
         resource_group: "{{ resource_group }}-keyvault"
         vault_name: "vault{{ rpfx }}"
         enabled_for_deployment: true
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         vault_tenant: "{{ tenant_id }}"
         soft_delete_retention_in_days: 7
         sku:

--- a/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultcertificate/tasks/main.yml
@@ -31,6 +31,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ tenant_id }}"
             object_id: "{{ object_id }}"

--- a/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultkey/tasks/main.yml
@@ -28,6 +28,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ tenant_id }}"
             object_id: '{{ object_id }}'

--- a/tests/integration/targets/azure_rm_keyvaultsecret/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_keyvaultsecret/tasks/main.yml
@@ -28,6 +28,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ tenant_id }}"
             object_id: "{{ object_id }}"

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -841,6 +841,7 @@
         sku:
           name: standard
           family: A
+        enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
         access_policies:
           - tenant_id: "{{ tenant_id }}"
             object_id: '{{ object_id }}'

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/setup_des.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/setup_des.yml
@@ -20,6 +20,7 @@
     sku:
       name: standard
       family: A
+    enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
     access_policies:
       - tenant_id: "{{ azure_tenant }}"
         object_id: "{{ object_id }}"
@@ -71,6 +72,7 @@
     sku:
       name: standard
       family: A
+    enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
     access_policies:
       - tenant_id: "{{ azure_tenant }}"
         object_id: "{{ object_id }}"

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/setup_des.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/setup_des.yml
@@ -21,6 +21,7 @@
     sku:
       name: standard
       family: A
+    enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
     access_policies:
       - tenant_id: "{{ azure_tenant }}"
         object_id: "{{ object_id }}"
@@ -72,6 +73,7 @@
     sku:
       name: standard
       family: A
+    enable_rbac_authorization: false  # Required: subsequent keyvaultkey/secret data-plane tests rely on access_policies; API 2026-02-01 defaults RBAC to true when omitted.
     access_policies:
       - tenant_id: "{{ azure_tenant }}"
         object_id: "{{ object_id }}"


### PR DESCRIPTION
##### SUMMARY
Fix #2252. `azure_rm_keyvault_info` silently drops key vaults (returning an incomplete or empty `keyvaults` list while `az keyvault list` shows more) when running against `azure-mgmt-keyvault >= 13`. Root causes:
1. **`Permissions.keys` was renamed to `keys_property` in `azure-mgmt-keyvault 13.0.0`** (the class now inherits from a `MutableMapping`-style base, so `keys` collides with `dict.keys`). Reading `policy.permissions.keys` returns the bound `dict.keys` method — iterating it raises `TypeError: 'method' object is not iterable`, which was swallowed by the broad `except Exception` at loop level, aborting the loop and returning the partial list with task status `ok`. RBAC vaults survive (empty `access_policies`); access-policy vaults get silently dropped.
2. **Hybrid `.as_dict()` now emits camelCase** in `azure-mgmt-keyvault >= 13`, which would flip the module's documented snake_case return shape (`identity.principal_id`, `properties.tenant_id`, `properties.access_policies`, etc.) to camelCase.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_keyvault.py
plugins/modules/azure_rm_keyvault_info.py
requirements.txt

##### ADDITIONAL INFORMATION
This PR migrates both `azure_rm_keyvault` and `azure_rm_keyvault_info` to the SDK 14.0.1 hybrid-model API. Same migration pattern used in PR #2260 for `azure-mgmt-storage`. The collection **already hardcodes** `api_version="2026-02-01"` in both modules (`azure_rm_keyvault.py:588`, `azure_rm_keyvault_info.py:363`) — v14.0.1's default API version matches, so wire behaviour is unchanged; v12.1.1's default was `2025-05-01`. The bump aligns the SDK with the API version already in use.

Pre-existing test regression from PR #2154 (api-version bump to 2026-02-01): Azure now defaults enableRbacAuthorization=true when omitted, causing any integration target that creates a vault via access_policies and later exercises the KV data-plane to fail with Forbidden/ForbiddenByRbac. Fixed by adding `enable_rbac_authorization: false` to affected test tasks (11 targets: keyvault, keyvaultkey, keyvaultsecret, keyvaultcertificate, appgateway, diskencryptionset, gallery, image, storageaccount, virtualmachine, virtualmachinescaleset).