### PR TITLE
fix: add UUID validation to Azure EDA source plugins

### DIFF
--- a/extensions/eda/plugins/event_source/azure_event_hub.py
+++ b/extensions/eda/plugins/event_source/azure_event_hub.py
@@ -7,6 +7,7 @@ events into Ansible EDA rulebooks.
 import asyncio
 import json
 import logging
+import uuid
 from typing import Any
 
 from azure.eventhub import EventData
@@ -19,6 +20,14 @@ short_description: Receive events via a Azure Event Hub
 description:
   - An ansible-rulebook event source plugin for receiving events
     via Azure Event Hub
+  - Each event is assigned a valid RFC 4122 UUID under meta.uuid.
+  - If message_id is a valid UUID it is used. Otherwise if correlation_id is a valid UUID
+    it is used. Each is validated independently so an invalid message_id does not hide
+    a valid correlation_id.
+  - AMQP ID values of any type (str, bytes, uuid.UUID, int) are normalised to str
+    before validation.
+  - If neither is a valid UUID, a deterministic UUID5 is generated from
+    partition_id:sequence_number. The original value is preserved under meta.message_id.
 options:
   azure_tenant_id:
     description:
@@ -94,6 +103,74 @@ EXAMPLES = r"""
 
 logger = logging.getLogger()
 
+_uuid_warning = {"emitted": False}
+
+
+def is_valid_uuid(value: str) -> bool:
+    """Check if a string is a valid RFC 4122 UUID.
+
+    Accepts a str but handles non-string types defensively by catching
+    TypeError, so callers do not need to guard against unexpected types.
+    """
+    try:
+        uuid.UUID(value)
+        return True  # noqa: TRY300
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _normalize_amqp_id(value: str | bytes | uuid.UUID | int | None) -> str | None:
+    """Normalize an AMQP ID value to a string suitable for UUID validation.
+
+    AMQP message-id and correlation-id may be str, bytes, uuid.UUID, or int (ulong).
+    Returns None if value is None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.hex()
+    return str(value)
+
+
+def _process_event_hub_uuid(
+    partition_context: PartitionContext,
+    event: EventData,
+    meta: dict[str, Any],
+) -> None:
+    """Assign a valid UUID to meta["uuid"].
+
+    Priority: message_id > correlation_id > generated UUID5.
+    Each candidate is validated independently so an invalid message_id does
+    not hide a valid correlation_id. Generated UUID5 uses
+    partition_id:sequence_number as coordinates. The original value is
+    preserved under meta["message_id"] when the fallback is used.
+    """
+    coordinates = f"{partition_context.partition_id}:{event.sequence_number}"
+    generated_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, coordinates))
+
+    message_id = _normalize_amqp_id(event.message_id)
+    correlation_id = _normalize_amqp_id(event.correlation_id)
+
+    if message_id and is_valid_uuid(message_id):
+        meta["uuid"] = message_id
+    elif correlation_id and is_valid_uuid(correlation_id):
+        meta["uuid"] = correlation_id
+    else:
+        meta["uuid"] = generated_uuid
+        raw_id = message_id or correlation_id
+        if raw_id:
+            meta["message_id"] = raw_id
+            if not _uuid_warning["emitted"]:
+                _uuid_warning["emitted"] = True
+                logger.warning(
+                    "Provided message_id/correlation_id is not a valid UUID,"
+                    " using generated UUID. The original value has been"
+                    " stored under event.meta.message_id for tracking.",
+                )
+
 
 REQUIRED_ARGS = [
     "azure_tenant_id",
@@ -144,16 +221,10 @@ class AzureHubConsumer:
     ) -> None:
         """Receiving event data."""
         if event:
-            meta = {}
-            msg_id = (
-                event.message_id
-                or event.correlation_id
-                or f"{partition_context.partition_id}:{event.sequence_number}"
-            )
-
-            meta["event"] = {"uuid": msg_id}
+            meta: dict[str, Any] = {}
             if event.enqueued_time:
-                meta["event"]["produced_at"] = event.enqueued_time.isoformat()
+                meta["produced_at"] = event.enqueued_time.isoformat()
+            _process_event_hub_uuid(partition_context, event, meta)
             # Process message body
             try:
                 value = event.body_as_str()

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -8,8 +8,10 @@ import asyncio
 import contextlib
 import json
 import logging
+import uuid
 from typing import Any
 
