### PR TITLE
Fix #2297: add `smb_oauth_enabled` support to `azure_rm_storageaccount`

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1161,6 +1161,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         self.allow_cross_tenant_replication = None
         self.default_to_o_auth_authentication = None
         self.smb_oauth_enabled = None
+        self._existing_azure_files_auth = None
         self._managed_identity = None
         self.identity = None
         self.update_identity = False
@@ -1372,6 +1373,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         afa = getattr(account_obj, 'azure_files_identity_based_authentication', None)
         smb = getattr(afa, 'smb_o_auth_settings', None) if afa else None
         account_dict['smb_oauth_enabled'] = bool(getattr(smb, 'is_smb_o_auth_enabled', False)) if smb else False
+        self._existing_azure_files_auth = afa
 
         return account_dict
 
@@ -1668,7 +1670,8 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             if not self.check_mode:
                 try:
                     parameters = self.storage_models.StorageAccountUpdateParameters(
-                        azure_files_identity_based_authentication=self._build_azure_files_identity_auth_payload())
+                        azure_files_identity_based_authentication=self._build_azure_files_identity_auth_payload(
+                            existing_afa=self._existing_azure_files_auth))
                     self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
                 except Exception as exc:
                     self.fail("Failed to update smb_oauth_enabled: {0}".format(str(exc)))
@@ -1767,7 +1770,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             immutability_policy=self.storage_models.AccountImmutabilityPolicyProperties(**policy) if policy else None,
         )
 
-    def _build_azure_files_identity_auth_payload(self):
+    def _build_azure_files_identity_auth_payload(self, existing_afa=None):
         '''
         Build an AzureFilesIdentityBasedAuthentication SDK model that carries the
         smb_oauth_enabled toggle. Returns None when the caller did not set the
@@ -1775,11 +1778,20 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         '''
         if self.smb_oauth_enabled is None:
             return None
+
+        smb_settings = self.storage_models.SmbOAuthSettings(
+            is_smb_o_auth_enabled=self.smb_oauth_enabled,
+        )
+
+        directory_service_options = getattr(existing_afa, 'directory_service_options', None) or "None"
+        active_directory_properties = getattr(existing_afa, 'active_directory_properties', None)
+        default_share_permission = getattr(existing_afa, 'default_share_permission', None)
+
         return self.storage_models.AzureFilesIdentityBasedAuthentication(
-            directory_service_options="None",
-            smb_o_auth_settings=self.storage_models.SmbOAuthSettings(
-                is_smb_o_auth_enabled=self.smb_oauth_enabled,
-            ),
+            directory_service_options=directory_service_options,
+            active_directory_properties=active_directory_properties,
+            default_share_permission=default_share_permission,
+            smb_o_auth_settings=smb_settings,
         )
 
     def create_account(self):

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -308,7 +308,6 @@ options:
     smb_oauth_enabled:
         description:
             - Whether managed identities can access Azure Files SMB shares using OAuth.
-            - Corresponds to C(properties.azureFilesIdentityBasedAuthentication.smbOAuthSettings.isSmbOAuthEnabled) in the REST API.
             - When unset, the value on Azure is left unchanged (the service default is C(false) for new accounts).
         type: bool
     encryption:

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -305,6 +305,12 @@ options:
             - A boolean flag which indicates whether the default authentication is OAuth or not.
             - The default interpretation is false for this property.
         type: bool
+    smb_oauth_enabled:
+        description:
+            - Whether managed identities can access Azure Files SMB shares using OAuth.
+            - Corresponds to C(properties.azureFilesIdentityBasedAuthentication.smbOAuthSettings.isSmbOAuthEnabled) in the REST API.
+            - When unset, the value on Azure is left unchanged (the service default is C(false) for new accounts).
+        type: bool
     encryption:
         description:
             - The encryption settings on the storage account.
