### PR TITLE
Fix pre-existing bugs and clean up azure_rm_virtualmachinescaleset

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1094,8 +1094,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     differences.append('Capacity')
                     changed = True
                     vmss_dict['sku']['capacity'] = self.capacity
-                elif self.capacity is None:
-                    self.capacity = vmss_dict['sku']['capacity']
 
                 if self.vm_size and \
                    self.vm_size != vmss_dict['sku']['name']:
@@ -1144,8 +1142,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                    bool(self.single_placement_group) != bool(vmss_dict['single_placement_group']):
                     differences.append('single_placement_group')
                     changed = True
-                elif self.single_placement_group is None:
-                    self.single_placement_group = vmss_dict['single_placement_group']
 
                 vmss_dict['zones'] = [int(i) for i in vmss_dict['zones']] if 'zones' in vmss_dict and vmss_dict['zones'] else None
                 if self.zones is not None and self.zones != vmss_dict['zones']:
@@ -1467,7 +1463,10 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     vmss_resource.tags = self.tags
 
                     if self.upgrade_policy:
-                        vmss_resource.upgrade_policy = self.compute_models.UpgradePolicy(mode=self.upgrade_policy)
+                        if vmss_resource.upgrade_policy is not None:
+                            vmss_resource.upgrade_policy.mode = self.upgrade_policy
+                        else:
+                            vmss_resource.upgrade_policy = self.compute_models.UpgradePolicy(mode=self.upgrade_policy)
 
                     if self.custom_data and vmss_resource.virtual_machine_profile.os_profile is not None:
                         vmss_resource.virtual_machine_profile.os_profile.custom_data = self.custom_data

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -1094,7 +1094,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     differences.append('Capacity')
                     changed = True
                     vmss_dict['sku']['capacity'] = self.capacity
-                else:
+                elif self.capacity is None:
                     self.capacity = vmss_dict['sku']['capacity']
 
                 if self.vm_size and \

--- a/plugins/modules/azure_rm_virtualmachinescaleset.py
+++ b/plugins/modules/azure_rm_virtualmachinescaleset.py
@@ -58,7 +58,8 @@ options:
     capacity:
         description:
             - Capacity of VMSS.
-        default: 1
+            - When not set on create, Azure defaults to C(1).
+            - When not set on update, the existing capacity is preserved (safe for autoscaled VMSS).
         type: int
     tier:
         description:
@@ -140,11 +141,12 @@ options:
     os_disk_caching:
         description:
             - Type of OS disk caching.
+            - When not set on create, Azure defaults to C(ReadOnly).
+            - When not set on update, the existing value is preserved.
         type: str
         choices:
             - ReadOnly
             - ReadWrite
-        default: ReadOnly
         aliases:
             - disk_caching
     os_disk_size_gb:
@@ -279,8 +281,9 @@ options:
     single_placement_group:
         description:
             - When true this limits the scale set to a single placement group, of max size 100 virtual machines.
+            - When I(orchestration_mode=Flexible), this must be C(false).
+            - When not set on update, the existing value is preserved.
         type: bool
-        default: False
     plan:
         description:
             - Third-party billing plan for the VM.
@@ -334,8 +337,8 @@ options:
     platform_fault_domain_count:
         description:
             - Fault Domain count for each placement group.
+            - When omitted on create, Azure's service default is used. When omitted on update, the existing value is retained.
         type: int
-        default: 1
     orchestration_mode:
         description:
             - Specifies the orchestration mode for the virtual machine scale set.
@@ -344,11 +347,11 @@ options:
             - When I(orchestration_mode=Flexible), I(single_placement_group=False) must be set.
             - When I(orchestration_mode=Flexible), it cannot be configured I(overprovision).
             - When I(orchestration_mode=Flexible), it cannot be configured I(upgrade_policy) and configured when I(orchestration_mode=Uniform).
+            - When omitted on create, Azure's service default is used. When omitted on update, the existing value is retained.
         type: str
         choices:
             - Flexible
             - Uniform
-        default: Flexible
     specialized_image:
         description:
             - Set to C(true) when the source image referenced by I(image) has an C(osState) of C(Specialized). For example a Shared Image Gallery
@@ -754,7 +757,6 @@ import time
 try:
     from azure.core.exceptions import ResourceNotFoundError
     from azure.mgmt.core.tools import parse_resource_id
-    from azure.core.exceptions import ResourceNotFoundError
     from azure.mgmt.compute.models import (VirtualMachineScaleSetIdentity, UserAssignedIdentitiesValue)
 
 except ImportError:
@@ -783,7 +785,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             short_hostname=dict(type='str'),
             vm_size=dict(type='str'),
             tier=dict(type='str', choices=['Basic', 'Standard']),
-            capacity=dict(type='int', default=1),
+            capacity=dict(type='int'),
             upgrade_policy=dict(type='str', choices=['Automatic', 'Manual']),
             priority=dict(type='str', choices=['None', 'Spot', 'Regular']),
             eviction_policy=dict(type='str', choices=['Deallocate', 'Delete']),
@@ -793,8 +795,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             ssh_password_enabled=dict(type='bool', default=True),
             ssh_public_keys=dict(type='list', elements='dict'),
             image=dict(type='raw'),
-            os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite'],
-                                 default='ReadOnly'),
+            os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite']),
             os_type=dict(type='str', choices=['Linux', 'Windows', 'linux', 'windows'], default='Linux'),
             managed_disk_type=dict(type='str', choices=['Standard_LRS', 'Premium_LRS', 'StandardSSD_LRS', 'UltraSSD_LRS', 'Premium_ZRS', 'StandardSSD_ZRS']),
             os_disk_encryption_set=dict(type='str'),
@@ -822,7 +823,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             enable_accelerated_networking=dict(type='bool'),
             security_group=dict(type='raw', aliases=['security_group_name']),
             overprovision=dict(type='bool'),
