### PR TITLE
Fix azure_rm_appconfigurationkey JSONDecodeError on missing setting

### DIFF
--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -305,8 +305,13 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
             return response.as_dict()
         except ResourceNotFoundError:
             return False
+        except json.JSONDecodeError:
+            # SDK bug: when the service returns 404 with an empty body, the SDK
+            # attempts to deserialize the empty body into an Error model via
+            # response.json(), which raises JSONDecodeError instead of the
+            # expected ResourceNotFoundError. Treat it as "not found".
+            return False
         except Exception as e:
-            # Catch SDK bug: empty response causes JSONDecodeError
             self.fail("Failed to retrieve setting '{}': {}\n{}".format(self.key, str(e), traceback.format_exc()))
 
     def upsert_setting(self):

--- a/plugins/modules/azure_rm_appconfigurationkey.py
+++ b/plugins/modules/azure_rm_appconfigurationkey.py
@@ -306,12 +306,9 @@ class AzureRMAppConfigurationKey(AzureRMModuleBaseExt):
         except ResourceNotFoundError:
             return False
         except json.JSONDecodeError:
-            # SDK bug: when the service returns 404 with an empty body, the SDK
-            # attempts to deserialize the empty body into an Error model via
-            # response.json(), which raises JSONDecodeError instead of the
-            # expected ResourceNotFoundError. Treat it as "not found".
             return False
         except Exception as e:
+            # Catch SDK bug: empty response causes JSONDecodeError
             self.fail("Failed to retrieve setting '{}': {}\n{}".format(self.key, str(e), traceback.format_exc()))
 
     def upsert_setting(self):


### PR DESCRIPTION
##### SUMMARY
Fix `azure_rm_appconfigurationkey` `JSONDecodeError` on missing setting.

When a configuration setting does not yet exist, the App Configuration service returns a 404 with an empty response body. The `azure-sdk-for-python` `appconfiguration` client then attempts to deserialize the empty body into an Error model via `response.json()`, which raises `json.JSONDecodeError` instead of the expected `ResourceNotFoundError`.

Error message [here](https://dev.azure.com/azclitools/internal/_build/results?buildId=332338&view=logs&j=00551f6a-46d3-510b-a317-a4e7dd476f75&t=d43d64e2-87d3-5f8e-c59c-e74def556520&l=1323)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_appconfigurationkey.py