@@ -558,6 +564,14 @@ EXAMPLES = '''
       default_action: Deny
       bypass: AzureServices
       resource_access_rules: []
+
+- name: Create a StorageV2 account with SMB OAuth enabled for Managed Identity access
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: mystorageacct
+    account_type: Standard_LRS
+    kind: StorageV2
+    smb_oauth_enabled: true
 '''
 
 RETURN = '''
@@ -589,6 +603,12 @@ state:
             description:
                 - A boolean flag which indicates whether the default authentication is OAuth or not.
                 - The default interpretation is false for this property.
+            type: bool
+            returned: always
+            sample: true
+        smb_oauth_enabled:
+            description:
+                - Whether managed identities can access Azure Files SMB shares using OAuth.
             type: bool
             returned: always
             sample: true
@@ -1012,6 +1032,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             allow_shared_key_access=dict(type='bool'),
             allow_cross_tenant_replication=dict(type='bool'),
             default_to_o_auth_authentication=dict(type='bool'),
+            smb_oauth_enabled=dict(type='bool'),
             network_acls=dict(
                 type='dict',
                 options=dict(
@@ -1140,6 +1161,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         self.allow_shared_key_access = None
         self.allow_cross_tenant_replication = None
         self.default_to_o_auth_authentication = None
+        self.smb_oauth_enabled = None
         self._managed_identity = None
         self.identity = None
         self.update_identity = False
@@ -1347,6 +1369,10 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         account_dict['encryption'] = as_attribute_dict(account_obj.encryption) if account_obj.encryption else dict()
 
         account_dict['identity'] = as_attribute_dict(account_obj.identity) if account_obj.identity else dict()
+
+        afa = getattr(account_obj, 'azure_files_identity_based_authentication', None)
+        smb = getattr(afa, 'smb_o_auth_settings', None) if afa else None
+        account_dict['smb_oauth_enabled'] = bool(getattr(smb, 'is_smb_o_auth_enabled', False)) if smb else False
 
         return account_dict
 
@@ -1636,6 +1662,18 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 except Exception as exc:
                     self.fail("Failed to update large_file_shares_state: {0}".format(str(exc)))
 
+        if self.smb_oauth_enabled is not None and \
+           self.smb_oauth_enabled != self.account_dict.get('smb_oauth_enabled'):
+            self.results['changed'] = True
+            self.account_dict['smb_oauth_enabled'] = self.smb_oauth_enabled
+            if not self.check_mode:
+                try:
+                    parameters = self.storage_models.StorageAccountUpdateParameters(
+                        azure_files_identity_based_authentication=self._build_azure_files_identity_auth_payload())
+                    self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
+                except Exception as exc:
+                    self.fail("Failed to update smb_oauth_enabled: {0}".format(str(exc)))
+
         update_tags, self.account_dict['tags'] = self.update_tags(self.account_dict['tags'])
         if update_tags:
             self.results['changed'] = True
@@ -1730,6 +1768,21 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             immutability_policy=self.storage_models.AccountImmutabilityPolicyProperties(**policy) if policy else None,
         )
 
+    def _build_azure_files_identity_auth_payload(self):
+        '''
+        Build an AzureFilesIdentityBasedAuthentication SDK model that carries the
+        smb_oauth_enabled toggle. Returns None when the caller did not set the
+        parameter.
+        '''
+        if self.smb_oauth_enabled is None:
+            return None
+        return self.storage_models.AzureFilesIdentityBasedAuthentication(
+            directory_service_options="None",
+            smb_o_auth_settings=self.storage_models.SmbOAuthSettings(
+                is_smb_o_auth_enabled=self.smb_oauth_enabled,
+            ),
+        )
+
     def create_account(self):
         self.log("Creating account {0}".format(self.name))
 
@@ -1764,6 +1817,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                 allow_shared_key_access=self.allow_shared_key_access,
                 identity=as_attribute_dict(self.identity) if self.identity else None,
                 immutable_storage_with_versioning=self.immutable_storage_with_versioning,
+                smb_oauth_enabled=self.smb_oauth_enabled,
                 tags=dict()
             )
             if self.tags:
@@ -1779,6 +1833,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         sku.tier = self.storage_models.SkuTier.standard if 'Standard' in self.account_type else \
             self.storage_models.SkuTier.premium
         # pylint: disable=missing-kwoa
+        azure_files_auth = self._build_azure_files_identity_auth_payload()
         parameters = self.storage_models.StorageAccountCreateParameters(sku=sku,
                                                                         kind=self.kind,
                                                                         location=self.location,
@@ -1796,6 +1851,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
                                                                         default_to_o_auth_authentication=self.default_to_o_auth_authentication,
                                                                         allow_cross_tenant_replication=self.allow_cross_tenant_replication,
                                                                         immutable_storage_with_versioning=self._build_immutable_storage_payload(),
+                                                                        azure_files_identity_based_authentication=azure_files_auth,
                                                                         large_file_shares_state=self.large_file_shares_state)
         self.log(str(parameters))
         try:

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -168,6 +168,12 @@ storageaccounts:
             type: bool
             returned: always
             sample: true
+        smb_oauth_enabled:
+            description:
+                - Whether managed identities can access Azure Files SMB shares using OAuth.
+            type: bool
+            returned: always
+            sample: true
         custom_domain:
             description:
                 - User domain assigned to the storage account.
@@ -889,6 +895,10 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         account_dict['encryption'] = as_attribute_dict(account_obj.encryption) if account_obj.encryption else dict()
 
         account_dict['identity'] = as_attribute_dict(account_obj.identity) if account_obj.identity else dict()
+
+        afa = getattr(account_obj, 'azure_files_identity_based_authentication', None)
+        smb = getattr(afa, 'smb_o_auth_settings', None) if afa else None
+        account_dict['smb_oauth_enabled'] = bool(getattr(smb, 'is_smb_o_auth_enabled', False)) if smb else False
 
         return account_dict
 

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -69,6 +69,7 @@
         - "{{ storage_account_name_default }}10"
         - "{{ storage_account_name_default }}11"
         - "{{ storage_account_name_default }}12"
+        - "{{ storage_account_name_default }}13"
 
     - name: Create new storage account with defaults (omitted parameters)
       azure.azcollection.azure_rm_storageaccount:
@@ -1006,6 +1007,73 @@
         that:
           - "output.storageaccounts | length >= 2"
 
+    - name: Create a storage account with smb_oauth_enabled=true
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+        account_type: Standard_LRS
+        kind: StorageV2
+        smb_oauth_enabled: true
+      register: smb_oauth_create
+
+    - name: Assert storage account is created with smb_oauth_enabled=true
+      ansible.builtin.assert:
+        that:
+          - smb_oauth_create is changed
+          - smb_oauth_create.state.smb_oauth_enabled == true
+
+    - name: Create a storage account with smb_oauth_enabled=true (Idempotent test)
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+        account_type: Standard_LRS
+        kind: StorageV2
+        smb_oauth_enabled: true
+      register: smb_oauth_idem
+
+    - name: Assert idempotency
+      ansible.builtin.assert:
+        that:
+          - smb_oauth_idem is not changed
+
+    - name: Update the storage account to disable smb_oauth_enabled
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+        account_type: Standard_LRS
+        kind: StorageV2
+        smb_oauth_enabled: false
+      register: smb_oauth_disable
+
+    - name: Assert smb_oauth_enabled was disabled
+      ansible.builtin.assert:
+        that:
+          - smb_oauth_disable is changed
+
+    - name: Get storage account facts for smb_oauth account
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+      register: smb_oauth_facts
+
+    - name: Assert info module reports smb_oauth_enabled=false
+      ansible.builtin.assert:
+        that:
+          - smb_oauth_facts.storageaccounts[0].smb_oauth_enabled == false
+
+    - name: Update the storage account omitting smb_oauth_enabled (tri-state no-op)
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}-storageaccount"
+        name: "{{ storage_account_name_default }}13"
+        account_type: Standard_LRS
+        kind: StorageV2
+      register: smb_oauth_noop
+
+    - name: Assert omitting smb_oauth_enabled does not trigger a change
+      ansible.builtin.assert:
+        that:
+          - smb_oauth_noop is not changed
+
     - name: Delete storage accounts
       azure.azcollection.azure_rm_storageaccount:
         resource_group: "{{ resource_group }}-storageaccount"
@@ -1027,6 +1095,7 @@
         - "{{ storage_account_name_default }}10"
         - "{{ storage_account_name_default }}11"
         - "{{ storage_account_name_default }}12"
+        - "{{ storage_account_name_default }}13"
 
     - name: Delete user managed identities
       ansible.builtin.include_tasks: "{{ role_path }}/../../../integration_common_tasks/managed_identity.yml"


### PR DESCRIPTION
##### SUMMARY
Fix #2297

Adds a top-level `smb_oauth_enabled` boolean to `azure_rm_storageaccount` that toggles Managed Identity (OAuth) access to Azure Files SMB shares. This maps to `properties.azureFilesIdentityBasedAuthentication.smbOAuthSettings.isSmbOAuthEnabled` in the Storage REST API, the same feature exposed as:
````
- Azure Portal > Storage account > Configuration > Managed Identity for SMB
- Azure CLI: az storage account update --enable-smb-oauth true
- Bicep: properties.azureFilesIdentityBasedAuthentication.smbOAuthSettings.isSmbOAuthEnabled
````

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_storageaccount.py
plugins/modules/azure_rm_storageaccount_info.py

##### ADDITIONAL INFORMATION
This PR writes `properties.azureFilesIdentityBasedAuthentication` with `directoryServiceOptions="None"` whenever the caller sets `smb_oauth_enabled`. That is safe today because the module does not yet expose an Azure Files identity-based authentication block (AD DS / Azure AD DS / Azure AD Kerberos).

If a future PR adds such a block (e.g. `azure_files_authentication`), the two settings must be merged into a single `AzureFilesIdentityBasedAuthentication` payload on both create and update, otherwise setting `smb_oauth_enabled` would overwrite `directoryServiceOptions=AD` (and vice versa), because both properties live inside the same object in the REST API.