-            single_placement_group=dict(type='bool', default=False),
+            single_placement_group=dict(type='bool'),
             zones=dict(type='list', elements='str'),
             custom_data=dict(type='str'),
             plan=dict(type='dict', options=dict(publisher=dict(type='str', required=True),
@@ -831,11 +832,9 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             scale_in_policy=dict(type='str', choices=['Default', 'OldestVM', 'NewestVM']),
             terminate_event_timeout_minutes=dict(type='int'),
             ephemeral_os_disk=dict(type='bool'),
-            orchestration_mode=dict(type='str',
-                                    choices=['Uniform', 'Flexible'],
-                                    default='Flexible',),
+            orchestration_mode=dict(type='str', choices=['Uniform', 'Flexible']),
             specialized_image=dict(type='bool', default=False),
-            platform_fault_domain_count=dict(type='int', default=1),
+            platform_fault_domain_count=dict(type='int'),
             os_disk_size_gb=dict(type='int'),
             security_profile=dict(
                 type='dict',
@@ -940,6 +939,10 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
         # make sure options are lower case
         self.remove_on_absent = set([resource.lower() for resource in self.remove_on_absent])
 
+        # normalize os_type to canonical lower-case form (argspec accepts both cases)
+        if self.os_type:
+            self.os_type = self.os_type.lower()
+
         # convert elements to ints
         self.zones = [int(i) for i in self.zones] if self.zones else None
 
@@ -980,9 +983,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     self.vm_size
                 ))
 
-            # if self.virtual_network_name:
-            #     virtual_network = self.get_virtual_network(self.virtual_network_name)
-
             if self.ssh_public_keys:
                 msg = "Parameter error: expecting ssh_public_keys to be a list of type dict where " \
                     "each dict contains keys: path, key_data."
@@ -993,7 +993,17 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                         self.fail(msg)
 
             if self.image and isinstance(self.image, dict):
-                if all(key in self.image for key in ('publisher', 'offer', 'sku', 'version')):
+                if self.image.get('id'):
+                    try:
+                        image_reference = self.compute_models.ImageReference(id=self.image['id'])
+                    except Exception as exc:
+                        self.fail("id Error: Cannot get image from the reference id - {0}".format(self.image['id']))
+                elif self.image.get('community_gallery_image_id'):
+                    try:
+                        image_reference = self.compute_models.ImageReference(community_gallery_image_id=self.image['community_gallery_image_id'])
+                    except Exception as exc:
+                        self.fail("id Error: Cannot get image from the community gallery image id - {0}".format(self.image['community_gallery_image_id']))
+                elif all(key in self.image for key in ('publisher', 'offer', 'sku', 'version')):
                     marketplace_image = self.get_marketplace_image_version()
                     if self.image['version'] == 'latest':
                         self.image['version'] = marketplace_image.name
@@ -1010,18 +1020,9 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     image_reference = self.get_custom_image_reference(
                         self.image.get('name'),
                         self.image.get('resource_group'))
-                elif self.image.get('id'):
-                    try:
-                        image_reference = self.compute_models.ImageReference(id=self.image['id'])
-                    except Exception as exc:
-                        self.fail("id Error: Cannot get image from the reference id - {0}".format(self.image['id']))
-                elif self.image.get('community_gallery_image_id'):
-                    try:
-                        image_reference = self.compute_models.ImageReference(community_gallery_image_id=self.image['community_gallery_image_id'])
-                    except Exception as exc:
-                        self.fail("id Error: Cannot get image from the cummunity gallery image id- {0}".format(self.image['community_gallery_image_id']))
                 else:
-                    self.fail("parameter error: expecting image to contain [publisher, offer, sku, version], [name, resource_group] or [id]")
+                    self.fail("parameter error: expecting image to contain [publisher, offer, sku, version], "
+                              "[name, resource_group], [id] or [community_gallery_image_id]")
             elif self.image and isinstance(self.image, str):
                 custom_image = True
                 image_reference = self.get_custom_image_reference(self.image)
@@ -1066,7 +1067,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                 if self.eviction_policy and \
                    self.eviction_policy != current_properties.get('eviction_policy', None):
                     self.fail('VM Eviction Policy is not updatable: requested virtual machine eviction policy is {0}'.format(self.eviction_policy))
-                if self.max_price and \
+                if self.max_price is not None and self.max_price != -1 and \
                    vmss_dict['virtual_machine_profile'].get('billing_profile', None) and \
                    self.max_price != vmss_dict['virtual_machine_profile']['billing_profile'].get('max_price', None):
                     self.fail('VM Maximum Price is not updatable: requested virtual machine maximum price is {0}'.format(self.max_price))
@@ -1087,12 +1088,14 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     changed = True
                     vmss_dict['virtual_machine_profile']['storage_profile']['os_disk']['caching'] = self.os_disk_caching
 
-                if self.capacity and \
+                if self.capacity is not None and \
                    self.capacity != vmss_dict['sku']['capacity']:
                     self.log('CHANGED: virtual machine scale set {0} - Capacity'.format(self.name))
                     differences.append('Capacity')
                     changed = True
                     vmss_dict['sku']['capacity'] = self.capacity
+                else:
+                    self.capacity = vmss_dict['sku']['capacity']
 
                 if self.vm_size and \
                    self.vm_size != vmss_dict['sku']['name']:
@@ -1101,11 +1104,12 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     changed = True
                     vmss_dict['sku']['name'] = self.vm_size
 
-                if self.data_disks and \
-                   len(self.data_disks) != len(vmss_dict['virtual_machine_profile']['storage_profile'].get('data_disks', [])):
-                    self.log('CHANGED: virtual machine scale set {0} - Data Disks'.format(self.name))
-                    differences.append('Data Disks')
-                    changed = True
+                if self.data_disks is not None:
+                    existing_data_disks = vmss_dict['virtual_machine_profile']['storage_profile'].get('data_disks') or []
+                    if self.data_disks_differ(self.data_disks, existing_data_disks):
+                        self.log('CHANGED: virtual machine scale set {0} - Data Disks'.format(self.name))
+                        differences.append('Data Disks')
+                        changed = True
 
                 if self.upgrade_policy and \
                    self.upgrade_policy != vmss_dict['upgrade_policy']['mode']:
@@ -1136,16 +1140,16 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     differences.append('overprovision')
                     changed = True
 
-                if bool(self.single_placement_group) != bool(vmss_dict['single_placement_group']):
+                if self.single_placement_group is not None and \
+                   bool(self.single_placement_group) != bool(vmss_dict['single_placement_group']):
                     differences.append('single_placement_group')
                     changed = True
+                elif self.single_placement_group is None:
+                    self.single_placement_group = vmss_dict['single_placement_group']
 
                 vmss_dict['zones'] = [int(i) for i in vmss_dict['zones']] if 'zones' in vmss_dict and vmss_dict['zones'] else None
-                if self.zones != vmss_dict['zones']:
-                    self.log("CHANGED: virtual machine scale sets {0} zones".format(self.name))
-                    differences.append('Zones')
-                    changed = True
-                    vmss_dict['zones'] = self.zones
+                if self.zones is not None and self.zones != vmss_dict['zones']:
+                    self.fail('VMSS zones are not updatable: requested virtual machine scale set zones are {0}'.format(self.zones))
 
                 if self.terminate_event_timeout_minutes:
                     timeout = self.terminate_event_timeout_minutes
@@ -1162,9 +1166,9 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                             "enable": 'true'
                         }
 
