### PR TITLE
Replace deprecated ansible.module_utils._text import

### DIFF
--- a/plugins/inventory/azure_kql.py
+++ b/plugins/inventory/azure_kql.py
@@ -107,7 +107,7 @@ import re
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.errors import AnsibleError
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from os import environ
 

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -159,7 +159,7 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from ansible.errors import AnsibleParserError, AnsibleError
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils._text import to_native, to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 from ansible.utils.display import Display
 from itertools import chain
 from os import environ

--- a/plugins/lookup/azure_service_principal_attribute.py
+++ b/plugins/lookup/azure_service_principal_attribute.py
@@ -60,7 +60,7 @@ _raw:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     import asyncio

--- a/plugins/modules/azure_rm_autoscale.py
+++ b/plugins/modules/azure_rm_autoscale.py
@@ -446,7 +446,7 @@ state:
 '''  # NOQA
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import timedelta
 
 try:

--- a/plugins/modules/azure_rm_autoscale_info.py
+++ b/plugins/modules/azure_rm_autoscale_info.py
@@ -129,7 +129,7 @@ autoscales:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # duplicated in azure_rm_autoscale

--- a/plugins/modules/azure_rm_dnszone.py
+++ b/plugins/modules/azure_rm_dnszone.py
@@ -119,7 +119,7 @@ state:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_dnszone_info.py
+++ b/plugins/modules/azure_rm_dnszone_info.py
@@ -127,7 +127,7 @@ dnszones:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -448,7 +448,7 @@ changed:
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import format_resource_id
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 try:
     from azure.core.exceptions import ResourceNotFoundError
     from azure.mgmt.core.tools import parse_resource_id

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -487,7 +487,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
                                                                                          normalize_location_name,
                                                                                          format_resource_id
                                                                                          )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def subnet_to_dict(subnet):

--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -260,7 +260,7 @@ state:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_roledefinition.py
+++ b/plugins/modules/azure_rm_roledefinition.py
@@ -104,7 +104,7 @@ id:
 '''
 
 import uuid
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase

--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -538,7 +538,7 @@ except ImportError:
     pass
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def validate_rule(self, rule, rule_type=None):

--- a/plugins/modules/azure_rm_servicebus.py
+++ b/plugins/modules/azure_rm_servicebus.py
@@ -118,7 +118,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_servicebus_info.py
+++ b/plugins/modules/azure_rm_servicebus_info.py
@@ -406,7 +406,7 @@ except Exception:
     # This is handled in azure_rm_common
     pass
 from ansible.module_utils.common.dict_transformations import _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 duration_spec_map = dict(

--- a/plugins/modules/azure_rm_servicebusqueue.py
+++ b/plugins/modules/azure_rm_servicebusqueue.py
@@ -150,7 +150,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_servicebustopic.py
+++ b/plugins/modules/azure_rm_servicebustopic.py
@@ -128,7 +128,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_servicebustopicsubscription.py
+++ b/plugins/modules/azure_rm_servicebustopicsubscription.py
@@ -139,7 +139,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -917,7 +917,7 @@ import copy
 import time
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AZURE_SUCCESS_STATE
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import env_fallback
 
 try:

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -647,7 +647,7 @@ storageaccounts:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-    from ansible.module_utils._text import to_native
+    from ansible.module_utils.common.text.converters import to_native
     from ansible.module_utils.basic import env_fallback
     from azure.core.serialization import as_attribute_dict
 except ImportError:


### PR DESCRIPTION
## Summary
- `ansible.module_utils._text` is deprecated and scheduled for removal in ansible-core 2.24. Every module in this collection that still imports from it (18 files) emits a `DeprecationWarning` on each task invocation, e.g.:
  ```
  [DEPRECATION WARNING]: Importing 'to_native' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
  ```
- Swaps the import path to `ansible.module_utils.common.text.converters`, which re-exports the same `to_native`/`to_bytes`/`to_text` helpers and is the documented replacement location.
- No behavioral change — same functions, same signatures, just the modern import path.

## Files changed
plugins/inventory/azure_kql.py, plugins/inventory/azure_rm.py, plugins/lookup/azure_service_principal_attribute.py, plugins/modules/azure_rm_autoscale.py, azure_rm_autoscale_info.py, azure_rm_dnszone.py, azure_rm_dnszone_info.py, azure_rm_loadbalancer.py, azure_rm_networkinterface.py, azure_rm_publicipaddress.py, azure_rm_roledefinition.py, azure_rm_securitygroup.py, azure_rm_servicebus.py, azure_rm_servicebus_info.py, azure_rm_servicebusqueue.py, azure_rm_servicebustopic.py, azure_rm_servicebustopicsubscription.py, azure_rm_storageaccount.py, azure_rm_storageaccount_info.py

## Test plan
- [x] `grep -rn "ansible.module_utils._text"` across `plugins/` returns no remaining matches
- [ ] Maintainers to run collection sanity/integration tests (`ansible-test sanity`) per CONTRIBUTING.md