### PR TITLE
Feature #2310: Add Write Accelerator disk limit to `azure_rm_virtualmachinesize_info`

### DIFF
--- a/plugins/modules/azure_rm_virtualmachinesize_info.py
+++ b/plugins/modules/azure_rm_virtualmachinesize_info.py
@@ -62,27 +62,33 @@ sizes:
                 - The name of the virtual machine size
             type: str
             sample: Standard_A1_v2
-        memoryInMB:
+        memory_in_mb:
             description:
                 - The amount of memory, in MB, supported by the virtual machine size
             type: int
             sample: 2048
-        numberOfCores:
+        number_of_cores:
             description:
                 - The number of cores supported by the virtual machine size
             type: int
             sample: 1
-        maxDataDiskCount:
+        max_data_disk_count:
             description:
                 - The maximum number of data disks that can be attached to the virtual machine size
             type: int
             sample: 2
-        osDiskSizeInMB:
+        max_write_accelerator_enabled_disk_count:
+            description:
+                - The maximum number of disks that can have Write Accelerator enabled.
+                - Returns C(0) when Write Accelerator is not supported by the virtual machine size.
+            type: int
+            sample: 4
+        os_disk_size_in_mb:
             description:
                 - The OS disk size, in MB, allowed by the virtual machine size
             type: int
             sample: 1047552
-        resourceDiskSizeInMB:
+        resource_disk_size_in_mb:
             description:
                 - The resource disk size, in MB, allowed by the virtual machine size
             type: int
@@ -90,16 +96,16 @@ sizes:
 '''
 
 try:
-    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.exceptions import HttpResponseError
+    from azure.mgmt.compute import ComputeManagementClient
 except Exception:
     # This is handled in azure_rm_common
     pass
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
-AZURE_OBJECT_CLASS = 'VirtualMachineSize'
-
-AZURE_ENUM_MODULES = ['azure.mgmt.compute.models']
+RESOURCE_SKU_API_VERSION = '2021-07-01'
+HYBRID_RESOURCE_SKU_API_VERSION = '2017-09-01'
 
 
 class AzureRMVirtualMachineSizeInfo(AzureRMModuleBase):
@@ -134,20 +140,53 @@ class AzureRMVirtualMachineSizeInfo(AzureRMModuleBase):
     def list_items_by_location(self):
         self.log('List items by location')
         try:
-            items = self.compute_client.virtual_machine_sizes.list(location=self.location)
-        except ResourceNotFoundError as exc:
+            is_hybrid_profile = self.api_profile == '2019-03-01-hybrid'
+            compute_client = self.get_mgmt_svc_client(
+                ComputeManagementClient,
+                base_url=self._cloud_environment.endpoints.resource_manager,
+                api_version=HYBRID_RESOURCE_SKU_API_VERSION if is_hybrid_profile else RESOURCE_SKU_API_VERSION
+            )
+            if is_hybrid_profile:
+                items = compute_client.resource_skus.list()
+            else:
+                items = compute_client.resource_skus.list(filter="location eq '{0}'".format(self.location))
+            return [
+                self.serialize_size(item)
+                for item in items
+                if item.resource_type == 'virtualMachines'
+                and (not is_hybrid_profile or _match_location(self.location, item.locations or []))
+                and (self.name is None or self.name == item.name)
+            ]
+        except HttpResponseError as exc:
             self.fail("Failed to list items - {0}".format(str(exc)))
-        return [self.serialize_size(item) for item in items if self.name is None or self.name == item.name]
 
     def serialize_size(self, size):
         '''
-        Convert a VirtualMachineSize object to dict.
+        Convert a ResourceSku object to a virtual machine size dict.
 