+from azure.servicebus import ServiceBusReceivedMessage
 from azure.servicebus.aio import ServiceBusClient
 
 DOCUMENTATION = r"""
@@ -19,6 +21,11 @@ description:
   - An ansible-rulebook event source module for receiving events from an Azure service bus.
   - In order to get the service bus and the connection string, refer to
     https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-python-how-to-use-queues?tabs=passwordless
+  - Each event is assigned a valid RFC 4122 UUID under meta.uuid.
+  - If the message_id from Azure Service Bus is already a valid UUID it is used directly.
+  - If the message_id is not a valid UUID, a deterministic UUID5 is generated from
+    queue_name and sequence_number (broker-assigned, unique within the queue) to ensure
+    uniqueness within the configured queue. The original value is always preserved under meta.message_id.
 options:
   conn_str:
     description:
@@ -71,6 +78,50 @@ DEFAULT_FEEDBACK_TIMEOUT = 120
 
 logger = logging.getLogger()
 
+_uuid_warning = {"emitted": False}
+
+
+def is_valid_uuid(value: str) -> bool:
+    """Check if a string is a valid RFC 4122 UUID.
+
+    Accepts a str but handles non-string types defensively by catching
+    TypeError, so callers do not need to guard against unexpected types.
+    """
+    try:
+        uuid.UUID(value)
+        return True  # noqa: TRY300
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _process_service_bus_uuid(
+    msg: ServiceBusReceivedMessage,
+    queue_name: str,
+    meta: dict[str, Any],
+) -> None:
+    """Assign a valid UUID to meta["uuid"].
+
+    Uses msg.message_id if it is a valid UUID, otherwise generates a
+    deterministic UUID5 from queue_name and sequence_number to ensure
+    uniqueness within the configured queue. The original message_id is
+    always preserved under meta["message_id"] regardless of validity;
+    it is set to None when message_id is absent.
+    """
+    raw_id = str(msg.message_id) if msg.message_id is not None else None
+    meta["message_id"] = raw_id
+
+    if raw_id and is_valid_uuid(raw_id):
+        meta["uuid"] = raw_id
+    else:
+        meta["uuid"] = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{queue_name}:{msg.sequence_number}"))
+        if raw_id and not _uuid_warning["emitted"]:
+            _uuid_warning["emitted"] = True
+            logger.warning(
+                "Provided message_id is not a valid UUID,"
+                " using generated UUID. The original value has been"
+                " stored under event.meta.message_id for tracking.",
+            )
+
 
 async def receive_events(
     queue: asyncio.Queue[Any],
@@ -97,10 +148,10 @@ async def receive_events(
         receiver = servicebus_client.get_queue_receiver(queue_name=args["queue_name"])
         async with receiver:
             async for msg in receiver:
-                meta = {"message_id": msg.message_id, "event": {}}
-                meta["event"]["uuid"] = msg.message_id
+                meta: dict[str, Any] = {}
                 if msg.enqueued_time_utc:
-                    meta["event"]["produced_at"] = msg.enqueued_time_utc.isoformat()
+                    meta["produced_at"] = msg.enqueued_time_utc.isoformat()
+                _process_service_bus_uuid(msg, args["queue_name"], meta)
 
                 body = str(msg)
                 with contextlib.suppress(json.JSONDecodeError):

--- a/tests/unit/event_source/test_azure_event_hub.py
+++ b/tests/unit/event_source/test_azure_event_hub.py
@@ -1,18 +1,38 @@
 import asyncio
+import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Type
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from extensions.eda.plugins.event_source.azure_event_hub import AzureHubConsumer, main
+from extensions.eda.plugins.event_source.azure_event_hub import (
+    AzureHubConsumer,
+    _uuid_warning,
+    main,
+)
+
+VALID_UUID_1 = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
+VALID_UUID_2 = "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
+
+PATCH_CREDENTIAL = "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+PATCH_CLIENT = "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient"
+
+BASE_ARGS: Dict[str, Any] = {
+    "azure_tenant_id": "test_tenant_id",
+    "azure_client_id": "test_client_id",
+    "azure_client_secret": "test_client_secret",
+    "azure_namespace": "test.servicebus.windows.net",
+    "azure_event_hub_name": "test_hub",
+}
 
 
 class MockEvent:
     def __init__(
         self,
         body: str,
-        message_id: str | None = None,
-        correlation_id: str | None = None,
+        message_id: Any = None,
+        correlation_id: Any = None,
         sequence_number: int = 0,
         enqueued_time: Any = None,
     ) -> None:
@@ -55,6 +75,23 @@ class MockEventHubConsumerClient:
             await on_event_callback(partition_context, event)
 
 
+@pytest.fixture(autouse=True)
+def reset_uuid_warning():
+    _uuid_warning["emitted"] = False
+    yield
+    _uuid_warning["emitted"] = False
+
+
+def _make_consumer(queue: asyncio.Queue, extra_args: Dict[str, Any] | None = None) -> AzureHubConsumer:
+    args = {**BASE_ARGS, **(extra_args or {})}
+    with patch(PATCH_CREDENTIAL):
+        return AzureHubConsumer(queue, args)
+
+
+# ---------------------------------------------------------------------------
+# main() / required args
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_main_missing_required_args() -> None:
     queue: asyncio.Queue[Any] = asyncio.Queue()
@@ -67,26 +104,14 @@ async def test_main_missing_required_args() -> None:
 @pytest.mark.asyncio
 async def test_main_with_all_required_args() -> None:
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient"
-    ) as mock_client_class, patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ) as mock_credential:
-
+    with patch(PATCH_CLIENT) as mock_client_class, patch(PATCH_CREDENTIAL) as mock_credential:
         mock_client = AsyncMock()
         mock_client_class.return_value = mock_client
         mock_client.__aenter__.return_value = mock_client
         mock_client.receive = AsyncMock()
 
-        await main(queue, args)
+        await main(queue, BASE_ARGS)
 
         mock_credential.assert_called_once_with(
             tenant_id="test_tenant_id",
@@ -97,127 +122,233 @@ async def test_main_with_all_required_args() -> None:
         mock_client.receive.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# UUID assignment — string IDs
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
-async def test_azure_hub_consumer_on_event_json() -> None:
+async def test_on_event_no_message_id_generates_uuid5() -> None:
+    """No message_id or correlation_id → deterministic UUID5 from partition:sequence."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"message": "Hello World"}')
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
-        consumer = AzureHubConsumer(queue, args)
+    await consumer.on_event(MockPartitionContext("0"), event)
 
