### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -16,6 +16,8 @@ import traceback
 import json
 
 from os.path import expanduser
+import configparser
+import urllib.parse as urlparse
 
 from ansible.module_utils.basic import \
     AnsibleModule, missing_required_lib, env_fallback
@@ -24,8 +26,6 @@ try:
     from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION
 except Exception:
     ANSIBLE_VERSION = 'unknown'
-from ansible.module_utils.six.moves import configparser
-import ansible.module_utils.six.moves.urllib.parse as urlparse
 
 AZURE_COMMON_ARGS = dict(
     auth_source=dict(

--- a/plugins/modules/azure_rm_appgateway.py
+++ b/plugins/modules/azure_rm_appgateway.py
@@ -1601,10 +1601,10 @@ provisioning_state:
 import time
 from copy import deepcopy
 import json
+from collections.abc import MutableMapping
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
 from ansible.module_utils.common.dict_transformations import _snake_to_camel
-from ansible.module_utils.six.moves.collections_abc import MutableMapping
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -380,8 +380,9 @@ except Exception:
     # This is handled in azure_rm_common
     pass
 
+from urllib.parse import urlparse
+
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils.six.moves.urllib.parse import urlparse
 import re
 
 


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. The four uses in this collection are all stdlib re-exports:

```python
-from ansible.module_utils.six.moves import configparser
-import ansible.module_utils.six.moves.urllib.parse as urlparse
-from ansible.module_utils.six.moves.urllib.parse import urlparse
-from ansible.module_utils.six.moves.collections_abc import MutableMapping
+import configparser
+import urllib.parse as urlparse
+from urllib.parse import urlparse
+from collections.abc import MutableMapping
```

On Python 3 each of these resolves to the identical stdlib object, so `configparser.ConfigParser()`, `urlparse.urlparse()` and `isinstance(item, MutableMapping)` behave exactly as before. This collection requires ansible-core 2.16+ and Python 3.10+, so no supported configuration is affected.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

azure_rm_common, azure_rm_appgateway, azure_rm_virtualmachine_info