-                if self.scale_in_policy and self.scale_in_policy != vmss_dict.get('scale_in_policy', {}).get('rules', [""])[0]:
-                    self.log("CHANGED: virtual machine sale sets {0} scale in policy".format(self.name))
-                    differences.append('scaleInPolicy')
+                if self.scale_in_policy and self.scale_in_policy != (vmss_dict.get('scale_in_policy') or {}).get('rules', [None])[0]:
+                    self.log("CHANGED: virtual machine scale sets {0} scale in policy".format(self.name))
+                    differences.append('scale_in_policy')
                     changed = True
                     vmss_dict.setdefault('scale_in_policy', {})['rules'] = [self.scale_in_policy]
 
@@ -1204,47 +1208,42 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
 
                 if self.orchestration_mode and self.orchestration_mode != vmss_dict.get('orchestration_mode'):
                     self.fail("The orchestration_mode parameter cannot be updated!")
-                else:
-                    self.orchestration_mode = vmss_dict.get('orchestration_mode')
 
                 if self.platform_fault_domain_count and self.platform_fault_domain_count != vmss_dict.get('platform_fault_domain_count'):
                     self.fail("The platform_fault_domain_count parameter cannot be updated!")
 
                 if self.security_profile is not None:
                     update_security_profile = False
-                    if 'securityProfile' not in vmss_dict['virtual_machine_profile'].keys():
+                    existing_security_profile = vmss_dict['virtual_machine_profile'].get('security_profile') or {}
+                    existing_uefi = existing_security_profile.get('uefi_settings') or {}
+                    if not existing_security_profile:
                         update_security_profile = True
-                        differences.append('security_profile')
                     else:
                         if self.security_profile.get('encryption_at_host') is not None:
                             if bool(self.security_profile.get('encryption_at_host')) != \
-                                    bool(vmss_dict['virtual_machine_profile']['security_profile']['encryption_at_host']):
-                                update_security_profle = True
+                                    bool(existing_security_profile.get('encryption_at_host')):
+                                update_security_profile = True
                             else:
-                                self.security_profile['encryption_at_host'] = \
-                                    vmss_dict['virtual_machine_profile']['security_profile']['encryption_at_host']
+                                self.security_profile['encryption_at_host'] = existing_security_profile.get('encryption_at_host')
                         if self.security_profile.get('security_type') is not None:
-                            if self.security_profile.get('security_type') != \
-                                    vmss_dict['virtual_machine_profile']['security_profile']['security_type']:
+                            if self.security_profile.get('security_type') != existing_security_profile.get('security_type'):
                                 update_security_profile = True
                         if self.security_profile.get('uefi_settings') is not None:
                             if self.security_profile['uefi_settings'].get('secure_boot_enabled') is not None:
                                 if bool(self.security_profile['uefi_settings']['secure_boot_enabled']) != \
-                                        bool(vmss_dict['virtual_machine_profile']['security_profile']['uefi_settings']['secure_boot_nabled']):
+                                        bool(existing_uefi.get('secure_boot_enabled')):
                                     update_security_profile = True
                             else:
-                                self.security_profile['uefi_settings']['secure_boot_enabled'] = \
-                                    vmss_dict['virtual_machine_profile']['security_profile']['uefi_settings']['secure_boot_enabled']
+                                self.security_profile['uefi_settings']['secure_boot_enabled'] = existing_uefi.get('secure_boot_enabled')
                             if self.security_profile['uefi_settings'].get('v_tpm_enabled') is not None:
                                 if bool(self.security_profile['uefi_settings']['v_tpm_enabled']) != \
-                                        bool(vmss_dict['virtual_machine_profile']['security_profile']['uefi_settings']['v_tpm_enabled']):
+                                        bool(existing_uefi.get('v_tpm_enabled')):
                                     update_security_profile = True
                             else:
-                                self.security_profile['uefi_settings']['v_tpm_enabled'] = \
-                                    vmss_dict['virtual_machine_profile']['security_profile']['uefi_settings']['v_tpm_enabled']
-                        if update_security_profile:
-                            changed = True
-                            differences.append('security_profile')
+                                self.security_profile['uefi_settings']['v_tpm_enabled'] = existing_uefi.get('v_tpm_enabled')
+                    if update_security_profile:
+                        changed = True
+                        differences.append('security_profile')
 
                 self.differences = differences
 
@@ -1277,15 +1276,17 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     self.log("Create virtual machine scale set {0}".format(self.name))
                     self.results['actions'].append('Created VMSS {0}'.format(self.name))
 