-        partition_context = MockPartitionContext()
-        event = MockEvent('{"message": "Hello World"}')
-
-        await consumer.on_event(partition_context, event)
-
-        result = await queue.get()
-        assert result == {
-            "body": {"message": "Hello World"},
-            "meta": {"event": {"uuid": "0:0"}},
-        }
+    result = await queue.get()
+    expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "0:0"))
+    assert result["meta"]["uuid"] == expected_uuid
+    assert "event" not in result["meta"]
 
 
 @pytest.mark.asyncio
-async def test_azure_hub_consumer_on_event_raw_string() -> None:
+async def test_on_event_valid_uuid_message_id() -> None:
+    """Valid UUID message_id is used directly as meta.uuid."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"data": "test"}', message_id=VALID_UUID_1)
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
-        consumer = AzureHubConsumer(queue, args)
+    await consumer.on_event(MockPartitionContext(), event)
 
-        partition_context = MockPartitionContext()
-        event = MockEvent("Hello World")
-
-        await consumer.on_event(partition_context, event)
-
-        result = await queue.get()
-        assert result == {"body": "Hello World", "meta": {"event": {"uuid": "0:0"}}}
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_1
+    assert "message_id" not in result["meta"]
 
 
 @pytest.mark.asyncio
-async def test_azure_hub_consumer_on_event_unicode_error() -> None:
+async def test_on_event_valid_uuid_correlation_id() -> None:
+    """Valid UUID correlation_id is used when message_id is absent."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"data": "test"}', correlation_id=VALID_UUID_2)
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
-        consumer = AzureHubConsumer(queue, args)
+    await consumer.on_event(MockPartitionContext(), event)
 
-        partition_context = MockPartitionContext()
-        event = MockEvent('{"message": "Hello World"}')
-
-        with patch.object(
-            event, "body_as_str", side_effect=UnicodeError("Unicode decode error")
-        ):
-            await consumer.on_event(partition_context, event)
-
-        # Should not put anything in queue when there's a Unicode error
-        assert queue.empty()
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_2
+    assert "message_id" not in result["meta"]
 
 
 @pytest.mark.asyncio
-async def test_azure_hub_consumer_on_event_no_event() -> None:
+async def test_on_event_message_id_takes_precedence_over_correlation_id() -> None:
+    """message_id wins over correlation_id when both are valid UUIDs."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"data": "test"}', message_id=VALID_UUID_1, correlation_id=VALID_UUID_2)
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
-        consumer = AzureHubConsumer(queue, args)
+    await consumer.on_event(MockPartitionContext(), event)
 
-        partition_context = MockPartitionContext()
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_1
 
-        await consumer.on_event(partition_context, None)
 
-        # Should not put anything in queue when event is None
-        assert queue.empty()
+@pytest.mark.asyncio
+async def test_on_event_invalid_message_id_falls_through_to_valid_correlation_id() -> None:
+    """Invalid message_id does not hide a valid correlation_id."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent(
+        '{"data": "test"}',
+        message_id="not-a-valid-uuid",
+        correlation_id=VALID_UUID_2,
+    )
 
