### PR TITLE
4.0.0 Removal: `azure_rm_cosmosdbaccount*` remove deprecated `ip_range_filter`

### DIFF
--- a/plugins/modules/azure_rm_cosmosdbaccount.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount.py
@@ -96,13 +96,6 @@ options:
         type: bool
         default: false
         version_added: "1.10.0"
-    ip_range_filter:
-        description:
-            - (deprecated) Cosmos DB Firewall support. This value specifies the set of IP addresses or IP address ranges.
-            - In CIDR form to be included as the allowed list of client IPs for a given database account.
-            - IP addresses/ranges must be comma separated and must not contain any spaces.
-            - This value has been deprecated, and will be removed in a later version. Use I(ip_rules) instead.
-        type: str
     ip_rules:
         description:
             - The IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs.
@@ -314,9 +307,6 @@ class AzureRMCosmosDBAccount(AzureRMModuleBaseExt):
                 type='bool',
                 default=False,
             ),
-            ip_range_filter=dict(
-                type='str'
-            ),
             ip_rules=dict(
                 type='list',
                 elements='str',
@@ -415,12 +405,8 @@ class AzureRMCosmosDBAccount(AzureRMModuleBaseExt):
         elif kind == 'parse':
             self.parameters['kind'] = 'Parse'
 
-        ip_range_filter = self.parameters.pop('ip_range_filter', None)
         ip_rules = self.parameters.pop('ip_rules', [])
-        if ip_range_filter:
-            self.parameters['ip_rules'] = [{"ip_address_or_range": ip} for ip in ip_range_filter.split(",")]
         if ip_rules:
-            # overrides deprecated 'ip_range_filter' parameter
             self.parameters['ip_rules'] = [{"ip_address_or_range": ip} for ip in ip_rules]
 
         dict_camelize(self.parameters, ['consistency_policy', 'default_consistency_level'], True)

--- a/plugins/modules/azure_rm_cosmosdbaccount_info.py
+++ b/plugins/modules/azure_rm_cosmosdbaccount_info.py
@@ -234,13 +234,6 @@ accounts:
             type: bool
             sample: true
             version_added: "1.10.0"
-        ip_range_filter:
-            description:
-                - (deprecated) Enabled IP range filter.
-                - This value has been deprecated, and will be removed in a later version. Use c(ip_rules) instead.
-            returned: always
-            type: str
-            sample: 10.10.10.10
         ip_rules:
             description:
                 - The IP addresses or IP address ranges in CIDR form included as the allowed list of client IPs.
@@ -511,7 +504,6 @@ class AzureRMCosmosDBAccountInfo(AzureRMModuleBase):
             'database_account_offer_type': d.get('database_account_offer_type'),
             'enable_free_tier': d.get('enable_free_tier'),
             'ip_rules': [ip['ip_address_or_range'] for ip in d.get('ip_rules', [])],
-            'ip_range_filter': ",".join([ip['ip_address_or_range'] for ip in d.get('ip_rules', [])]),
             'is_virtual_network_filter_enabled': d.get('is_virtual_network_filter_enabled'),
             'enable_automatic_failover': d.get('enable_automatic_failover'),
             'enable_cassandra': 'EnableCassandra' in d.get('capabilities', []),

--- a/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_cosmosdbaccount/tasks/main.yml
@@ -279,7 +279,6 @@
           - output.accounts[0]['read_locations'] != None
           - output.accounts[0]['write_locations'] != None
           - output.accounts[0]['database_account_offer_type'] != None
-          - output.accounts[0]['ip_range_filter'] != None
           - output.accounts[0]['ip_rules'] != None
           - output.accounts[0]['is_virtual_network_filter_enabled'] != None
           - output.accounts[0]['enable_automatic_failover'] != None
@@ -365,7 +364,6 @@
           - output.accounts[0]['read_locations'] != None
           - output.accounts[0]['write_locations'] != None
           - output.accounts[0]['database_account_offer_type'] != None
-          - output.accounts[0]['ip_range_filter'] != None
           - output.accounts[0]['ip_rules'] != None
           - output.accounts[0]['is_virtual_network_filter_enabled'] != None
           - output.accounts[0]['enable_automatic_failover'] != None
@@ -439,7 +437,6 @@
           - output.accounts[0]['mongo_version'] == '4.0'
           - output.accounts[0]['enable_free_tier'] == free_tier_supported
           - output.accounts[0]['public_network_access'] == 'Disabled'
-          - output.accounts[0]['ip_range_filter'] == '1.1.1.1,2.2.2.2/28'
           - (output.accounts[0]['ip_rules'] | length) == 2
           - output.accounts[0]['ip_rules'][0] == '1.1.1.1'
           - output.accounts[0]['ip_rules'][1] == '2.2.2.2/28'


### PR DESCRIPTION
##### SUMMARY
Part of the 4.0.0 deprecation removal sweep. Removes the long-deprecated `ip_range_filter` option from `azure_rm_cosmosdbaccount` (and the corresponding key from `azure_rm_cosmosdbaccount_info`'s return shape), in favor of the SDK-native `ip_rules` option.

`ip_range_filter` was deprecated in **1.10.0 (2021)** with `ip_rules` shipped as the direct replacement; the module has been silently rewriting `ip_range_filter` -> `ip_rules` ever since.

##### ISSUE TYPE
- Removal Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_cosmosdbaccount.py
plugins/modules/azure_rm_cosmosdbaccount_info.py