-                    if self.os_type == 'Linux' or self.os_type == 'linux':
+                    if self.os_type == 'linux':
                         if disable_ssh_password and not self.ssh_public_keys and not self.specialized_image:
                             self.fail("Parameter error: ssh_public_keys required when disabling SSH password.")
 
                     if not self.virtual_network_name:
                         self.fail("virtual network name is required")
 
-                    if self.subnet_name:
-                        subnet = self.get_subnet(self.virtual_network_name, self.subnet_name)
+                    if not self.subnet_name:
+                        self.fail("subnet name is required")
+
+                    subnet = self.get_subnet(self.virtual_network_name, self.subnet_name)
 
                     if not image_reference:
                         self.fail("Parameter error: an image is required when creating a virtual machine.")
@@ -1410,7 +1411,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     if self.admin_password and vmss_resource.virtual_machine_profile.os_profile is not None:
                         vmss_resource.virtual_machine_profile.os_profile.admin_password = self.admin_password
 
-                    if (self.os_type == 'Linux' or self.os_type == 'linux') and os_profile:
+                    if self.os_type == 'linux' and os_profile:
                         vmss_resource.virtual_machine_profile.os_profile.linux_configuration = self.compute_models.LinuxConfiguration(
                             disable_password_authentication=disable_ssh_password
                         )
@@ -1422,34 +1423,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                             [self.compute_models.SshPublicKey(path=key['path'], key_data=key['key_data']) for key in self.ssh_public_keys]
                         vmss_resource.virtual_machine_profile.os_profile.linux_configuration.ssh = ssh_config
 
-                    if self.data_disks:
-                        data_disks = []
-
-                        for data_disk in self.data_disks:
-                            if data_disk.get('disk_encryption_set'):
-                                data_disk_encryption_set = self.compute_models.DiskEncryptionSetParameters(id=data_disk['disk_encryption_set'])
-                                data_disk_managed_disk = self.compute_models.VirtualMachineScaleSetManagedDiskParameters(
-                                    storage_account_type=data_disk.get('managed_disk_type', None),
-                                    disk_encryption_set=data_disk_encryption_set
-                                )
-                            else:
-                                data_disk_managed_disk = self.compute_models.VirtualMachineScaleSetManagedDiskParameters(
-                                    storage_account_type=data_disk.get('managed_disk_type', None)
-                                )
-
-                            data_disk['caching'] = data_disk.get(
-                                'caching',
-                                self.compute_models.CachingTypes.read_only
-                            )
-
-                            data_disks.append(self.compute_models.VirtualMachineScaleSetDataDisk(
-                                lun=data_disk.get('lun', None),
-                                caching=data_disk.get('caching', None),
-                                create_option=self.compute_models.DiskCreateOptionTypes.empty,
-                                disk_size_gb=data_disk.get('disk_size_gb', None),
-                                managed_disk=data_disk_managed_disk,
-                            ))
-
+                    data_disks = self.build_data_disks()
+                    if data_disks is not None:
                         vmss_resource.virtual_machine_profile.storage_profile.data_disks = data_disks
 
                     if self.plan:
@@ -1467,18 +1442,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                                        "Only service admin/account admin users can purchase images " +
                                        "from the marketplace. - {2}").format(self.name, self.plan, str(exc)))
 
-                    if self.security_profile is not None:
-                        uefi_settings_spec = None
-                        if self.security_profile.get('uefi_settings') is not None:
-                            uefi_settings_spec = self.compute_models.UefiSettings(
-                                secure_boot_enabled=self.security_profile['uefi_settings'].get('secure_boot_enabled'),
-                                v_tpm_enabled=self.security_profile['uefi_settings'].get('v_tpm_enabled'),
-                            )
-                        security_profile = self.compute_models.SecurityProfile(
-                            uefi_settings=uefi_settings_spec,
-                            encryption_at_host=self.security_profile.get('encryption_at_host'),
-                            security_type=self.security_profile.get('security_type'),
-                        )
+                    security_profile = self.build_security_profile()
+                    if security_profile is not None:
                         vmss_resource.virtual_machine_profile.security_profile = security_profile
 
                     self.log("Create virtual machine with parameters:")
@@ -1489,14 +1454,20 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                     self.results['actions'].append('Updated VMSS {0}'.format(self.name))
 
                     vmss_resource = self.get_vmss()
-                    vmss_resource.virtual_machine_profile.storage_profile.os_disk.caching = self.os_disk_caching
-                    vmss_resource.sku.capacity = self.capacity
-                    vmss_resource.sku.name = self.vm_size
-                    vmss_resource.orchestration_mode = self.orchestration_mode
-                    vmss_resource.platform_fault_domain_count = self.platform_fault_domain_count
-                    vmss_resource.overprovision = self.overprovision
-                    vmss_resource.single_placement_group = self.single_placement_group
+                    if self.os_disk_caching is not None:
+                        vmss_resource.virtual_machine_profile.storage_profile.os_disk.caching = self.os_disk_caching
+                    if self.capacity is not None:
+                        vmss_resource.sku.capacity = self.capacity
+                    if self.vm_size is not None:
+                        vmss_resource.sku.name = self.vm_size
+                    if self.overprovision is not None:
+                        vmss_resource.overprovision = self.overprovision
+                    if self.single_placement_group is not None:
+                        vmss_resource.single_placement_group = self.single_placement_group
                     vmss_resource.tags = self.tags
+
+                    if self.upgrade_policy:
+                        vmss_resource.upgrade_policy = self.compute_models.UpgradePolicy(mode=self.upgrade_policy)
 
                     if self.custom_data and vmss_resource.virtual_machine_profile.os_profile is not None:
                         vmss_resource.virtual_machine_profile.os_profile.custom_data = self.custom_data
@@ -1521,40 +1492,12 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
                         vmss_resource.virtual_machine_profile.network_profile.network_interface_configurations[0].ip_configurations[0] \
                             .application_security_groups = [self.compute_models.SubResource(id=item) for item in self.application_security_groups]
 