+    await consumer.on_event(MockPartitionContext(), event)
+
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_2
+    assert "message_id" not in result["meta"]
+
+
+@pytest.mark.asyncio
+async def test_on_event_invalid_uuid_falls_back_to_generated() -> None:
+    """Both IDs invalid → UUID5 fallback; original message_id preserved."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"data": "test"}', message_id="not-a-valid-uuid", sequence_number=42)
+
+    await consumer.on_event(MockPartitionContext("1"), event)
+
+    result = await queue.get()
+    expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "1:42"))
+    assert result["meta"]["uuid"] == expected_uuid
+    assert result["meta"]["message_id"] == "not-a-valid-uuid"
+
+
+# ---------------------------------------------------------------------------
+# UUID assignment — AMQP non-string types
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_on_event_bytes_message_id_valid_uuid() -> None:
+    """bytes message_id containing a valid UUID string is accepted."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"data": "test"}', message_id=VALID_UUID_1.encode("utf-8"))
+
+    await consumer.on_event(MockPartitionContext(), event)
+
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_1
+
+
+@pytest.mark.asyncio
+async def test_on_event_uuid_object_message_id() -> None:
+    """uuid.UUID object as message_id is accepted directly."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    uuid_obj = uuid.UUID(VALID_UUID_1)
+    event = MockEvent('{"data": "test"}', message_id=uuid_obj)
+
+    await consumer.on_event(MockPartitionContext(), event)
+
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_1
+
+
+@pytest.mark.asyncio
+async def test_on_event_integer_message_id_falls_back() -> None:
+    """int (AMQP ulong) message_id falls back to UUID5; does not crash."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"data": "test"}', message_id=12345, sequence_number=7)
+
+    await consumer.on_event(MockPartitionContext("0"), event)
+
+    result = await queue.get()
+    expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "0:7"))
+    assert result["meta"]["uuid"] == expected_uuid
+    assert result["meta"]["message_id"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_on_event_non_utf8_bytes_message_id_falls_back() -> None:
+    """Non-UTF-8 bytes message_id falls back to UUID5; normalised to hex."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    raw_bytes = b"\xff\xfe"
+    event = MockEvent('{"data": "test"}', message_id=raw_bytes, sequence_number=3)
+
+    await consumer.on_event(MockPartitionContext("0"), event)
+
+    result = await queue.get()
+    expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "0:3"))
+    assert result["meta"]["uuid"] == expected_uuid
+    assert result["meta"]["message_id"] == raw_bytes.hex()
+
+
+# ---------------------------------------------------------------------------
+# meta structure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_on_event_produced_at_flat_on_meta() -> None:
+    """enqueued_time is surfaced as meta.produced_at (flat, not under meta.event)."""
+    ts = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"x": 1}', message_id=VALID_UUID_1, enqueued_time=ts)
+
+    await consumer.on_event(MockPartitionContext(), event)
+
+    result = await queue.get()
+    assert result["meta"]["produced_at"] == ts.isoformat()
+    assert "event" not in result["meta"]
+
+
+@pytest.mark.asyncio
+async def test_on_event_raw_string_body() -> None:
+    """Non-JSON body is stored as a raw string."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent("Hello World")
+
+    await consumer.on_event(MockPartitionContext(), event)
+
+    result = await queue.get()
+    assert result["body"] == "Hello World"
+    assert "uuid" in result["meta"]
+    assert "event" not in result["meta"]
+
+
+@pytest.mark.asyncio
+async def test_on_event_unicode_error_does_not_enqueue() -> None:
+    """Unicode decode error on body means nothing is put in the queue."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    event = MockEvent('{"message": "Hello World"}')
+
+    with patch.object(event, "body_as_str", side_effect=UnicodeError("error")):
+        await consumer.on_event(MockPartitionContext(), event)
+
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_on_event_none_event_does_not_enqueue() -> None:
+    """None event means nothing is put in the queue."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+
+    await consumer.on_event(MockPartitionContext(), None)
+
+    assert queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_initialization() -> None:
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {
+        **BASE_ARGS,
         "azure_consumer_group": "custom_group",
         "azure_starting_position": "5",
     }
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ) as mock_credential:
-        queue: asyncio.Queue[Any] = asyncio.Queue()
+    with patch(PATCH_CREDENTIAL) as mock_credential:
         consumer = AzureHubConsumer(queue, args)
 
         assert consumer.event_hub_namespace == "test.servicebus.windows.net"
@@ -234,148 +365,99 @@ async def test_azure_hub_consumer_initialization() -> None:
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_defaults() -> None:
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
+    queue: asyncio.Queue[Any] = asyncio.Queue()
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        consumer = AzureHubConsumer(queue, args)
+    with patch(PATCH_CREDENTIAL):
+        consumer = AzureHubConsumer(queue, BASE_ARGS)
 
         assert consumer.consumer_group == "$Default"
         assert consumer.starting_position == -1
 
 
+# ---------------------------------------------------------------------------
+# start_receiving / end-to-end
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_start_receiving() -> None:
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
-
     events = [MockEvent('{"test": "data"}')]
+    queue: asyncio.Queue[Any] = asyncio.Queue()
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ), patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient",
-        return_value=MockEventHubConsumerClient(events),
+    with patch(PATCH_CREDENTIAL), patch(
+        PATCH_CLIENT, return_value=MockEventHubConsumerClient(events)
     ):
