### PR TITLE
Deprecate legacy `kind` values (`Storage`, `BlobStorage`) in `azure_rm_storageaccount`

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -85,7 +85,11 @@ options:
         description:
             - The kind of storage.
             - The C(FileStorage) and (BlockBlobStorage) only used when I(account_type=Premium_LRS) or I(account_type=Premium_ZRS).
-        default: 'Storage'
+            - C(Storage) (general-purpose v1) and C(BlobStorage) are legacy account kinds that Azure is retiring. Microsoft
+              is disabling creation of new legacy blob storage accounts in September 2026 and will fully retire both kinds
+              in October 2026 (any remaining accounts will be auto-migrated to C(StorageV2)). Use C(StorageV2) for all new
+              accounts.
+        default: 'StorageV2'
         type: str
         choices:
             - Storage
@@ -1022,7 +1026,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             state=dict(default='present', choices=['present', 'absent', 'failover']),
             force_delete_nonempty=dict(type='bool', default=False, aliases=['force']),
             tags=dict(type='dict'),
-            kind=dict(type='str', default='Storage', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
+            kind=dict(type='str', default='StorageV2', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
             access_tier=dict(type='str', choices=['Hot', 'Cool', 'Cold', 'Premium', 'Smart']),
             https_only=dict(type='bool'),
             minimum_tls_version=dict(type='str', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
@@ -1805,6 +1809,19 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
         if not self.access_tier and self.kind == 'BlobStorage':
             self.fail('Parameter error: access_tier required when creating a storage account of type BlobStorage.')
+
+        if self.kind in ('Storage', 'BlobStorage'):
+            self.module.deprecate(
+                "kind='{0}' is a legacy Azure storage account type. Microsoft is disabling creation of new "
+                "legacy blob storage accounts in September 2026 and fully retiring both 'Storage' "
+                "(general-purpose v1) and 'BlobStorage' accounts in October 2026, after which remaining "
+                "accounts will be auto-migrated to 'StorageV2'. Set kind='StorageV2' instead. See "
+                "https://learn.microsoft.com/en-us/azure/storage/common/legacy-blob-storage-account-migration-overview "
+                "and "
+                "https://learn.microsoft.com/en-us/azure/storage/common/general-purpose-version-1-account-migration-overview".format(self.kind),
+                version='4.0.0',
+                collection_name='azure.azcollection',
+            )
 
         self.check_name_availability()
         self.results['changed'] = True

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -1205,6 +1205,19 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
         if self.kind in ['FileStorage', 'BlockBlobStorage', ] and self.account_type not in ['Premium_LRS', 'Premium_ZRS']:
             self.fail("Parameter error: Storage account with {0} kind require account type is Premium_LRS or Premium_ZRS".format(self.kind))
+
+        if self.state == 'present' and self.kind in ('Storage', 'BlobStorage'):
+            self.module.deprecate(
+                "kind='{0}' is a legacy Azure storage account type. Microsoft is disabling creation of new "
+                "legacy blob storage accounts in September 2026 and fully retiring both 'Storage' "
+                "(general-purpose v1) and 'BlobStorage' accounts in October 2026, after which remaining "
+                "accounts will be auto-migrated to 'StorageV2'. Set kind='StorageV2' instead. See "
+                "https://learn.microsoft.com/en-us/azure/storage/common/legacy-blob-storage-account-migration-overview "
+                "and "
+                "https://learn.microsoft.com/en-us/azure/storage/common/general-purpose-version-1-account-migration-overview".format(self.kind),
+                version='4.0.0',
+                collection_name='azure.azcollection',
+            )
         self.account_dict = self.get_account()
 
         curr_identity = self.account_dict["identity"] if self.account_dict else None
@@ -1809,19 +1822,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
         if not self.access_tier and self.kind == 'BlobStorage':
             self.fail('Parameter error: access_tier required when creating a storage account of type BlobStorage.')
-
-        if self.kind in ('Storage', 'BlobStorage'):
-            self.module.deprecate(
-                "kind='{0}' is a legacy Azure storage account type. Microsoft is disabling creation of new "
-                "legacy blob storage accounts in September 2026 and fully retiring both 'Storage' "
-                "(general-purpose v1) and 'BlobStorage' accounts in October 2026, after which remaining "
-                "accounts will be auto-migrated to 'StorageV2'. Set kind='StorageV2' instead. See "
-                "https://learn.microsoft.com/en-us/azure/storage/common/legacy-blob-storage-account-migration-overview "
-                "and "
-                "https://learn.microsoft.com/en-us/azure/storage/common/general-purpose-version-1-account-migration-overview".format(self.kind),
-                version='4.0.0',
-                collection_name='azure.azcollection',
-            )
 
         self.check_name_availability()
         self.results['changed'] = True

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -317,7 +317,7 @@ storageaccounts:
                 - The kind of storage.
             returned: always
             type: str
-            sample: Storage
+            sample: StorageV2
         access_tier:
             description:
                 - The access tier for this storage account.

--- a/tests/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_resource/tasks/main.yml
@@ -129,7 +129,7 @@
         body:
           sku:
             name: Standard_GRS
-          kind: Storage
+          kind: StorageV2
           location: eastus
       register: output
 

--- a/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -84,7 +84,6 @@
           - defaults_output.state.name == storage_account_name_default
           - defaults_output.state.id is defined
           - defaults_output.state.https_only
-          - defaults_output.state.access_tier == None
           - defaults_output.state.allow_blob_public_access == false
           - defaults_output.state.minimum_tls_version == "TLS1_0"
 


### PR DESCRIPTION
##### SUMMARY
**FUTURE ACTION NEEDED:**
- Remove `Storage` and `BlobStorage` from `kind` argspec choices in v4.0.0

Microsoft is retiring the legacy Azure storage account kinds `Storage` (general-purpose v1) and `BlobStorage`. Creation of new legacy blob storage accounts is disabled in **September 2026**, and both kinds are fully retired in **October 2026** (remaining accounts are auto-migrated to `StorageV2`). This PR aligns `azure_rm_storageaccount` with the retirement timeline: it flips the argspec default from `Storage` to `StorageV2` (matching Azure CLI and Terraform `azurerm_storage_account`), emits `module.deprecate(...)` when a playbook explicitly passes a legacy kind, updates the documentation, and defuses one integration test that would otherwise hard-fail against Azure after Sep 2026.

##### COMPONENT NAME
plugins/modules/azure_rm_storageaccount.py

##### ADDITIONAL INFORMATION
- [Legacy Blob Storage account retirement overview](https://learn.microsoft.com/en-us/azure/storage/common/legacy-blob-storage-account-migration-overview) — Sep 2026 creation block, Oct 2026 full retirement; ARM query identifies affected `kind == "BlobStorage"` accounts.
- [GPv1 storage account retirement overview](https://learn.microsoft.com/en-us/azure/storage/common/general-purpose-version-1-account-migration-overview) — same timeline for `kind == "Storage"`.
- [Legacy Blob Storage retirement FAQ](https://learn.microsoft.com/en-us/azure/storage/common/legacy-blob-storage-account-migration-frequently-asked-questions)