-                    if self.data_disks is not None:
-                        data_disks = []
-                        for data_disk in self.data_disks:
-                            if data_disk.get('disk_encryption_set'):
-                                data_disk_encryption_set = self.compute_models.DiskEncryptionSetParameters(id=data_disk['disk_encryption_set'])
-                                data_disk_managed_disk = self.compute_models.VirtualMachineScaleSetManagedDiskParameters(
-                                    storage_account_type=data_disk.get('managed_disk_type', None),
-                                    disk_encryption_set=data_disk_encryption_set
-                                )
-                            else:
-                                data_disk_managed_disk = self.compute_models.VirtualMachineScaleSetManagedDiskParameters(
-                                    storage_account_type=data_disk.get('managed_disk_type', None)
-                                )
-                            data_disks.append(self.compute_models.VirtualMachineScaleSetDataDisk(
-                                lun=data_disk['lun'],
-                                caching=data_disk['caching'],
-                                create_option=self.compute_models.DiskCreateOptionTypes.empty,
-                                disk_size_gb=data_disk['disk_size_gb'],
-                                managed_disk=data_disk_managed_disk,
-                            ))
+                    data_disks = self.build_data_disks()
+                    if data_disks is not None:
                         vmss_resource.virtual_machine_profile.storage_profile.data_disks = data_disks
 
-                    if self.security_profile is not None:
-                        uefi_settings_spec = None
-                        if self.security_profile.get('uefi_settings') is not None:
-                            uefi_settings_spec = self.compute_models.UefiSettings(
-                                secure_boot_enabled=self.security_profile['uefi_settings'].get('secure_boot_enabled'),
-                                v_tpm_enabled=self.security_profile['uefi_settings'].get('v_tpm_enabled'),
-                            )
-                        security_profile = self.compute_models.SecurityProfile(
-                            uefi_settings=uefi_settings_spec,
-                            encryption_at_host=self.security_profile.get('encryption_at_host'),
-                            security_type=self.security_profile.get('security_type'),
-                        )
+                    security_profile = self.build_security_profile()
+                    if security_profile is not None:
                         vmss_resource.virtual_machine_profile.security_profile = security_profile
 
                     if self.scale_in_policy:
@@ -1607,13 +1550,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             return vmss
         except ResourceNotFoundError as exc:
             self.fail("Error getting virtual machine scale set {0} - {1}".format(self.name, str(exc)))
-
-    def get_virtual_network(self, name):
-        try:
-            vnet = self.network_client.virtual_networks.get(self.virtual_network_resource_group, name)
-            return vnet
-        except ResourceNotFoundError as exc:
-            self.fail("Error fetching virtual network {0} - {1}".format(name, str(exc)))
 
     def get_subnet(self, vnet_name, subnet_name):
         self.log("Fetching subnet {0} in virtual network {1}".format(subnet_name, vnet_name))
@@ -1760,6 +1696,100 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBaseExt):
             return None
 
         return self.compute_models.ScaleInPolicy(rules=[self.scale_in_policy])
+
+    def data_disks_differ(self, new_disks, existing_disks):
+        '''
+        Return True if the requested data disks differ from what is live on Azure.
+
+        Compares only the fields we manage (lun, caching, disk_size_gb, managed_disk_type).
+        '''
+        new_normalized = sorted(
+            [self._normalize_new_disk(d) for d in (new_disks or [])],
+            key=lambda x: x['lun'],
+        )
+        existing_normalized = sorted(
+            [self._normalize_existing_disk(d) for d in (existing_disks or [])],
+            key=lambda x: x['lun'],
+        )
+        if len(new_normalized) == len(existing_normalized):
+            for user_disk, live_disk in zip(new_normalized, existing_normalized):
+                for field, value in user_disk.items():
+                    if value is None:
+                        user_disk[field] = live_disk[field]
+        return not self.default_compare({}, new_normalized, existing_normalized, '', dict(compare=[]))
+
+    @staticmethod
+    def _normalize_new_disk(disk):
+        '''
+        Normalize a user-provided data_disk dict for diff comparison.
+        '''
+        return {
+            'lun': int(disk.get('lun', 0)),
+            'caching': (disk.get('caching') or '').lower() or None,
+            'disk_size_gb': disk.get('disk_size_gb'),
+            'managed_disk_type': disk.get('managed_disk_type'),
+        }
+
+    @staticmethod
+    def _normalize_existing_disk(disk):
+        '''
+        Normalize a live-from-Azure data_disk dict for diff comparison.
+        '''
+        return {
+            'lun': int(disk.get('lun', 0)),
+            'caching': (disk.get('caching') or '').lower() or None,
+            'disk_size_gb': disk.get('disk_size_gb'),
+            'managed_disk_type': (disk.get('managed_disk') or {}).get('storage_account_type'),
+        }
+
+    def build_data_disks(self):
+        '''
+        Build a list of VirtualMachineScaleSetDataDisk from self.data_disks.
+
+        :return: list of VirtualMachineScaleSetDataDisk, or None if self.data_disks is None
+        '''
+        if self.data_disks is None:
+            return None
+        data_disks = []
+        for data_disk in self.data_disks:
+            if data_disk.get('disk_encryption_set'):
+                disk_encryption_set = self.compute_models.DiskEncryptionSetParameters(id=data_disk['disk_encryption_set'])
+                managed_disk = self.compute_models.VirtualMachineScaleSetManagedDiskParameters(
+                    storage_account_type=data_disk.get('managed_disk_type'),
+                    disk_encryption_set=disk_encryption_set,
+                )
+            else:
+                managed_disk = self.compute_models.VirtualMachineScaleSetManagedDiskParameters(
+                    storage_account_type=data_disk.get('managed_disk_type'),
+                )
+            data_disks.append(self.compute_models.VirtualMachineScaleSetDataDisk(
+                lun=data_disk.get('lun', '0'),
+                caching=data_disk.get('caching', self.compute_models.CachingTypes.read_only),
+                create_option=self.compute_models.DiskCreateOptionTypes.empty,
+                disk_size_gb=data_disk.get('disk_size_gb'),
+                managed_disk=managed_disk,
+            ))
+        return data_disks
+
+    def build_security_profile(self):
+        '''
+        Build a SecurityProfile from self.security_profile.
+
+        :return: SecurityProfile, or None if self.security_profile is None
+        '''
+        if self.security_profile is None:
+            return None
+        uefi_settings_spec = None
+        if self.security_profile.get('uefi_settings') is not None:
+            uefi_settings_spec = self.compute_models.UefiSettings(
+                secure_boot_enabled=self.security_profile['uefi_settings'].get('secure_boot_enabled'),
+                v_tpm_enabled=self.security_profile['uefi_settings'].get('v_tpm_enabled'),
+            )
+        return self.compute_models.SecurityProfile(
+            uefi_settings=uefi_settings_spec,
+            encryption_at_host=self.security_profile.get('encryption_at_host'),
+            security_type=self.security_profile.get('security_type'),
+        )
 
 
 def main():

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -465,7 +465,7 @@
         capacity: 1
         virtual_network_name: VMSStestVnet
         subnet_name: VMSStestSubnet