-
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        consumer = AzureHubConsumer(queue, args)
-
+        consumer = AzureHubConsumer(queue, BASE_ARGS)
         await consumer.start_receiving()
 
-        result = await queue.get()
-        assert result == {"body": {"test": "data"}, "meta": {"event": {"uuid": "0:0"}}}
+    result = await queue.get()
+    expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "0:0"))
+    assert result["body"] == {"test": "data"}
+    assert result["meta"]["uuid"] == expected_uuid
+    assert "event" not in result["meta"]
 
+
+# ---------------------------------------------------------------------------
+# Feedback
+# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_enabled_without_queue() -> None:
-    """Test that ValueError is raised when feedback is enabled but no queue is provided."""
+    """ValueError is raised when feedback is enabled but no queue is provided."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-        "feedback": True,
-    }
+    args = {**BASE_ARGS, "feedback": True}
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ), pytest.raises(ValueError, match="feedback: true was set but no feedback queue"):
+    with patch(PATCH_CREDENTIAL), pytest.raises(
+        ValueError, match="feedback: true was set but no feedback queue"
+    ):
         AzureHubConsumer(queue, args)
 
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_enabled_with_queue() -> None:
-    """Test that consumer waits for feedback when enabled."""
+    """Consumer waits for feedback when enabled."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-        "feedback": True,
-        "eda_feedback_queue": feedback_queue,
-    }
+    args = {**BASE_ARGS, "feedback": True, "eda_feedback_queue": feedback_queue}
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
+    with patch(PATCH_CREDENTIAL):
         consumer = AzureHubConsumer(queue, args)
-        partition_context = MockPartitionContext()
-        event = MockEvent('{"message": "Hello World"}')
+        event = MockEvent('{"message": "Hello World"}', message_id=VALID_UUID_1)
 
-        # Put feedback in queue immediately so it doesn't block
         await feedback_queue.put("feedback_received")
-
-        await consumer.on_event(partition_context, event)
+        await consumer.on_event(MockPartitionContext(), event)
 
         result = await queue.get()
         assert result["body"] == {"message": "Hello World"}
-        # Verify feedback was consumed
         assert feedback_queue.empty()
 
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_timeout() -> None:
-    """Test that TimeoutError is raised when feedback timeout is exceeded."""
+    """TimeoutError is raised when feedback timeout is exceeded."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
+    args = {
+        **BASE_ARGS,
         "feedback": True,
         "eda_feedback_queue": feedback_queue,
-        "feedback_timeout": 0.1,  # Short timeout for testing
+        "feedback_timeout": 0.1,
     }
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
+    with patch(PATCH_CREDENTIAL):
         consumer = AzureHubConsumer(queue, args)
-        partition_context = MockPartitionContext()
-        event = MockEvent('{"message": "Hello World"}')
+        event = MockEvent('{"message": "Hello World"}', message_id=VALID_UUID_1)
 
-        # Don't put anything in feedback queue, so it times out
         with pytest.raises(asyncio.TimeoutError):
-            await consumer.on_event(partition_context, event)
+            await consumer.on_event(MockPartitionContext(), event)
 
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_defaults() -> None:
-    """Test that feedback defaults are set correctly."""
+    """Feedback defaults are set correctly."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
-        "azure_tenant_id": "test_tenant_id",
-        "azure_client_id": "test_client_id",
-        "azure_client_secret": "test_client_secret",
-        "azure_namespace": "test.servicebus.windows.net",
-        "azure_event_hub_name": "test_hub",
-    }
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-    ):
-        consumer = AzureHubConsumer(queue, args)
+    with patch(PATCH_CREDENTIAL):
+        consumer = AzureHubConsumer(queue, BASE_ARGS)
         assert consumer.feedback is False
         assert consumer.feedback_timeout == 120
         assert consumer.eda_feedback_queue is None

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -1,257 +1,262 @@
 import asyncio
+import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Type
 from unittest.mock import patch
 
 import pytest
 
-from extensions.eda.plugins.event_source.azure_service_bus import receive_events
+from extensions.eda.plugins.event_source.azure_service_bus import (
+    _uuid_warning,
+    receive_events,
+)
+
+VALID_UUID_1 = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
+VALID_UUID_2 = "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
+QUEUE_NAME = "queue"
+
+PATCH_TARGET = (
+    "extensions.eda.plugins.event_source.azure_service_bus"
+    ".ServiceBusClient.from_connection_string"
+)
 
 
 class MockMsg:
     def __init__(
-        self, message_id: int, body: str, enqueued_time_utc: Any = None
+        self,
+        message_id: Any,
+        body: str,
+        enqueued_time_utc: Any = None,
+        sequence_number: int = 0,
     ) -> None:
         self.message_id = message_id
         self._body = body
         self.enqueued_time_utc = enqueued_time_utc
