### PR TITLE
Feature #1849: Add specialized_image option to `azure_rm_virtualmachine` and `azure_rm_virtualmachinescaleset`

### DIFF
--- a/plugins/modules/azure_rm_galleryimageversion.py
+++ b/plugins/modules/azure_rm_galleryimageversion.py
@@ -855,6 +855,8 @@ class AzureRMGalleryImageVersions(AzureRMModuleBaseExt):
         # self.log('Deleting the GalleryImageVersion instance {0}'.format(self.))
         try:
             response = self.image_version_client.gallery_image_versions.begin_delete(self.resource_group, self.gallery_name, self.gallery_image_name, self.name)
+            if isinstance(response, LROPoller):
+                self.get_poller_result(response)
         except Exception as e:
             self.log('Error attempting to delete the GalleryImageVersion instance.')
             self.fail('Error deleting the GalleryImageVersion instance: {0}'.format(str(e)))

--- a/plugins/modules/azure_rm_virtualmachine.py
+++ b/plugins/modules/azure_rm_virtualmachine.py
@@ -79,6 +79,19 @@ options:
             - Generalizing a VM is irreversible.
         type: bool
         default: False
+    specialized_image:
+        description:
+            - Set to C(true) when the source image referenced by I(image) has an C(osState) of C(Specialized). For example a Shared Image Gallery
+              (Azure Compute Gallery) version, managed image, or attached OS disk that already has accounts, hostname and OS-level settings baked in.
+            - When C(true), the module omits the C(osProfile) block from the Virtual Machine create request. Azure rejects specialized sources
+              with C(Parameter OSProfile is not allowed with a specialized image) when C(osProfile) is present.
+            - When C(true), these options are ignored during VM creation - I(admin_username), I(admin_password), I(ssh_public_keys),
+              I(ssh_password_enabled), I(custom_data), I(short_hostname), I(windows_config) and I(linux_config).
+            - Distinct from I(generalized), which requests a power-state transition (sysprep/deprovision) on an existing VM and does not
+              describe the source image.
+        type: bool
+        default: False
+        version_added: "3.20.0"
     restarted:
         description:
             - Set to C(true) with I(state=present) to restart a running VM.
@@ -126,7 +139,9 @@ options:
     admin_username:
         description:
             - Admin username used to access the VM after it is created.
-            - Required when creating a VM.
+            - Required when creating a VM, except when I(specialized_image=true)
+              or I(swap_os_disk) is set - in those cases the OS user identities
+              are already baked into the source image or disk.
         type: str
     admin_password:
         description:
@@ -1024,6 +1039,19 @@ EXAMPLES = '''
     name: testvm002
     remove_on_absent: all_autocreated
     state: absent
+
+- name: Create a VM from a Specialized Shared Image Gallery version
+  azure_rm_virtualmachine:
+    resource_group: myResourceGroup
+    name: testvm-specialized
+    vm_size: Standard_B1s
+    specialized_image: true
+    os_type: Linux
+    managed_disk_type: StandardSSD_LRS
+    network_interfaces: testvm-specialized-nic
+    image:
+      id: >-
+        /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImage/versions/1.0.0
 '''
 
 RETURN = '''
@@ -1321,6 +1349,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             started=dict(type='bool'),
             force=dict(type='bool', default=False),
             generalized=dict(type='bool', default=False),
+            specialized_image=dict(type='bool', default=False),
             swap_os_disk=dict(
                 type='dict',
                 options=dict(
@@ -1428,6 +1457,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.restarted = None
         self.started = None
         self.generalized = None
+        self.specialized_image = None
         self.differences = None
         self.data_disks = None
         self.plan = None
@@ -2010,12 +2040,27 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     self.results['actions'].append('Created VM {0}'.format(self.name))
 
                     # Validate parameters
-                    if not self.admin_username and not self.swap_os_disk:
+                    if not self.admin_username and not self.swap_os_disk and not self.specialized_image:
                         self.fail("Parameter error: admin_username required when creating a virtual machine.")
 
                     if self.os_type == 'Linux' or self.os_type == 'linux':
-                        if disable_ssh_password and not self.ssh_public_keys and not self.swap_os_disk:
+                        if disable_ssh_password and not self.ssh_public_keys and not self.swap_os_disk and not self.specialized_image:
                             self.fail("Parameter error: ssh_public_keys required when disabling SSH password.")
+
+                    if self.specialized_image:
+                        ignored = [
+                            name for name, value in (
+                                ('admin_username', self.admin_username),
+                                ('admin_password', self.admin_password),
+                                ('ssh_public_keys', self.ssh_public_keys),
+                                ('custom_data', self.custom_data),
+                                ('short_hostname', self.short_hostname),
+                                ('windows_config', self.windows_config),
+                                ('linux_config', self.linux_config),
+                            ) if value
+                        ]
+                        if ignored:
+                            self.module.warn("specialized_image=true; the following options are ignored on create: {0}".format(", ".join(ignored)))
 
                     availability_set_resource = None
                     if self.availability_set:
@@ -2163,10 +2208,13 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                             ),
                             image_reference=image_reference
                         )
-                        os_profile = self.compute_models.OSProfile(
-                            admin_username=self.admin_username,
-                            computer_name=self.short_hostname,
-                        )
+                        if self.specialized_image:
+                            os_profile = None
+                        else:
+                            os_profile = self.compute_models.OSProfile(
+                                admin_username=self.admin_username,
+                                computer_name=self.short_hostname,
+                            )
 
                     vm_resource.storage_profile = storage_profile
                     vm_resource.os_profile = os_profile

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -103,6 +103,7 @@ options:
     admin_username:
         description:
             - Admin username used to access the host after it is created. Required when creating a VM.
+            - Not required when I(specialized_image=true) - the OS user identities are baked into the source image.
         type: str
     admin_password:
         description:
@@ -348,6 +349,20 @@ options:
             - Flexible
             - Uniform
         default: Flexible
+    specialized_image:
+        description:
+            - Set to C(true) when the source image referenced by I(image) has an C(osState) of C(Specialized). For example a Shared Image Gallery
+              (Azure Compute Gallery) version that already has accounts, hostname and OS-level settings baked in.
+            - When C(true), the module omits the C(osProfile) block from the Virtual Machine Scale Set create request. Azure rejects
+              specialized sources with C(Parameter OSProfile is not allowed with a specialized image) when C(osProfile) is present.
+            - When C(true), these options are ignored during scale set creation - I(admin_username), I(admin_password),
+              I(ssh_public_keys), I(ssh_password_enabled), I(custom_data) and I(short_hostname).
+            - For backward compatibility, the scale set is also created without C(osProfile) when I(admin_username), I(custom_data) and
+              I(ssh_public_keys) are all omitted; setting this option explicitly is preferred as it produces clearer error messages
+              and documents intent.
+        type: bool
+        default: False
+        version_added: "3.20.0"
     security_profile:
         description:
             - Specifies the Security related profile settings for the virtual machine sclaset.
@@ -582,6 +597,21 @@ EXAMPLES = '''
         disk_size_gb: 64
         caching: ReadWrite
         managed_disk_type: Standard_LRS
+
+- name: Create a scale set from a Specialized Shared Image Gallery version
+  azure.azcollection.azure_rm_virtualmachinescaleset:
+    resource_group: myResourceGroup
+    name: testvmss-specialized
+    vm_size: Standard_DS1_v2
+    capacity: 2
+    specialized_image: true
+    os_type: Linux
+    managed_disk_type: Standard_LRS
+    image:
+      id: >-
+        /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImage/versions/1.0.0
+    virtual_network_name: testvnet
+    subnet_name: testsubnet
 '''
 
 RETURN = '''
@@ -804,6 +834,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             orchestration_mode=dict(type='str',
                                     choices=['Uniform', 'Flexible'],
                                     default='Flexible',),
+            specialized_image=dict(type='bool', default=False),
             platform_fault_domain_count=dict(type='int', default=1),
             os_disk_size_gb=dict(type='int'),
             security_profile=dict(
@@ -873,6 +904,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
         self.terminate_event_timeout_minutes = None
         self.ephemeral_os_disk = None
         self.orchestration_mode = None
+        self.specialized_image = None
         self.os_disk_size_gb = None
         self.security_profile = None
         self._managed_identity = None
@@ -1164,10 +1196,11 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                         differences.append('application_security_groups')
 
                 if self.custom_data:
-                    if self.custom_data != vmss_dict['virtual_machine_profile']['os_profile'].get('custom_data'):
+                    existing_os_profile = vmss_dict['virtual_machine_profile'].get('os_profile') or {}
+                    if self.custom_data != existing_os_profile.get('custom_data'):
                         differences.append('custom_data')
                         changed = True
-                        vmss_dict['virtual_machine_profile']['os_profile']['custom_data'] = self.custom_data
+                        vmss_dict['virtual_machine_profile'].setdefault('os_profile', {})['custom_data'] = self.custom_data
 
                 if self.orchestration_mode and self.orchestration_mode != vmss_dict.get('orchestration_mode'):
                     self.fail("The orchestration_mode parameter cannot be updated!")
@@ -1279,7 +1312,19 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                                                         promotion_code=self.plan.get('promotion_code'))
 
                     os_profile = None