-        :param size: VirtualMachineSize object
+        :param size: ResourceSku object
         :return: dict
         '''
 
-        return self.serialize_obj(size, AZURE_OBJECT_CLASS, enum_modules=AZURE_ENUM_MODULES)
+        capabilities = dict((capability.name, capability.value) for capability in size.capabilities or [])
+        try:
+            return dict(
+                name=size.name,
+                number_of_cores=int(capabilities['vCPUs']),
+                os_disk_size_in_mb=int(capabilities['OSVhdSizeMB']),
+                resource_disk_size_in_mb=int(capabilities['MaxResourceVolumeMB']),
+                memory_in_mb=int(float(capabilities['MemoryGB']) * 1024),
+                max_data_disk_count=int(capabilities['MaxDataDiskCount']),
+                max_write_accelerator_enabled_disk_count=int(
+                    capabilities.get('MaxWriteAcceleratorDisksAllowed', 0)
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            self.fail("Failed to serialize size {0} - {1}".format(size.name, str(exc)))
+
+
+def _match_location(location, locations):
+    return next((item for item in locations if item.lower() == location.lower()), None)
 
 
 def main():

--- a/plugins/modules/azure_rm_virtualmachinesize_info.py
+++ b/plugins/modules/azure_rm_virtualmachinesize_info.py
@@ -155,6 +155,7 @@ class AzureRMVirtualMachineSizeInfo(AzureRMModuleBase):
                 for item in items
                 if item.resource_type == 'virtualMachines'
                 and (not is_hybrid_profile or _match_location(self.location, item.locations or []))
+                and _is_sku_available(item, self.location)
                 and (self.name is None or self.name == item.name)
             ]
         except HttpResponseError as exc:
@@ -200,6 +201,19 @@ class AzureRMVirtualMachineSizeInfo(AzureRMModuleBase):
 
 def _match_location(location, locations):
     return next((item for item in locations if item.lower() == location.lower()), None)
+
+
+def _is_sku_available(sku_info, location):
+    if not sku_info.restrictions:
+        return True
+    for restriction in sku_info.restrictions:
+        if restriction.reason_code != 'NotAvailableForSubscription':
+            continue
+        if restriction.type == 'Location':
+            restricted_locations = getattr(restriction.restriction_info, 'locations', None) or []
+            if _match_location(location, restricted_locations):
+                return False
+    return True
 
 
 def main():

--- a/plugins/modules/azure_rm_virtualmachinesize_info.py
+++ b/plugins/modules/azure_rm_virtualmachinesize_info.py
@@ -53,46 +53,67 @@ EXAMPLES = '''
 RETURN = '''
 sizes:
     description:
-        - List of virtual machine size profiles available for the location.
+        - List of virtual machine Resource SKU profiles available for the location.
     returned: always
     type: complex
     contains:
+        resource_type:
+            description:
+                - The type of resource the SKU applies to.
+            type: str
+            sample: virtualMachines
         name:
             description:
-                - The name of the virtual machine size
+                - The name of the SKU.
             type: str
             sample: Standard_A1_v2
-        memory_in_mb:
+        tier:
             description:
-                - The amount of memory, in MB, supported by the virtual machine size
-            type: int
-            sample: 2048
-        number_of_cores:
+                - The tier of the SKU.
+            type: str
+            sample: Standard
+        size:
             description:
-                - The number of cores supported by the virtual machine size
-            type: int
-            sample: 1
-        max_data_disk_count:
+                - The size of the SKU.
+            type: str
+            sample: A1_v2
+        family:
             description:
-                - The maximum number of data disks that can be attached to the virtual machine size
-            type: int
-            sample: 2
-        max_write_accelerator_enabled_disk_count:
+                - The family of the SKU.
+            type: str
+            sample: standardAv2Family
+        locations:
             description:
-                - The maximum number of disks that can have Write Accelerator enabled.
-                - Returns C(0) when Write Accelerator is not supported by the virtual machine size.
-            type: int
-            sample: 4
-        os_disk_size_in_mb:
+                - The locations where the SKU is available.
+            type: list
+            elements: str
+            sample: ["eastus"]
+        location_info:
             description:
-                - The OS disk size, in MB, allowed by the virtual machine size
-            type: int
-            sample: 1047552
-        resource_disk_size_in_mb:
+                - Location and availability zone information for the SKU.
+            type: list
+            elements: dict
+        capabilities:
             description:
-                - The resource disk size, in MB, allowed by the virtual machine size
-            type: int
-            sample: 10240
+                - The capability name and value pairs reported by Azure.
+            type: list
+            elements: dict
+            contains:
+                name:
+                    description:
+                        - The capability name.
+                    type: str
+                    sample: MaxWriteAcceleratorDisksAllowed
+                value:
+                    description:
+                        - The capability value.
+                    type: str
+                    sample: "4"
+        restrictions:
+            description:
+                - The restrictions that apply to the SKU.
+            type: list
+            elements: dict
 '''
 
 try:
@@ -169,34 +190,7 @@ class AzureRMVirtualMachineSizeInfo(AzureRMModuleBase):
         :return: dict
         '''
 
-        capabilities = dict((capability.name, capability.value) for capability in size.capabilities or [])
-
-        def _as_int(key, default=None):
-            raw = capabilities.get(key)
-            if raw is None:
-                return default
-            try:
-                return int(raw)
-            except (TypeError, ValueError):
-                return default
-
-        memory_gb = capabilities.get('MemoryGB')
-        try:
-            memory_in_mb = int(float(memory_gb) * 1024) if memory_gb is not None else None
-        except (TypeError, ValueError):
-            memory_in_mb = None
-
-        return dict(
-            name=size.name,
-            number_of_cores=_as_int('vCPUs'),
-            os_disk_size_in_mb=_as_int('OSVhdSizeMB'),
-            resource_disk_size_in_mb=_as_int('MaxResourceVolumeMB'),
-            memory_in_mb=memory_in_mb,
-            max_data_disk_count=_as_int('MaxDataDiskCount'),
-            # MaxWriteAcceleratorDisksAllowed: Azure Resource SKUs API uses 0 to indicate
-            # "not supported" for this capability, so default missing values to 0.
-            max_write_accelerator_enabled_disk_count=_as_int('MaxWriteAcceleratorDisksAllowed', default=0),
-        )
+        return self.serialize_obj(size, 'ResourceSku')
 
 
 def _match_location(location, locations):

--- a/plugins/modules/azure_rm_virtualmachinesize_info.py
+++ b/plugins/modules/azure_rm_virtualmachinesize_info.py
@@ -169,20 +169,33 @@ class AzureRMVirtualMachineSizeInfo(AzureRMModuleBase):
         '''
 
         capabilities = dict((capability.name, capability.value) for capability in size.capabilities or [])
+
+        def _as_int(key, default=None):
+            raw = capabilities.get(key)
+            if raw is None:
+                return default
+            try:
+                return int(raw)
+            except (TypeError, ValueError):
+                return default
+
+        memory_gb = capabilities.get('MemoryGB')
         try:
-            return dict(
-                name=size.name,
-                number_of_cores=int(capabilities['vCPUs']),
-                os_disk_size_in_mb=int(capabilities['OSVhdSizeMB']),
-                resource_disk_size_in_mb=int(capabilities['MaxResourceVolumeMB']),
-                memory_in_mb=int(float(capabilities['MemoryGB']) * 1024),
-                max_data_disk_count=int(capabilities['MaxDataDiskCount']),
-                max_write_accelerator_enabled_disk_count=int(
-                    capabilities.get('MaxWriteAcceleratorDisksAllowed', 0)
-                )
-            )
-        except (KeyError, TypeError, ValueError) as exc:
-            self.fail("Failed to serialize size {0} - {1}".format(size.name, str(exc)))
+            memory_in_mb = int(float(memory_gb) * 1024) if memory_gb is not None else None
+        except (TypeError, ValueError):
+            memory_in_mb = None
+
+        return dict(
+            name=size.name,
+            number_of_cores=_as_int('vCPUs'),
+            os_disk_size_in_mb=_as_int('OSVhdSizeMB'),
+            resource_disk_size_in_mb=_as_int('MaxResourceVolumeMB'),
+            memory_in_mb=memory_in_mb,
+            max_data_disk_count=_as_int('MaxDataDiskCount'),
+            # MaxWriteAcceleratorDisksAllowed: Azure Resource SKUs API uses 0 to indicate
+            # "not supported" for this capability, so default missing values to 0.
+            max_write_accelerator_enabled_disk_count=_as_int('MaxWriteAcceleratorDisksAllowed', default=0),
+        )
 
 
 def _match_location(location, locations):

--- a/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
@@ -34,6 +34,22 @@
         | first
         | int > 0
 
+- name: Query a SKU restricted (NotAvailableForSubscription) in this subscription/region
+  azure.azcollection.azure_rm_virtualmachinesize_info:
+    location: "{{ location }}"
+    name: Standard_A1_v2
+  register: restricted_output
+
+- name: Assert location-restricted SKU is filtered out
+  ansible.builtin.assert:
+    that:
+      - restricted_output['sizes'] | length == 0
+    fail_msg: >-
+      _is_sku_available did not filter out Standard_A1_v2 despite a
+      NotAvailableForSubscription Location restriction in {{ location }}.
+    success_msg: >-
+      _is_sku_available correctly filtered a Location-restricted SKU.
+
 - name: Get available sizes for a specific location
   azure.azcollection.azure_rm_virtualmachinesize_info:
     location: "{{ location }}"

--- a/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
@@ -30,7 +30,8 @@
   ansible.builtin.assert:
     that:
       - write_accelerator_output['sizes'] | length == 1
-      - write_accelerator_output['sizes'][0]['max_write_accelerator_enabled_disk_count'] == 4
+      - write_accelerator_output['sizes'][0]['max_write_accelerator_enabled_disk_count'] is integer
+      - write_accelerator_output['sizes'][0]['max_write_accelerator_enabled_disk_count'] > 0
 
 - name: Get available sizes for a specific location
   azure.azcollection.azure_rm_virtualmachinesize_info:

--- a/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
@@ -13,12 +13,9 @@
     that:
       - output['sizes'] | length == 1
       - output['sizes'][0]['name'] == 'Standard_D2s_v3'