+        self.sequence_number = sequence_number
 
     def __str__(self) -> str:
         return self._body
 
 
-@pytest.mark.asyncio
-async def test_receive_events() -> None:
-    msg1 = MockMsg(1, "Hello World")
-    msg2 = MockMsg(2, '{"Say": "Hello World"}')
+class AsyncMsgIter:
+    def __init__(self, msgs: list[MockMsg]) -> None:
+        self._msgs = msgs
+        self._idx = 0
 
-    class AsyncMsgIter:
-        def __init__(self, msgs: list[MockMsg]) -> None:
-            self._msgs = msgs
-            self._idx = 0
+    def __aiter__(self) -> "AsyncMsgIter":
+        return self
 
-        def __aiter__(self) -> "AsyncMsgIter":
-            return self
+    async def __anext__(self) -> MockMsg:
+        if self._idx < len(self._msgs):
+            msg = self._msgs[self._idx]
+            self._idx += 1
+            return msg
+        raise StopAsyncIteration
 
-        async def __anext__(self) -> MockMsg:
-            if self._idx < len(self._msgs):
-                msg = self._msgs[self._idx]
-                self._idx += 1
-                return msg
-            raise StopAsyncIteration
 
-    class MockReceiver:
-        async def __aenter__(self) -> "MockReceiver":
-            return self
+class MockReceiver:
+    def __init__(self, msgs: list[MockMsg]) -> None:
+        self._msgs = msgs
 
-        async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc: Optional[BaseException],
-            tb: Any,
-        ) -> None:
-            pass
+    async def __aenter__(self) -> "MockReceiver":
+        return self
 
-        def __aiter__(self) -> AsyncMsgIter:
-            return AsyncMsgIter([msg1, msg2])
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Any,
+    ) -> None:
+        pass
 
-        async def complete_message(self, msg: MockMsg) -> None:
-            pass
+    def __aiter__(self) -> AsyncMsgIter:
+        return AsyncMsgIter(self._msgs)
 
-    class MockServiceBusClient:
-        async def __aenter__(self) -> "MockServiceBusClient":
-            return self
+    async def complete_message(self, msg: MockMsg) -> None:
+        pass
 
-        async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc: Optional[BaseException],
-            tb: Any,
-        ) -> None:
-            pass
 
-        def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
-            return MockReceiver()
+class MockServiceBusClient:
+    def __init__(self, msgs: list[MockMsg]) -> None:
+        self._msgs = msgs
 
-    with patch(
-        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient.from_connection_string",
-        return_value=MockServiceBusClient(),
-    ):
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        args: Dict[str, Any] = {"conn_str": "fake", "queue_name": "queue"}
+    async def __aenter__(self) -> "MockServiceBusClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Any,
+    ) -> None:
+        pass
+
+    def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
+        return MockReceiver(self._msgs)
+
+
+@pytest.fixture(autouse=True)
+def reset_uuid_warning():
+    _uuid_warning["emitted"] = False
+    yield
+    _uuid_warning["emitted"] = False
+
+
+async def _run(msgs: list[MockMsg], extra_args: Dict[str, Any] | None = None) -> asyncio.Queue:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: Dict[str, Any] = {"conn_str": "fake", "queue_name": QUEUE_NAME}
+    if extra_args:
+        args.update(extra_args)
+    with patch(PATCH_TARGET, return_value=MockServiceBusClient(msgs)):
         await receive_events(queue, args)
+    return queue
 
-        result1 = await queue.get()
-        result2 = await queue.get()
-        assert result1 == {
-            "body": "Hello World",
-            "meta": {"message_id": 1, "event": {"uuid": 1}},
-        }
-        assert result2 == {
-            "body": {"Say": "Hello World"},
-            "meta": {"message_id": 2, "event": {"uuid": 2}},
-        }
 