-                    if self.admin_username or self.custom_data or self.ssh_public_keys:
+                    if self.specialized_image:
+                        ignored = [
+                            name for name, value in (
+                                ('admin_username', self.admin_username),
+                                ('admin_password', self.admin_password),
+                                ('ssh_public_keys', self.ssh_public_keys),
+                                ('custom_data', self.custom_data),
+                                ('short_hostname', self.short_hostname),
+                            ) if value
+                        ]
+                        if ignored:
+                            self.module.warn("specialized_image=true; the following options are ignored on create: {0}".format(", ".join(ignored)))
+                    elif self.admin_username or self.custom_data or self.ssh_public_keys:
                         os_profile = self.compute_models.VirtualMachineScaleSetOSProfile(
                             admin_username=self.admin_username,
                             computer_name_prefix=self.short_hostname,
@@ -1363,7 +1408,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     if self.terminate_event_timeout_minutes:
                         vmss_resource.virtual_machine_profile.scheduled_events_profile = self.gen_scheduled_event_profile()
 
-                    if self.admin_password:
+                    if self.admin_password and vmss_resource.virtual_machine_profile.os_profile is not None:
                         vmss_resource.virtual_machine_profile.os_profile.admin_password = self.admin_password
 
                     if (self.os_type == 'Linux' or self.os_type == 'linux') and os_profile:
@@ -1371,7 +1416,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                             disable_password_authentication=disable_ssh_password
                         )
 
-                    if self.ssh_public_keys:
+                    if self.ssh_public_keys and vmss_resource.virtual_machine_profile.os_profile is not None \
+                            and vmss_resource.virtual_machine_profile.os_profile.linux_configuration is not None:
                         ssh_config = self.compute_models.SshConfiguration()
                         ssh_config.public_keys = \
                             [self.compute_models.SshPublicKey(path=key['path'], key_data=key['key_data']) for key in self.ssh_public_keys]
@@ -1453,7 +1499,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     vmss_resource.single_placement_group = self.single_placement_group
                     vmss_resource.tags = self.tags
 
-                    if self.custom_data:
+                    if self.custom_data and vmss_resource.virtual_machine_profile.os_profile is not None:
                         vmss_resource.virtual_machine_profile.os_profile.custom_data = self.custom_data
 
                     if support_lb_change:

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1287,9 +1287,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     if self.subnet_name:
                         subnet = self.get_subnet(self.virtual_network_name, self.subnet_name)
 
-                    if not self.short_hostname:
-                        self.short_hostname = self.name
-
                     if not image_reference:
                         self.fail("Parameter error: an image is required when creating a virtual machine.")
 
@@ -1325,6 +1322,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                         if ignored:
                             self.module.warn("specialized_image=true; the following options are ignored on create: {0}".format(", ".join(ignored)))
                     elif self.admin_username or self.custom_data or self.ssh_public_keys:
+                        if not self.short_hostname:
+                            self.short_hostname = self.name
                         os_profile = self.compute_models.VirtualMachineScaleSetOSProfile(
                             admin_username=self.admin_username,
                             computer_name_prefix=self.short_hostname,

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1278,7 +1278,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     self.results['actions'].append('Created VMSS {0}'.format(self.name))
 
                     if self.os_type == 'Linux' or self.os_type == 'linux':
-                        if disable_ssh_password and not self.ssh_public_keys:
+                        if disable_ssh_password and not self.ssh_public_keys and not self.specialized_image:
                             self.fail("Parameter error: ssh_public_keys required when disabling SSH password.")
 
                     if not self.virtual_network_name:

--- a/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/inventory.yml
@@ -60,6 +60,10 @@ all:
       network: 10.42.10.0/24
       subnet: 10.42.10.0/28
 
+    azure_test_specialized_image:
+      network: 10.42.11.0/24
+      subnet: 10.42.11.0/28
+
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
@@ -78,13 +82,13 @@ all:
     des_name: "{{ 'des' ~ uid_short }}"
 
     ssh_keys:
-      - path: '/home/chouseknecht/.ssh/authorized_keys'
+      - path: "/home/chouseknecht/.ssh/authorized_keys"
         key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1igsIlcmTa/yfsJnTtnrEX7PP/a01gwbXcig6JOKyrUmJB8E6c/wtZwP115VSyDRTO6TEL/sBFUpkSw01zM8ydNATErh8meBlAlbnDq5NLhDXnMizgG0VNn0iLc/WplFTqkefsHXa8NtIxAtyEVIj/fKbK3XfBOdEpE3+MJYNtGlWyaod28W+5qmQPZDQys+YnE4OjSwN7D3g85/7dtLFvDH+lEC4ooJOaxVFr9VSMXUIkaRF6oI+R1Zu803LFSCTb4BfFOYOHPuQ/rEMP0KuUzggvP+TEBY14PEA2FoHOn+oRsT0ZR2+loGRaxSVqCQKaEHbNbkm+6Rllx2NQRO0BJxCSKRU1iifInLPxmSc4gvsHCKMAWy/tGkmKHPWIfN8hvwyDMK5MNBp/SJ1pVx4xuFDQjVWNbll0yk2+72uJgtFHHwEPK9QsOz45gX85vS3yhYCKrscS/W9h2l36SWwQXuGy4fXotE7esPsvNGAzBndHX1O8RMPg47qJXz059RyoGforoa9TnzIs3hIv+ts7ESx3OEq3HNk0FJ+wDka7IM7WQpGrVToJ0vfDy9Q46nw54vv5Zc/u4OZF3F5twHmyf3rLYKXRDuCvZQKT2iWQKVX6j63bq6orA5hwl22zndxWZNtOwtq8Sd0Ns0K/Fo/ggYDDGBtr68DwhA+MrxrHw== chouseknecht@ansible.com"
 
     image:
       offer: CentOS
       publisher: OpenLogic
-      sku: '7.1'
+      sku: "7.1"
       version: latest
 
     image_paid:

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_specialized_image.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_specialized_image.yml
@@ -42,7 +42,7 @@
     location: eastus
     os_type: linux
     os_state: specialized
-    hyper_v_generation: V1
+    hypervgeneration: V1
     identifier:
       publisher: OrgName
       offer: TestOffer
@@ -72,7 +72,7 @@
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ resource_group }}-vm01"
     name: "{{ vm_name }}-negspec"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     os_type: Linux
@@ -87,7 +87,7 @@
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ resource_group }}-vm01"
     name: "{{ vm_name }}-spec"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     specialized_image: true
@@ -106,7 +106,7 @@
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ resource_group }}-vm01"
     name: "{{ vm_name }}-spec"
-    vm_size: Standard_DS1_v2
+    vm_size: Standard_D2s_v3
     virtual_network: "{{ network_name }}"
     managed_disk_type: StandardSSD_LRS
     specialized_image: true

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_specialized_image.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_specialized_image.yml
@@ -48,6 +48,12 @@
       offer: TestOffer
       sku: TestSku
 
+- name: Get source VM info
+  azure.azcollection.azure_rm_virtualmachine_info:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+  register: srcvm_info
+
 - name: Create gallery image version from the source VM (specialized)
   azure.azcollection.azure_rm_galleryimageversion:
     resource_group: "{{ resource_group }}-vm01"
@@ -55,13 +61,13 @@
     gallery_image_name: "imgdef{{ uid_short }}"
     name: 1.0.0
     location: eastus
+    storage_profile:
+      source_image:
+        virtual_machine_id: "{{ srcvm_info.vms[0].id }}"
     publishing_profile:
       target_regions:
         - name: eastus
           regional_replica_count: 1
-      managed_image:
-        resource_group: "{{ resource_group }}-vm01"
-        name: "{{ vm_name }}-src"
   register: sig_specialized
 
 - name: Set specialized SIG version ID