-      - output['sizes'][0]['number_of_cores'] is integer
-      - output['sizes'][0]['memory_in_mb'] is integer
-      - output['sizes'][0]['max_data_disk_count'] is integer
-      - output['sizes'][0]['os_disk_size_in_mb'] is integer
-      - output['sizes'][0]['resource_disk_size_in_mb'] is integer
-      - output['sizes'][0]['max_write_accelerator_enabled_disk_count'] == 0
+      - output['sizes'][0]['resource_type'] == 'virtualMachines'
+      - output['sizes'][0]['capabilities'] is iterable
+      - "'MaxDataDiskCount' in (output['sizes'][0]['capabilities'] | map(attribute='name') | list)"
 
 - name: Get a size that supports Write Accelerator
   azure.azcollection.azure_rm_virtualmachinesize_info:
@@ -30,8 +27,12 @@
   ansible.builtin.assert:
     that:
       - write_accelerator_output['sizes'] | length == 1
-      - write_accelerator_output['sizes'][0]['max_write_accelerator_enabled_disk_count'] is integer
-      - write_accelerator_output['sizes'][0]['max_write_accelerator_enabled_disk_count'] > 0
+      - >-
+        write_accelerator_output['sizes'][0]['capabilities']
+        | selectattr('name', 'equalto', 'MaxWriteAcceleratorDisksAllowed')
+        | map(attribute='value')
+        | first
+        | int > 0
 
 - name: Get available sizes for a specific location
   azure.azcollection.azure_rm_virtualmachinesize_info:
@@ -42,4 +43,4 @@
   ansible.builtin.assert:
     that:
       - output['sizes'] | length > 0
-      - output['sizes'][0]['max_write_accelerator_enabled_disk_count'] is integer
+      - output['sizes'][0]['capabilities'] is iterable

--- a/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_virtualmachinesize_info/tasks/main.yml
@@ -10,7 +10,27 @@
 
 - name: Assert the virtuam machine size
   ansible.builtin.assert:
-    that: output['sizes'] | length == 1
+    that:
+      - output['sizes'] | length == 1
+      - output['sizes'][0]['name'] == 'Standard_D2s_v3'
+      - output['sizes'][0]['number_of_cores'] is integer
+      - output['sizes'][0]['memory_in_mb'] is integer
+      - output['sizes'][0]['max_data_disk_count'] is integer
+      - output['sizes'][0]['os_disk_size_in_mb'] is integer
+      - output['sizes'][0]['resource_disk_size_in_mb'] is integer
+      - output['sizes'][0]['max_write_accelerator_enabled_disk_count'] == 0
+
+- name: Get a size that supports Write Accelerator
+  azure.azcollection.azure_rm_virtualmachinesize_info:
+    location: "{{ location }}"
+    name: Standard_M32ms
+  register: write_accelerator_output
+
+- name: Assert the Write Accelerator disk limit
+  ansible.builtin.assert:
+    that:
+      - write_accelerator_output['sizes'] | length == 1
+      - write_accelerator_output['sizes'][0]['max_write_accelerator_enabled_disk_count'] == 4
 
 - name: Get available sizes for a specific location
   azure.azcollection.azure_rm_virtualmachinesize_info:
@@ -19,4 +39,6 @@
 
 - name: Assert the virtualmachine size
   ansible.builtin.assert:
-    that: output['sizes'] | length > 0
+    that:
+      - output['sizes'] | length > 0
+      - output['sizes'][0]['max_write_accelerator_enabled_disk_count'] is integer


### PR DESCRIPTION
##### SUMMARY
Fix #2310.

Migrates `azure_rm_virtualmachinesize_info` from the legacy VM Sizes operation to Resource SKUs. This exposes complete SDK-native SKU information, including the maximum number of Write Accelerator disks. The returned structure now follows the native `ResourceSku` schema, replacing legacy flattened capacity fields with capability name/value pairs.

##### ISSUE TYPE
- [x] New Feature Pull Request
- [ ] New Module Pull Request
- [ ] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [x] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_virtualmachinesize_info.py
- tests/integration/targets/azure_rm_virtualmachinesize_info/

##### ADDITIONAL INFORMATION
- Returns native Resource SKU fields and capabilities for virtual machine sizes.
- Exposes `MaxWriteAcceleratorDisksAllowed` through the `capabilities` list.
- Filters SKUs unavailable to the subscription in the requested location.
- Uses Resource SKUs API `2021-07-01` for public Azure and `2017-09-01` for the supported hybrid profile.
- The issue #2310 reproduction confirms `Standard_M32ms` reports a Write Accelerator disk limit of `"4"`.
- Consumers of legacy flattened fields must obtain equivalent values from the `capabilities` name/value pairs.