+def _expected_fallback_uuid(sequence_number: int = 0) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_OID, f"{QUEUE_NAME}:{sequence_number}"))
+
+
+# ---------------------------------------------------------------------------
+# UUID assignment
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_receive_events_valid_uuid_message_id() -> None:
+    """Valid UUID message_id is used directly as meta.uuid."""
+    msg = MockMsg(VALID_UUID_1, '{"data": "test"}')
+
+    queue = await _run([msg])
+
+    result = await queue.get()
+    assert result["meta"]["uuid"] == VALID_UUID_1
+    assert result["meta"]["message_id"] == VALID_UUID_1
+
+
+@pytest.mark.asyncio
+async def test_receive_events_non_uuid_message_id_falls_back() -> None:
+    """Non-UUID message_ids fall back to UUID5 seeded on queue_name:sequence_number."""
+    msg1 = MockMsg(1, "Hello World", sequence_number=0)
+    msg2 = MockMsg(2, '{"Say": "Hello World"}', sequence_number=1)
+
+    queue = await _run([msg1, msg2])
+
+    result1 = await queue.get()
+    result2 = await queue.get()
+
+    assert result1 == {
+        "body": "Hello World",
+        "meta": {"uuid": _expected_fallback_uuid(0), "message_id": "1"},
+    }
+    assert result2 == {
+        "body": {"Say": "Hello World"},
+        "meta": {"uuid": _expected_fallback_uuid(1), "message_id": "2"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_receive_events_invalid_uuid_falls_back() -> None:
+    """Invalid UUID message_id falls back to UUID5 of queue_name:sequence_number; original preserved."""
+    msg = MockMsg("not-a-valid-uuid", '{"data": "test"}', sequence_number=42)
+
+    queue = await _run([msg])
+
+    result = await queue.get()
+    assert result["meta"]["uuid"] == _expected_fallback_uuid(42)
+    assert result["meta"]["message_id"] == "not-a-valid-uuid"
+
+
+@pytest.mark.asyncio
+async def test_receive_events_message_id_always_preserved() -> None:
+    """meta.message_id is present regardless of whether the UUID was valid."""
+    msg_valid = MockMsg(VALID_UUID_1, '{"a": 1}')
+    msg_invalid = MockMsg("not-a-uuid", '{"b": 2}')
+
+    queue = await _run([msg_valid, msg_invalid])
+
+    r_valid = await queue.get()
+    r_invalid = await queue.get()
+
+    assert r_valid["meta"]["message_id"] == VALID_UUID_1
+    assert r_invalid["meta"]["message_id"] == "not-a-uuid"
+
+
+@pytest.mark.asyncio
+async def test_receive_events_uuid5_seed_includes_queue_name() -> None:
+    """UUID5 fallback seed includes queue_name, so the same sequence_number on different
+    queues produces distinct UUIDs."""
+    msg = MockMsg("not-a-uuid", '{"data": "test"}', sequence_number=0)
+
+    queue_a: asyncio.Queue[Any] = asyncio.Queue()
+    queue_b: asyncio.Queue[Any] = asyncio.Queue()
+
+    with patch(PATCH_TARGET, return_value=MockServiceBusClient([msg])):
+        await receive_events(queue_a, {"conn_str": "fake", "queue_name": "queue-a"})
+    with patch(PATCH_TARGET, return_value=MockServiceBusClient([msg])):
+        await receive_events(queue_b, {"conn_str": "fake", "queue_name": "queue-b"})
+
+    result_a = await queue_a.get()
+    result_b = await queue_b.get()
+
+    assert result_a["meta"]["uuid"] != result_b["meta"]["uuid"]
+
+
+# ---------------------------------------------------------------------------
+# meta structure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_receive_events_produced_at() -> None:
+    """enqueued_time_utc is surfaced as meta.produced_at (flat on meta)."""
+    ts = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    msg = MockMsg(VALID_UUID_2, '{"x": 1}', enqueued_time_utc=ts)
+
+    queue = await _run([msg])
+
+    result = await queue.get()
+    assert result["meta"]["produced_at"] == ts.isoformat()
+    assert "event" not in result["meta"]
+
+
+# ---------------------------------------------------------------------------
+# Feedback
+# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_receive_events_feedback_enabled_without_queue() -> None:
-    """Test that ValueError is raised when feedback is enabled but no queue is provided."""
+    """ValueError is raised when feedback is enabled but no queue is provided."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     args: Dict[str, Any] = {
         "conn_str": "fake",
-        "queue_name": "queue",
+        "queue_name": QUEUE_NAME,
         "feedback": True,
     }
 
-    with pytest.raises(
-        ValueError, match="feedback: true was set but no feedback queue"
-    ):
+    with pytest.raises(ValueError, match="feedback: true was set but no feedback queue"):
         await receive_events(queue, args)
 
 
 @pytest.mark.asyncio
 async def test_receive_events_feedback_enabled_with_queue() -> None:
-    """Test that consumer waits for feedback when enabled."""
-    msg1 = MockMsg(1, '{"message": "Test"}')
+    """Consumer waits for feedback when enabled."""
+    msg = MockMsg(VALID_UUID_1, '{"message": "Test"}')
+    feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
+    await feedback_queue.put("feedback_received")
 
-    class AsyncMsgIter:
-        def __init__(self, msgs: list[MockMsg]) -> None:
-            self._msgs = msgs
-            self._idx = 0
+    queue = await _run([msg], {"feedback": True, "eda_feedback_queue": feedback_queue})
 
-        def __aiter__(self) -> "AsyncMsgIter":
-            return self
-
-        async def __anext__(self) -> MockMsg:
-            if self._idx < len(self._msgs):
-                msg = self._msgs[self._idx]
-                self._idx += 1
-                return msg
-            raise StopAsyncIteration
-
-    class MockReceiver:
-        async def __aenter__(self) -> "MockReceiver":
-            return self
-
-        async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc: Optional[BaseException],
-            tb: Any,
-        ) -> None:
-            pass
-
-        def __aiter__(self) -> AsyncMsgIter:
-            return AsyncMsgIter([msg1])
-
-        async def complete_message(self, msg: MockMsg) -> None:
-            pass
-
-    class MockServiceBusClient:
-        async def __aenter__(self) -> "MockServiceBusClient":
-            return self
-
-        async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc: Optional[BaseException],
-            tb: Any,
-        ) -> None:
-            pass
-
-        def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
-            return MockReceiver()
-
-    with patch(
-        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient.from_connection_string",
-        return_value=MockServiceBusClient(),
-    ):
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
-        args: Dict[str, Any] = {
-            "conn_str": "fake",
-            "queue_name": "queue",
-            "feedback": True,
-            "eda_feedback_queue": feedback_queue,
-        }
-
-        # Put feedback in queue immediately so it doesn't block
-        await feedback_queue.put("feedback_received")
-
-        await receive_events(queue, args)
-
-        result = await queue.get()
-        assert result["body"] == {"message": "Test"}
-        # Verify feedback was consumed
-        assert feedback_queue.empty()
+    result = await queue.get()
+    assert result["body"] == {"message": "Test"}
+    assert feedback_queue.empty()
 
 
 @pytest.mark.asyncio
 async def test_receive_events_feedback_timeout() -> None:
-    """Test that TimeoutError is raised when feedback timeout is exceeded."""
-    msg1 = MockMsg(1, '{"message": "Test"}')
+    """TimeoutError is raised when feedback timeout is exceeded."""
+    msg = MockMsg(VALID_UUID_1, '{"message": "Test"}')
 
-    class AsyncMsgIter:
-        def __init__(self, msgs: list[MockMsg]) -> None:
-            self._msgs = msgs
-            self._idx = 0
-
-        def __aiter__(self) -> "AsyncMsgIter":
-            return self
-
-        async def __anext__(self) -> MockMsg:
-            if self._idx < len(self._msgs):
-                msg = self._msgs[self._idx]
-                self._idx += 1
-                return msg
-            raise StopAsyncIteration
-
-    class MockReceiver:
-        async def __aenter__(self) -> "MockReceiver":
-            return self
-
-        async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc: Optional[BaseException],
-            tb: Any,
-        ) -> None:
-            pass
-
-        def __aiter__(self) -> AsyncMsgIter:
-            return AsyncMsgIter([msg1])
-
-        async def complete_message(self, msg: MockMsg) -> None:
-            pass
-
-    class MockServiceBusClient:
-        async def __aenter__(self) -> "MockServiceBusClient":
-            return self
-
-        async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc: Optional[BaseException],
-            tb: Any,
-        ) -> None:
-            pass
-
-        def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
-            return MockReceiver()
-
-    with patch(
-        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient.from_connection_string",
-        return_value=MockServiceBusClient(),
-    ):
-        queue: asyncio.Queue[Any] = asyncio.Queue()
+    with pytest.raises(asyncio.TimeoutError):
         feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
-        args: Dict[str, Any] = {
-            "conn_str": "fake",
-            "queue_name": "queue",
-            "feedback": True,
-            "eda_feedback_queue": feedback_queue,
-            "feedback_timeout": 0.1,  # Short timeout for testing
-        }
-
-        # Don't put anything in feedback queue, so it times out
-        with pytest.raises(asyncio.TimeoutError):
-            await receive_events(queue, args)
+        await _run(
+            [msg],
+            {"feedback": True, "eda_feedback_queue": feedback_queue, "feedback_timeout": 0.1},
+        )


### PR DESCRIPTION
Both plugins were writing to meta["event"]["uuid"] — a nested sub-dict that ansible-rulebook's insert_meta_info filter never reads. This caused every event to receive a random UUID4 regardless of what the plugin set, and eda-server validation failures when the Azure-supplied ID was not a valid RFC 4122 UUID.

Fixes:
- Set meta["uuid"] (flat) to match the schema expected by ansible-rulebook and eda-server
- Validate Azure-supplied IDs before use; fall back to a deterministic UUID5 when invalid, preserving the original under meta["message_id"]
- Move produced_at from meta["event"] to meta (flat) for consistency with the Kafka plugin
- Add one-time warning when an invalid ID triggers fallback

Added test cases and refactored existing tests for de-duplication.

UUID5 seeds:
- azure_service_bus: queue_name:sequence_number
- azure_event_hub: partition_id:sequence_number coordinates

Refs: AAP-77077, AAP-77078

Assisted-by: Claude

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
EDA

