### PR TITLE
Fix #2302: `azure_rm_privateendpoint_info` `AttributeError` on manual connections

### DIFF
--- a/plugins/modules/azure_rm_privateendpoint_info.py
+++ b/plugins/modules/azure_rm_privateendpoint_info.py
@@ -412,9 +412,9 @@ class AzureRMPrivateEndpointInfo(AzureRMModuleBase):
                 connection['name'] = connections.name
                 connection['type'] = connections.type
                 connection['group_ids'] = connections.group_ids
-                connection['connection_state']['status'] = connections.manual_private_link_service_connection_state.status
-                connection['connection_state']['description'] = connections.manual_private_link_service_connection_state.description
-                connection['connection_state']['actions_required'] = connections.manual_private_link_service_connection_state.actions_required
+                connection['connection_state']['status'] = connections.private_link_service_connection_state.status
+                connection['connection_state']['description'] = connections.private_link_service_connection_state.description
+                connection['connection_state']['actions_required'] = connections.private_link_service_connection_state.actions_required
                 results['manual_private_link_service_connections'].append(connection)
         if privateendpoint.ip_configurations:
             for item in privateendpoint.ip_configurations:

--- a/tests/integration/targets/azure_rm_privateendpoint/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_privateendpoint/tasks/main.yml
@@ -226,6 +226,20 @@
         that:
           - output is changed
 
+    - name: Get secondary private endpoint info (manual connections)
+      azure.azcollection.azure_rm_privateendpoint_info:
+        name: "privateendpoint{{ rpfx }}02"
+        resource_group: "{{ resource_group }}-privateendpoint"
+      register: manual_output
+
+    - name: Assert secondary private endpoint info exposes manual connection state
+      ansible.builtin.assert:
+        that:
+          - manual_output.privateendpoints[0].provisioning_state == "Succeeded"
+          - manual_output.privateendpoints[0].manual_private_link_service_connections | length == 1
+          - manual_output.privateendpoints[0].manual_private_link_service_connections[0].name == "privateEndpoints_test_name02"
+          - manual_output.privateendpoints[0].manual_private_link_service_connections[0].connection_state.status is defined
+
     - name: Create an application security group
       azure.azcollection.azure_rm_applicationsecuritygroup:
         resource_group: "{{ resource_group }}-privateendpoint"
@@ -238,7 +252,7 @@
         name: "app{{ rpfx }}"
       register: app_group_output
 
-    - name: Create third private endpoint with manual_private_link_service_connections parameters
+    - name: Create third private endpoint with application_security_groups and ip_configurations
       azure.azcollection.azure_rm_privateendpoint:
         name: "privateendpoint{{ rpfx }}03"
         resource_group: "{{ resource_group }}-privateendpoint"


### PR DESCRIPTION
##### SUMMARY
Fix #2302.

In `privateendpoints_to_dict()`, the branch that serializes manual connections referenced a non-existent SDK attribute `manual_private_link_service_connection_state`. The Azure SDK model `azure.mgmt.network.models.PrivateLinkServiceConnection` exposes the connection state as `private_link_service_connection_state` regardless of whether the connection was auto-approved or manual — the distinction is which parent list the connection lives in on the `PrivateEndpoint` resource. The auto-approved block a few lines above already used the correct attribute; the manual block was a copy-paste with the wrong name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_privateendpoint_info.py