### PR TITLE
Fixe extensions type for azure_rm_monitordatacollectionrules

### DIFF
--- a/plugins/modules/azure_rm_monitordatacollectionrules.py
+++ b/plugins/modules/azure_rm_monitordatacollectionrules.py
@@ -195,12 +195,11 @@ options:
                     extension_name:
                         description:
                             - The name of the VM extension.
-                        type: list
-                        elements: str
+                        type: str
                     extension_settings:
                         description:
                             - The extension settings. The format is specific for particular extension.
-                        type: str
+                        type: dict
                     input_data_sources:
                         description:
                             - The list of data sources this extension needs data from.
@@ -749,8 +748,8 @@ data_sources_spec_syslog_options = dict(
 
 data_sources_spec_extensions_options = dict(
     streams=dict(type='list', elements='str'),
-    extension_name=dict(type='list', elements='str'),
-    extension_settings=dict(type='str'),
+    extension_name=dict(type='str'),
+    extension_settings=dict(type='dict'),
     input_data_sources=dict(type='list', elements='str'),
     name=dict(type='str')
 )

--- a/tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loganalyticsworkspace/tasks/main.yml
@@ -855,6 +855,145 @@
         that:
           - output is changed
 
+    - name: Create data collection rule for Container Insights
+      azure.azcollection.azure_rm_monitordatacollectionrules:
+        name: "{{ name_rpfx }}-DCR-Insights"
+        resource_group: "{{ resource_group }}-loganalyticsworkspace"
+        location: "{{ location }}"
+        kind: Linux
+        data_sources:
+          extensions:
+            - name: ContainerInsightsExtension
+              extension_name: ContainerInsights
+              streams:
+                - Microsoft-ContainerLogV2
+                - Microsoft-KubeEvents
+                - Microsoft-KubePodInventory
+                - Microsoft-KubeNodeInventory
+                - Microsoft-KubeServices
+                - Microsoft-KubePVInventory
+                - Microsoft-Perf
+                - Microsoft-KubeMonAgentEvents
+              extension_settings:
+                dataCollectionSettings:
+                  enableContainerLogV2: true
+                  interval: 1m
+                  namespaceFilteringMode: Exclude
+                  namespaces:
+                    - kube-system
+                    - gatekeeper-system
+                    - azure-arc
+                  streams:
+                    - Microsoft-ContainerLogV2
+                    - Microsoft-KubeEvents
+                    - Microsoft-KubePodInventory
+                    - Microsoft-KubeNodeInventory
+                    - Microsoft-KubeServices
+                    - Microsoft-KubePVInventory
+                    - Microsoft-Perf
+                    - Microsoft-KubeMonAgentEvents
+        destinations:
+          log_analytics:
+            - workspace_resource_id: "{{ log_analytics_workspace_output.id }}"
+              name: "{{ log_analytics_workspace_output.name }}"
+        data_flows:
+          - streams:
+              - Microsoft-ContainerLogV2
+              - Microsoft-KubeEvents
+              - Microsoft-KubePodInventory
+              - Microsoft-KubeNodeInventory
+              - Microsoft-KubeServices
+              - Microsoft-KubePVInventory
+              - Microsoft-Perf
+              - Microsoft-KubeMonAgentEvents
+            destinations:
+              - "{{ log_analytics_workspace_output.name }}"
+      register: output
+
+    - name: Assert the data collection rule for Container Insights is created
+      ansible.builtin.assert:
+        that:
+          - output is changed
+          - src_ext | length == 1
+          - src_ext[0].name == 'ContainerInsightsExtension'
+          - src_ext[0].extension_name == 'ContainerInsights'
+          - src_ext[0].streams | length == 8
+          - src_ext[0].extension_settings.dataCollectionSettings.enableContainerLogV2 == true
+      vars:
+        src_ext: "{{ output.datacollectionrule.data_sources.extensions | d([]) }}"
+
+    - name: Update data collection rule for Container Insights (Idempotence)
+      azure.azcollection.azure_rm_monitordatacollectionrules:
+        name: "{{ name_rpfx }}-DCR-Insights"
+        resource_group: "{{ resource_group }}-loganalyticsworkspace"
+        location: "{{ location }}"
+        kind: Linux
+        data_sources:
+          extensions:
+            - name: ContainerInsightsExtension
+              extension_name: ContainerInsights
+              streams:
+                - Microsoft-ContainerLogV2
+                - Microsoft-KubeEvents
+                - Microsoft-KubePodInventory
+                - Microsoft-KubeNodeInventory
+                - Microsoft-KubeServices
+                - Microsoft-KubePVInventory
+                - Microsoft-Perf
+                - Microsoft-KubeMonAgentEvents
+              extension_settings:
+                dataCollectionSettings:
+                  enableContainerLogV2: true
+                  interval: 1m
+                  namespaceFilteringMode: Exclude
+                  namespaces:
+                    - kube-system
+                    - gatekeeper-system
+                    - azure-arc
+                  streams:
+                    - Microsoft-ContainerLogV2
+                    - Microsoft-KubeEvents
+                    - Microsoft-KubePodInventory
+                    - Microsoft-KubeNodeInventory
+                    - Microsoft-KubeServices
+                    - Microsoft-KubePVInventory
+                    - Microsoft-Perf
+                    - Microsoft-KubeMonAgentEvents
+        destinations:
+          log_analytics:
+            - workspace_resource_id: "{{ log_analytics_workspace_output.id }}"
+              name: "{{ log_analytics_workspace_output.name }}"
+        data_flows:
+          - streams:
+              - Microsoft-ContainerLogV2
+              - Microsoft-KubeEvents
+              - Microsoft-KubePodInventory
+              - Microsoft-KubeNodeInventory
+              - Microsoft-KubeServices
+              - Microsoft-KubePVInventory
+              - Microsoft-Perf
+              - Microsoft-KubeMonAgentEvents
+            destinations:
+              - "{{ log_analytics_workspace_output.name }}"
+      register: output
+
+    - name: Assert the data collection rule for Container Insights is idempotence
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Remove data collection rule for Container Insights
+      azure.azcollection.azure_rm_monitordatacollectionrules:
+        name: "{{ name_rpfx }}-DCR-Insights"
+        resource_group: "{{ resource_group }}-loganalyticsworkspace"
+        state: absent
+      register: output
+
+    - name: Assert the data collection rule for Container Insights is changed
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
     - name: Remove Log Analytics workspace (Check Mode On)
       azure.azcollection.azure_rm_loganalyticsworkspace:
         name: "{{ name_rpfx }}"


### PR DESCRIPTION
##### SUMMARY

This PR fixes the argument specification for the `azure_rm_monitordatacollectionrules` module.

The following argument types have been corrected to match the Azure REST API and SDK model:

- `extension_name`
  - **Before:** `list[str]`
  - **After:** `str`
- `extension_settings`
  - **Before:** `str`
  - **After:** `dict`

The previous argument types generated an invalid request payload when creating or updating Data Collection Rules with extension data sources, causing the Azure service to reject the request.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

azure_rm_monitordatacollectionrules

##### ADDITIONAL INFORMATION

Before this change, using an extension data source with `extension_name` and `extension_settings` resulted in the following Azure API error:

```text
Code: InvalidProperty
Message: Resource payload is missing or invalid.
```

The issue was caused by incorrect argument types in the module specification:

| Argument | Previous type | Correct type |
|----------|---------------|--------------|
| `extension_name` | `list[str]` | `str` |
| `extension_settings` | `str` | `dict` |

After this change, the generated request payload matches the Azure SDK model and Data Collection Rules containing extension data sources can be created successfully.