### PR TITLE
Fix Ruff CPY001 failure on EDA event source plugins

### DIFF
--- a/extensions/eda/plugins/event_source/azure_event_hub.py
+++ b/extensions/eda/plugins/event_source/azure_event_hub.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Red Hat, Inc.
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """Ansible-rulebook event source plugin for Azure Event Hub.
 
 This module provides asynchronous consumers for Azure Event Hub to feed

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Red Hat, Inc.
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """Ansible-rulebook event source plugin for Azure Service Bus.
 
 This module provides asynchronous consumers for Azure Service Bus to feed


### PR DESCRIPTION
##### SUMMARY
The "Ruff Check for EDA plugins" job in `.github/workflows/extra_ci.yml` runs `ruff check --select ALL` with an unpinned ruff. A recent ruff release promoted the flake8-copyright rule (CPY001) into ALL, causing the job to fail on two pre-existing EDA plugin files that lack a copyright header:
````
  extensions/eda/plugins/event_source/azure_event_hub.py
  extensions/eda/plugins/event_source/azure_service_bus.py
````

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
extensions/eda/plugins/event_source/azure_event_hub.py
extensions/eda/plugins/event_source/azure_service_bus.py