--- a/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_specialized_image.yml
+++ b/tests/integration/targets/azure_rm_virtualmachine/tasks/azure_test_specialized_image.yml
@@ -1,0 +1,154 @@
+- name: Set variables
+  ansible.builtin.include_tasks: setup.yml
+
+# Create a source VM to capture (its OS keeps its baked-in accounts; register it as a Specialized SIG version below)
+- name: Create source VM (source of the specialized image)
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+    admin_username: testuser
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/testuser/.ssh/authorized_keys
+        key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+    vm_size: Standard_D2s_v3
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    image:
+      offer: 0001-com-ubuntu-server-focal
+      publisher: Canonical
+      sku: 20_04-lts
+      version: latest
+  register: source_vm
+
+- name: Assert source VM created
+  ansible.builtin.assert:
+    that:
+      - source_vm.changed
+
+# Publish the specialized SIG image (osState=Specialized) from the running source VM. Note we do NOT generalize the source VM here.
+- name: Create Compute Gallery
+  azure.azcollection.azure_rm_gallery:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "gal{{ uid_short }}"
+    location: eastus
+    description: Specialized image gallery for integration tests
+
+- name: Create Specialized gallery image definition
+  azure.azcollection.azure_rm_galleryimage:
+    resource_group: "{{ resource_group }}-vm01"
+    gallery_name: "gal{{ uid_short }}"
+    name: "imgdef{{ uid_short }}"
+    location: eastus
+    os_type: linux
+    os_state: specialized
+    hyper_v_generation: V1
+    identifier:
+      publisher: OrgName
+      offer: TestOffer
+      sku: TestSku
+
+- name: Create gallery image version from the source VM (specialized)
+  azure.azcollection.azure_rm_galleryimageversion:
+    resource_group: "{{ resource_group }}-vm01"
+    gallery_name: "gal{{ uid_short }}"
+    gallery_image_name: "imgdef{{ uid_short }}"
+    name: 1.0.0
+    location: eastus
+    publishing_profile:
+      target_regions:
+        - name: eastus
+          regional_replica_count: 1
+      managed_image:
+        resource_group: "{{ resource_group }}-vm01"
+        name: "{{ vm_name }}-src"
+  register: sig_specialized
+
+- name: Set specialized SIG version ID
+  ansible.builtin.set_fact:
+    sig_specialized_version_id: "{{ sig_specialized.id }}"
+
+- name: Create VM from specialized SIG version WITHOUT specialized_image (expect failure)
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-negspec"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    os_type: Linux
+    image:
+      id: "{{ sig_specialized_version_id }}"
+  register: negspec
+  failed_when: >
+    negspec is not failed
+    or 'admin_username required' not in (negspec.msg | default(''))
+
+- name: Create VM from specialized SIG version (specialized_image=true)
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-spec"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    specialized_image: true
+    os_type: Linux
+    image:
+      id: "{{ sig_specialized_version_id }}"
+  register: specvm
+
+- name: Assert specialized VM created without osProfile
+  ansible.builtin.assert:
+    that:
+      - specvm.changed
+      - specvm.ansible_facts.azure_vm.properties.osProfile is not defined
+
+- name: Idempotency check - re-run specialized create
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-spec"
+    vm_size: Standard_DS1_v2
+    virtual_network: "{{ network_name }}"
+    managed_disk_type: StandardSSD_LRS
+    specialized_image: true
+    os_type: Linux
+    image:
+      id: "{{ sig_specialized_version_id }}"
+  register: specvm_idem
+
+- name: Assert specialized VM re-create is idempotent
+  ansible.builtin.assert:
+    that:
+      - not specvm_idem.changed
+
+- name: Delete specialized VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-spec"
+    state: absent
+
+- name: Delete source VM
+  azure.azcollection.azure_rm_virtualmachine:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "{{ vm_name }}-src"
+    state: absent
+
+- name: Delete gallery image version
+  azure.azcollection.azure_rm_galleryimageversion:
+    resource_group: "{{ resource_group }}-vm01"
+    gallery_name: "gal{{ uid_short }}"
+    gallery_image_name: "imgdef{{ uid_short }}"
+    name: 1.0.0
+    state: absent
+
+- name: Delete gallery image definition
+  azure.azcollection.azure_rm_galleryimage:
+    resource_group: "{{ resource_group }}-vm01"
+    gallery_name: "gal{{ uid_short }}"
+    name: "imgdef{{ uid_short }}"
+    state: absent
+
+- name: Delete gallery
+  azure.azcollection.azure_rm_gallery:
+    resource_group: "{{ resource_group }}-vm01"
+    name: "gal{{ uid_short }}"
+    state: absent

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1249,6 +1249,7 @@
         vm_size: Standard_D2s_v3
         capacity: 1
         specialized_image: true