-        upgrade_policy: Automatic
+        upgrade_policy: Manual
         load_balancer: testLB1
         tier: Standard
         managed_disk_type: Standard_LRS
@@ -502,7 +502,7 @@
         capacity: 1
         virtual_network_name: VMSStestVnet
         subnet_name: VMSStestSubnet
-        upgrade_policy: Automatic
+        upgrade_policy: Manual
         load_balancer: testLB1
         tier: Standard
         managed_disk_type: Standard_LRS

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1552,13 +1552,7 @@
           sku: 22_04-lts-gen2
           version: latest
       register: no_subnet_result
-      failed_when: false
-
-    - name: Assert missing subnet_name fails with clear error
-      ansible.builtin.assert:
-        that:
-          - no_subnet_result is failed
-          - "'subnet' in (no_subnet_result.msg | lower)"
+      failed_when: no_subnet_result.msg != "subnet name is required"
 
     - name: Create Uniform VMSS with distinctive values for preserve-live-values baseline
       azure.azcollection.azure_rm_virtualmachinescaleset:

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1347,6 +1347,391 @@
         resource_group: "{{ resource_group }}-vmss01"
         name: "srcvm{{ rpfx }}"
         state: absent
+
+    - name: Create Uniform VMSS with security_profile and scale_in_policy
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        capacity: 1
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        os_type: Linux
+        single_placement_group: true
+        orchestration_mode: Uniform
+        scale_in_policy: NewestVM
+        security_profile:
+          uefi_settings:
+            secure_boot_enabled: true
+            v_tpm_enabled: true
+          encryption_at_host: false
+          security_type: TrustedLaunch
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        data_disks:
+          - lun: 0
+            disk_size_gb: 64
+            caching: ReadWrite
+            managed_disk_type: Standard_LRS
+      register: auditvmss_create
+
+    - name: Assert audit VMSS created with security_profile and scale_in_policy
+      ansible.builtin.assert:
+        that:
+          - auditvmss_create.changed
+          - auditvmss_create.ansible_facts.azure_vmss.virtual_machine_profile.security_profile.security_type == 'TrustedLaunch'
+          - auditvmss_create.ansible_facts.azure_vmss.virtual_machine_profile.security_profile.uefi_settings.secure_boot_enabled
+          - auditvmss_create.ansible_facts.azure_vmss.virtual_machine_profile.security_profile.uefi_settings.v_tpm_enabled
+          - auditvmss_create.ansible_facts.azure_vmss.scale_in_policy.rules[0] == 'NewestVM'
+
+    - name: Re-run same task to assert idempotence
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        capacity: 1
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        os_type: Linux
+        single_placement_group: true
+        orchestration_mode: Uniform
+        scale_in_policy: NewestVM
+        security_profile:
+          uefi_settings:
+            secure_boot_enabled: true
+            v_tpm_enabled: true
+          encryption_at_host: false
+          security_type: TrustedLaunch
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        data_disks:
+          - lun: 0
+            disk_size_gb: 64
+            caching: ReadWrite
+            managed_disk_type: Standard_LRS
+      register: auditvmss_idem
+
+    - name: Assert audit VMSS re-run is idempotent
+      ansible.builtin.assert:
+        that:
+          - not auditvmss_idem.changed
+
+    - name: Update audit VMSS without specifying orchestration_mode
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        capacity: 2
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        single_placement_group: true
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+      register: auditvmss_b12
+
+    - name: Assert update without orchestration_mode succeeded
+      ansible.builtin.assert:
+        that:
+          - auditvmss_b12.changed
+          - auditvmss_b12.ansible_facts.azure_vmss.sku.capacity == 2
+
+    - name: Update audit VMSS data_disks with minimal fields
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        capacity: 2
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        single_placement_group: true
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        data_disks:
+          - lun: 0
+            disk_size_gb: 128
+            managed_disk_type: Standard_LRS
+      register: auditvmss_b11
+
+    - name: Assert update with minimal data_disks did not fail
+      ansible.builtin.assert:
+        that:
+          - auditvmss_b11 is not failed
+
+    - name: Update audit VMSS security_profile.uefi_settings.v_tpm_enabled
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        capacity: 2
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        single_placement_group: true
+        security_profile:
+          uefi_settings:
+            secure_boot_enabled: true
+            v_tpm_enabled: false
+          encryption_at_host: false
+          security_type: TrustedLaunch
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+      register: auditvmss_secprof
+
+    - name: Assert security_profile update did not fail
+      ansible.builtin.assert:
+        that:
+          - auditvmss_secprof is not failed
+
+    - name: Delete audit VMSS
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+        state: absent
+
+    - name: Attempt VMSS create without subnet_name
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "nosubnetvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        virtual_network_name: VMSStestVnet
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_type: Linux
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+      register: no_subnet_result
+      failed_when: false
+
+    - name: Assert missing subnet_name fails with clear error
+      ansible.builtin.assert:
+        that:
+          - no_subnet_result is failed
+          - "'subnet' in (no_subnet_result.msg | lower)"
+
+    - name: Create Uniform VMSS with distinctive values for preserve-live-values baseline
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        capacity: 3
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_disk_caching: ReadWrite
+        os_type: linux
+        overprovision: true
+        single_placement_group: true
+        orchestration_mode: Uniform
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        data_disks:
+          - lun: 0
+            disk_size_gb: 64
+            managed_disk_type: Standard_LRS
+
+    - name: Update preserve VMSS with tags only and no other options provided
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        tags:
+          preserve_test: "yes"
+
+    - name: Fetch preserve VMSS live state
+      azure.azcollection.azure_rm_virtualmachinescaleset_info:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+      register: preserve_live
+
+    - name: Assert live values preserved after tags-only update
+      ansible.builtin.assert:
+        that:
+          - preserve_live.vmss[0].sku.capacity == 3
+          - preserve_live.vmss[0].properties.overprovision == true
+          - preserve_live.vmss[0].properties.singlePlacementGroup == true
+          - preserve_live.vmss[0].sku.name == 'Standard_D2s_v3'
+          - preserve_live.vmss[0].properties.virtualMachineProfile.storageProfile.osDisk.caching == 'ReadWrite'
+
+    - name: Update preserve VMSS upgrade_policy Manual to Automatic
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Automatic
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+      register: upgrade_policy_result
+
+    - name: Fetch preserve VMSS after upgrade_policy flip
+      azure.azcollection.azure_rm_virtualmachinescaleset_info:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+      register: upgrade_policy_live
+
+    - name: Assert upgrade_policy actually changed on Azure
+      ansible.builtin.assert:
+        that:
+          - upgrade_policy_result.changed
+          - upgrade_policy_live.vmss[0].properties.upgradePolicy.mode == 'Automatic'
+
+    - name: Update preserve VMSS data_disks size only
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        data_disks:
+          - lun: 0
+            disk_size_gb: 128
+            managed_disk_type: Standard_LRS
+      register: data_disk_resize_result
+
+    - name: Fetch preserve VMSS after data_disks resize
+      azure.azcollection.azure_rm_virtualmachinescaleset_info:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+      register: data_disk_resize_live
+
+    - name: Assert data_disks size change detected and applied
+      ansible.builtin.assert:
+        that:
+          - data_disk_resize_result.changed
+          - data_disk_resize_live.vmss[0].properties.virtualMachineProfile.storageProfile.dataDisks[0].diskSizeGB == 128
+
+    - name: Delete preserve VMSS
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "preservevmss{{ rpfx }}"
+        state: absent
+
+    - name: Create Spot VMSS with max_price for spot-preservation baseline
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "spotvmss{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        admin_username: testuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/testuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        capacity: 1
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        upgrade_policy: Manual
+        tier: Standard
+        managed_disk_type: Standard_LRS
+        os_type: Linux
+        priority: Spot
+        eviction_policy: Deallocate
+        max_price: 0.5
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+
+    - name: Update Spot VMSS tags without providing max_price
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "spotvmss{{ rpfx }}"
+        virtual_network_name: VMSStestVnet
+        subnet_name: VMSStestSubnet
+        image:
+          offer: 0001-com-ubuntu-server-jammy
+          publisher: Canonical
+          sku: 22_04-lts-gen2
+          version: latest
+        tags:
+          spot_test: "yes"
+      register: spot_tags_result
+
+    - name: Assert Spot VMSS tags update did not falsely fail on max_price
+      ansible.builtin.assert:
+        that:
+          - spot_tags_result is not failed
+
+    - name: Delete Spot VMSS
+      azure.azcollection.azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "spotvmss{{ rpfx }}"
+        state: absent
     # ---------------------------------------------------------------------
 
     - name: Delete user managed identities

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1609,10 +1609,10 @@
       ansible.builtin.assert:
         that:
           - preserve_live.vmss[0].sku.capacity == 3
