### PR TITLE
Test fix: Fix tests that hit capacity constraint

### DIFF
--- a/tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml
@@ -29,7 +29,7 @@
         auto_replace_on_failure: false
         license_type: 'None'
         sku:
-          name: "DCSv2-Type1"
+          name: "DSv3-Type1"
         tags:
           key1: value1
       check_mode: true
@@ -49,7 +49,7 @@
         auto_replace_on_failure: false
         license_type: 'None'
         sku:
-          name: "DCSv2-Type1"
+          name: "DSv3-Type1"
         tags:
           key1: value1
       register: output
@@ -67,7 +67,7 @@
         platform_fault_domain: 0
         auto_replace_on_failure: false
         sku:
-          name: "DCSv2-Type1"
+          name: "DSv3-Type1"
         tags:
           key1: value1
       register: output
@@ -86,7 +86,7 @@
         auto_replace_on_failure: true
         license_type: Windows_Server_Hybrid
         sku:
-          name: "DCSv2-Type1"
+          name: "DSv3-Type1"
         tags:
           key2: value2
       register: output

--- a/tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Creat a new resource group for dedicated host test
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}-dhost"
-    location: eastus
+    location: australiaeast
 
 - name: For dedicated host test
   block:
@@ -13,9 +13,9 @@
       azure.azcollection.azure_rm_hostgroup:
         resource_group: "{{ resource_group }}-dhost"
         name: "group{{ rpfx }}"
-        location: eastus
+        location: australiaeast
         zones:
-          - "2"
+          - "1"
         platform_fault_domain_count: 1
         state: present
       register: results

--- a/tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml
@@ -15,7 +15,7 @@
         name: "group{{ rpfx }}"
         location: eastus
         zones:
-          - "1"
+          - "2"
         platform_fault_domain_count: 1
         state: present
       register: results


### PR DESCRIPTION
##### SUMMARY
Fix following test errors:

1. azure_rm_dedicatedhost
```
Error creating or updating host hosteae8cxxxxx - (ZonalAllocationFailed) Allocation failed. We do not have sufficient capacity for the requested host SKU in this zone.
```

##### ISSUE TYPE
- Test Fix Pull Request

##### COMPONENT NAME
tests/integration/targets/azure_rm_dedicatedhost/tasks/main.yml