+        ssh_password_enabled: false
         os_type: Linux
         virtual_network_name: VMSStestVnet
         subnet_name: VMSStestSubnet

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1220,6 +1220,12 @@
           offer: TestOffer
           sku: TestSku
 
+    - name: Get source VM info
+      azure.azcollection.azure_rm_virtualmachine_info:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "srcvm{{ rpfx }}"
+      register: srcvm_info
+
     - name: Create gallery image version from the source VM (specialized)
       azure.azcollection.azure_rm_galleryimageversion:
         resource_group: "{{ resource_group }}-vmss01"
@@ -1227,13 +1233,13 @@
         gallery_image_name: "imgdef{{ rpfx }}"
         name: 1.0.0
         location: "{{ location }}"
+        storage_profile:
+          source_image:
+            virtual_machine_id: "{{ srcvm_info.vms[0].id }}"
         publishing_profile:
           target_regions:
             - name: "{{ location }}"
               regional_replica_count: 1
-          managed_image:
-            resource_group: "{{ resource_group }}-vmss01"
-            name: "srcvm{{ rpfx }}"
       register: vmss_sig_specialized
 
     - name: Create VMSS from specialized SIG version (specialized_image=true)

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1289,6 +1289,31 @@
         that:
           - not specvmss_idem.changed
 
+    - name: Scale specialized VMSS to capacity 2
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "specvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        capacity: 2
+        specialized_image: true
+        os_type: Linux
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        managed_disk_type: Standard_LRS
+        upgrade_policy: Manual
+        orchestration_mode: Uniform
+        single_placement_group: true
+        image:
+          id: "{{ vmss_sig_specialized.id }}"
+      register: specvmss_scale
+
+    - name: Assert specialized VMSS scaled without touching osProfile
+      ansible.builtin.assert:
+        that:
+          - specvmss_scale.changed
+          - specvmss_scale.ansible_facts.azure_vmss.sku.capacity == 2
+          - specvmss_scale.ansible_facts.azure_vmss.properties.virtualMachineProfile.osProfile is not defined
+
     - name: Delete specialized VMSS
       azure.azcollection.azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}-vmss01"

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -22,9 +22,9 @@
     - name: Create user managed identities
       ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
       vars:
-        managed_identity_test_unique: 'vmss'
-        managed_identity_unique: '1'
-        managed_identity_action: 'create'
+        managed_identity_test_unique: "vmss"
+        managed_identity_unique: "1"
+        managed_identity_action: "create"
         managed_identity_location: "{{ location }}"
         resource_group: "{{ new_resource_group }}"
 
@@ -598,7 +598,7 @@
         type: CustomScript
         type_handler_version: 2.0
         auto_upgrade_minor_version: true
-        settings: {"commandToExecute": "sudo apt-get -y install apache2"}
+        settings: { "commandToExecute": "sudo apt-get -y install apache2" }
       register: results
 
     - name: Assert that something was changed
@@ -614,7 +614,7 @@
         type: CustomScript
         type_handler_version: 2.0
         auto_upgrade_minor_version: true
-        settings: {"commandToExecute": "sudo apt-get -y install apache2"}
+        settings: { "commandToExecute": "sudo apt-get -y install apache2" }
       register: results
 
     - name: Assert that nothing was changed
@@ -770,9 +770,9 @@
     - name: Assert that VMSS ran
       ansible.builtin.assert:
         that:
-          - 'results is changed'
-          - 'results.ansible_facts.azure_vmss.virtual_machine_profile.network_profile.network_interface_configurations[0].enable_accelerated_networking == true'
-          - 'results.ansible_facts.azure_vmss.virtual_machine_profile.network_profile.network_interface_configurations[0].network_security_group != {}'
+          - "results is changed"
+          - "results.ansible_facts.azure_vmss.virtual_machine_profile.network_profile.network_interface_configurations[0].enable_accelerated_networking == true"
+          - "results.ansible_facts.azure_vmss.virtual_machine_profile.network_profile.network_interface_configurations[0].network_security_group != {}"
 
     - name: Create VMSS with security group in same resource group, with accelerated networking.
       azure.azcollection.azure_rm_virtualmachinescaleset:
@@ -1004,7 +1004,7 @@
       azure.azcollection.azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}-vmss01"
         name: testVMSS{{ rpfx }}des
-        vm_size: Standard_D4s_v3  # upgrade
+        vm_size: Standard_D4s_v3 # upgrade
         virtual_network_name: VMSStestVnet
         subnet_name: VMSStestSubnet
         admin_username: testuser
@@ -1168,12 +1168,146 @@
       register: fail_missing_custom_image_dict
       failed_when: fail_missing_custom_image_dict.msg != "Error could not find image with name invalid-image"
 
+    # Specialized image scenario ------------------------------------------
+    - name: Create source VM for specialized SIG
+      azure.azcollection.azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "srcvm{{ rpfx }}"
+        admin_username: testuser
+        admin_password: "Password1234!"
+        vm_size: Standard_DS1_v2
+        virtual_network: VMSStestVnet
+        managed_disk_type: StandardSSD_LRS
+        image:
+          offer: 0001-com-ubuntu-server-focal
+          publisher: Canonical
+          sku: 20_04-lts
+          version: latest
+
+    - name: Create Compute Gallery
+      azure.azcollection.azure_rm_gallery:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "gal{{ rpfx }}"
+        location: "{{ location }}"
+        description: Specialized image gallery for VMSS integration tests
+
+    - name: Create Specialized gallery image definition
+      azure.azcollection.azure_rm_galleryimage:
+        resource_group: "{{ resource_group }}-vmss01"
+        gallery_name: "gal{{ rpfx }}"
+        name: "imgdef{{ rpfx }}"
+        location: "{{ location }}"
+        os_type: linux
+        os_state: specialized
+        hyper_v_generation: V1
+        identifier:
+          publisher: OrgName
+          offer: TestOffer
+          sku: TestSku
+
+    - name: Create gallery image version from the source VM (specialized)
+      azure.azcollection.azure_rm_galleryimageversion:
+        resource_group: "{{ resource_group }}-vmss01"
+        gallery_name: "gal{{ rpfx }}"
+        gallery_image_name: "imgdef{{ rpfx }}"
+        name: 1.0.0
+        location: "{{ location }}"
+        publishing_profile:
+          target_regions:
+            - name: "{{ location }}"
+              regional_replica_count: 1
+          managed_image:
+            resource_group: "{{ resource_group }}-vmss01"
+            name: "srcvm{{ rpfx }}"
+      register: vmss_sig_specialized
+
+    - name: Create VMSS from specialized SIG version (specialized_image=true)
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "specvmss{{ rpfx }}"
+        vm_size: Standard_DS1_v2
+        capacity: 1
+        specialized_image: true
+        os_type: Linux
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        managed_disk_type: Standard_LRS
+        upgrade_policy: Manual
+        orchestration_mode: Uniform
+        single_placement_group: true
+        image:
+          id: "{{ vmss_sig_specialized.id }}"
+      register: specvmss
+
+    - name: Assert specialized VMSS created without osProfile
+      ansible.builtin.assert:
+        that:
+          - specvmss.changed
+          - specvmss.ansible_facts.azure_vmss.properties.virtualMachineProfile.osProfile is not defined
+
+    - name: Idempotency check - re-run specialized VMSS create
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "specvmss{{ rpfx }}"
+        vm_size: Standard_DS1_v2
+        capacity: 1
+        specialized_image: true
+        os_type: Linux
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        managed_disk_type: Standard_LRS
+        upgrade_policy: Manual
+        orchestration_mode: Uniform
+        single_placement_group: true
+        image:
+          id: "{{ vmss_sig_specialized.id }}"
+      register: specvmss_idem
+
+    - name: Assert specialized VMSS re-create is idempotent
+      ansible.builtin.assert:
+        that:
+          - not specvmss_idem.changed
+
+    - name: Delete specialized VMSS
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "specvmss{{ rpfx }}"
+        state: absent
+
+    - name: Delete gallery image version
+      azure.azcollection.azure_rm_galleryimageversion:
+        resource_group: "{{ resource_group }}-vmss01"
+        gallery_name: "gal{{ rpfx }}"
+        gallery_image_name: "imgdef{{ rpfx }}"
+        name: 1.0.0
+        state: absent
+
+    - name: Delete gallery image definition
+      azure.azcollection.azure_rm_galleryimage:
+        resource_group: "{{ resource_group }}-vmss01"
+        gallery_name: "gal{{ rpfx }}"
+        name: "imgdef{{ rpfx }}"
+        state: absent
+
+    - name: Delete gallery
+      azure.azcollection.azure_rm_gallery:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "gal{{ rpfx }}"
+        state: absent
+
+    - name: Delete source VM
+      azure.azcollection.azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "srcvm{{ rpfx }}"
+        state: absent
+    # ---------------------------------------------------------------------
+
     - name: Delete user managed identities
       ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"
       vars:
-        managed_identity_test_unique: 'vmss'
-        managed_identity_unique: '1'
-        managed_identity_action: 'delete'
+        managed_identity_test_unique: "vmss"
+        managed_identity_unique: "1"
+        managed_identity_action: "delete"
         managed_identity_location: "{{ location }}"
         resource_group: "{{ new_resource_group }}"
 

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1190,7 +1190,7 @@
         name: "srcvm{{ rpfx }}"
         admin_username: testuser
         admin_password: "Password1234!"
-        vm_size: Standard_DS1_v2
+        vm_size: Standard_D2s_v3
         virtual_network: VMSStestVnet
         managed_disk_type: StandardSSD_LRS
         image:
@@ -1214,7 +1214,7 @@
         location: "{{ location }}"
         os_type: linux
         os_state: specialized
-        hyper_v_generation: V1
+        hypervgeneration: V1
         identifier:
           publisher: OrgName
           offer: TestOffer
@@ -1240,7 +1240,7 @@
       azure.azcollection.azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}-vmss01"
         name: "specvmss{{ rpfx }}"
-        vm_size: Standard_DS1_v2
+        vm_size: Standard_D2s_v3
         capacity: 1
         specialized_image: true
         os_type: Linux
@@ -1264,7 +1264,7 @@
       azure.azcollection.azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}-vmss01"
         name: "specvmss{{ rpfx }}"
-        vm_size: Standard_DS1_v2
+        vm_size: Standard_D2s_v3
         capacity: 1
         specialized_image: true
         os_type: Linux

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1169,6 +1169,21 @@
       failed_when: fail_missing_custom_image_dict.msg != "Error could not find image with name invalid-image"
 
     # Specialized image scenario ------------------------------------------
+    # NOTE: the earlier "Delete virtual network" step removed VMSStestVnet
+    # for cleanup, so we recreate it here before the source VM step.
+    - name: Recreate virtual network for specialized scenario
+      azure.azcollection.azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: VMSStestVnet
+        address_prefixes: "10.0.0.0/16"
+
+    - name: Recreate subnet for specialized scenario
+      azure.azcollection.azure_rm_subnet:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: VMSStestSubnet
+        address_prefix: "10.0.1.0/24"
+        virtual_network: VMSStestVnet
+
     - name: Create source VM for specialized SIG
       azure.azcollection.azure_rm_virtualmachine:
         resource_group: "{{ resource_group }}-vmss01"


### PR DESCRIPTION
##### SUMMARY
Fix #1849.

Adds a new `specialized_image` (bool, default `false`) option on `azure_rm_virtualmachine` and `azure_rm_virtualmachinescaleset` to support creating VMs / scale sets from **Specialized** image sources (Shared Image Gallery / Azure Compute Gallery versions with `osState=Specialized`, managed images, or attached specialized OS disks).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachine.py
plugins/modules/azure_rm_virtualmachinescaleset.py

##### ADDITIONAL INFORMATION
- `plugins/modules/azure_rm_virtualmachine.py`
  - New `specialized_image` option (doc + argspec + `__init__`).
  - Relaxed pre-flight validation for `admin_username` and `ssh_public_keys`.
  - Consolidated warning for ignored params.
  - Guarded `OSProfile()` construction (set to `None` when `specialized_image=true`).
  - New EXAMPLES entry showing creation from a SIG version.
  - Updated `admin_username` doc to reflect it is not required under `specialized_image=true` or `swap_os_disk`.
- `plugins/modules/azure_rm_virtualmachinescaleset.py`
  - New `specialized_image` option (doc + argspec + `__init__`).
  - Explicit `if specialized_image:` branch in `OSProfile` assembly (with warn), `elif` preserves implicit legacy behavior.
  - `.get()` chain hardening on 4 update paths (custom_data diff, admin_password write, ssh_public_keys write, custom_data write).
  - New EXAMPLES entry showing creation from a specialized SIG version.