-          - preserve_live.vmss[0].properties.overprovision == true
-          - preserve_live.vmss[0].properties.singlePlacementGroup == true
+          - preserve_live.vmss[0].overprovision == true
+          - preserve_live.vmss[0].single_placement_group == true
           - preserve_live.vmss[0].sku.name == 'Standard_D2s_v3'
-          - preserve_live.vmss[0].properties.virtualMachineProfile.storageProfile.osDisk.caching == 'ReadWrite'
+          - preserve_live.vmss[0].virtual_machine_profile.storage_profile.os_disk.caching == 'ReadWrite'
 
     - name: Update preserve VMSS upgrade_policy Manual to Automatic
       azure.azcollection.azure_rm_virtualmachinescaleset:
@@ -1638,7 +1638,7 @@
       ansible.builtin.assert:
         that:
           - upgrade_policy_result.changed
-          - upgrade_policy_live.vmss[0].properties.upgradePolicy.mode == 'Automatic'
+          - upgrade_policy_live.vmss[0].upgrade_policy.mode == 'Automatic'
 
     - name: Update preserve VMSS data_disks size only
       azure.azcollection.azure_rm_virtualmachinescaleset:
@@ -1667,7 +1667,7 @@
       ansible.builtin.assert:
         that:
           - data_disk_resize_result.changed
-          - data_disk_resize_live.vmss[0].properties.virtualMachineProfile.storageProfile.dataDisks[0].diskSizeGB == 128
+          - data_disk_resize_live.vmss[0].virtual_machine_profile.storage_profile.data_disks[0].disk_size_gb == 128
 
     - name: Delete preserve VMSS
       azure.azcollection.azure_rm_virtualmachinescaleset:

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1137,7 +1137,7 @@
         image:
           offer: 0001-com-ubuntu-server-focal
       register: fail_invalid_image_dict
-      failed_when: 'fail_invalid_image_dict.msg != "parameter error: expecting image to contain [publisher, offer, sku, version], [name, resource_group] or [id]"'
+      failed_when: 'fail_invalid_image_dict.msg != "parameter error: expecting image to contain [publisher, offer, sku, version], [name, resource_group], [id] or [community_gallery_image_id]"'
 
     - name: Assert error thrown with invalid image type
       azure.azcollection.azure_rm_virtualmachinescaleset:

--- a/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml
@@ -1494,6 +1494,18 @@
       ansible.builtin.assert:
         that:
           - auditvmss_b11 is not failed
+          - auditvmss_b11.changed
+
+    - name: Fetch audit VMSS after minimal data_disks resize
+      azure.azcollection.azure_rm_virtualmachinescaleset_info:
+        resource_group: "{{ resource_group }}-vmss01"
+        name: "auditvmss{{ rpfx }}"
+      register: auditvmss_b11_live
+
+    - name: Assert audit VMSS data_disks resize actually applied on Azure
+      ansible.builtin.assert:
+        that:
+          - auditvmss_b11_live.vmss[0].virtual_machine_profile.storage_profile.data_disks[0].disk_size_gb == 128
 
     - name: Update audit VMSS security_profile.uefi_settings.v_tpm_enabled
       azure.azcollection.azure_rm_virtualmachinescaleset:


### PR DESCRIPTION
##### SUMMARY

Consolidated cleanup of pre-existing bugs in `azure_rm_virtualmachinescaleset` discovered during the audit for #117 (multi-NIC VMSS support). Landing these fixes first keeps the #117 diff focused purely on the multi-NIC feature.

Fixes latent bugs across four categories:
- Field-name typos that caused user input to be silently ignored (`secure_boot_nabled`, `update_security_profle`, `cummunity_gallery_image_id`, `sale in policy`, and the `securityProfile` camelCase key lookup).
- Argspec defaults (`capacity=1`, `single_placement_group=False`, `os_disk_caching='ReadOnly'`, `orchestration_mode='Flexible'`, `platform_fault_domain_count=1`) that silently reset live VMSS state on unrelated updates — a real hazard for autoscaled or Spot production VMSSes.
- Diff blocks that reported `changed=True` but never assigned the new value to the SDK model — the API call sent the old value and state never actually changed (`upgrade_policy`, `security_profile`).
- A `data_disks` diff that only compared list length, so changing disk size on an existing disk was silently ignored, plus a `KeyError` on update when the user omitted optional fields.
- Missing input validation (`subnet_name` required on create) that surfaced as an unhelpful `AttributeError: 'NoneType' object has no attribute 'id'`.
- `max_price = -1` (argspec default sentinel) treated as a real value in diff, causing Spot VMSSes with a real `max_price` to false-fail "not updatable" on tag-only updates.
- Image dict identifier priority contradicted the Azure REST spec (`name` was preferred over `id`).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_virtualmachinescaleset.py
tests/integration/targets/azure_rm_virtualmachinescaleset/tasks/main.yml

##### ADDITIONAL INFORMATION

**This PR contains behavior changes. It should target a major release (next appropriate SemVer bump), not a minor.**

**Potentially breaking — argspec defaults removed**

Removing these argspec defaults changes what gets sent to Azure on create when the user omits the option. On update, the module now inherits the live value (this is what makes the fix worthwhile).

| Option | Old default | New behavior |
|---|---|---|
| `capacity` | `1` | No default; Azure default applies on create; live value preserved on update |
| `single_placement_group` | `False` | No default; Azure default (`true` for Uniform) applies on create; live value preserved on update |
| `orchestration_mode` | `'Flexible'` | No default; Azure default (`Uniform`) applies on create; immutable on update |
| `platform_fault_domain_count` | `1` | No default; Azure default applies on create; immutable on update |
| `os_disk_caching` | `'ReadOnly'` | No default; Azure default applies on create; live value preserved on update |

Playbooks that omit these options on create will now receive Azure's own defaults instead of the module's. In most cases the outcome is the same, but `orchestration_mode` and `single_placement_group` may differ. Users who rely on any of the above defaults should set them explicitly in their playbooks.

**Behavior change — immutable field errors are now surfaced**

- `zones` change on update now fails with a clear "not updatable" error. Previously it was a silent no-op. Playbooks that were "successfully" doing nothing on a `zones` change will now error.

**Behavior change — image dict priority reordered**

When the `image` dict contains multiple identifier keys, the priority is now `id → community_gallery_image_id → marketplace (publisher/offer/sku/version) → name`. Previously the module preferred `name` over `id`, contradicting the Azure REST spec. Playbooks passing both `name` and `id` will now use `id`.

**Refactor and dead-code cleanup**

- Extracted `build_data_disks()` and `build_security_profile()` helpers to deduplicate ~40 LOC between the create and update paths.
- Extracted `data_disks_differ()` with two normalizer helpers to keep the diff block readable, using `default_compare` from `azure_rm_common_ext`.
- Removed dead `get_virtual_network()` method (only caller was commented out).
- Removed commented-out virtual network lookup cruft.
- Removed duplicate `ResourceNotFoundError` import.

**Integration tests added (~385 LOC)**

- Create VMSS with `security_profile` + `scale_in_policy` and assert live state; idempotence re-run.
- Update without specifying `orchestration_mode` (regression for argspec-default reset).
- Update `data_disks` with minimal fields (regression for KeyError).
- Update `security_profile.uefi_settings.v_tpm_enabled` (regression for typo).
- Preserve-live-values baseline: create with distinctive values, tag-only update, read back and assert `capacity`, `overprovision`, `single_placement_group`, `vm_size`, `os_disk_caching` all unchanged.
- Update `upgrade_policy` Manual → Automatic and assert live-side flip.
- Update `data_disks` `disk_size_gb` 64 → 128 and assert live-side resize.
- Create Spot VMSS with `max_price=0.5`, then tag-only update — assert no false "not updatable" failure.
- Create without `subnet_name` — assert `failed` with clear message.

**Testing**

- `ansible-test sanity --python 3.10` on the module and integration test target passes clean.
- No CHANGELOG edits (per release-time convention).
- No new dependencies.

**Follow-up**

- Prerequisite for #117 (multi-NIC VMSS support) — a follow-up PR will build on this cleanup.
