### PR TITLE
4.0.0 Removal: `azure_rm_storageaccount` remove legacy `Storage` and `BlobStorage` `kind` values

### DIFF
--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -85,22 +85,15 @@ options:
         description:
             - The kind of storage.
             - The C(FileStorage) and (BlockBlobStorage) only used when I(account_type=Premium_LRS) or I(account_type=Premium_ZRS).
-            - C(Storage) (general-purpose v1) and C(BlobStorage) are legacy account kinds that Azure is retiring. Microsoft
-              is disabling creation of new legacy blob storage accounts in September 2026 and will fully retire both kinds
-              in October 2026 (any remaining accounts will be auto-migrated to C(StorageV2)). Use C(StorageV2) for all new
-              accounts.
         default: 'StorageV2'
         type: str
         choices:
-            - Storage
             - StorageV2
-            - BlobStorage
             - BlockBlobStorage
             - FileStorage
     is_hns_enabled:
         description:
             - Account HierarchicalNamespace enabled if sets to true.
-            - When I(is_hns_enabled=True), I(kind) cannot be C(Storage).
         type: bool
     enable_nfs_v3:
         description:
@@ -108,7 +101,7 @@ options:
         type: bool
     access_tier:
         description:
-            - The access tier for this storage account. Required when I(kind=BlobStorage).
+            - The access tier for this storage account. Defaults to C(Hot) when I(kind=StorageV2).
         type: str
         choices:
             - Hot
@@ -1026,7 +1019,7 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
             state=dict(default='present', choices=['present', 'absent', 'failover']),
             force_delete_nonempty=dict(type='bool', default=False, aliases=['force']),
             tags=dict(type='dict'),
-            kind=dict(type='str', default='StorageV2', choices=['Storage', 'StorageV2', 'BlobStorage', 'FileStorage', 'BlockBlobStorage']),
+            kind=dict(type='str', default='StorageV2', choices=['StorageV2', 'BlockBlobStorage', 'FileStorage']),
             access_tier=dict(type='str', choices=['Hot', 'Cool', 'Cold', 'Premium', 'Smart']),
             https_only=dict(type='bool'),
             minimum_tls_version=dict(type='str', choices=['TLS1_0', 'TLS1_1', 'TLS1_2']),
@@ -1206,18 +1199,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
         if self.kind in ['FileStorage', 'BlockBlobStorage', ] and self.account_type not in ['Premium_LRS', 'Premium_ZRS']:
             self.fail("Parameter error: Storage account with {0} kind require account type is Premium_LRS or Premium_ZRS".format(self.kind))
 
-        if self.state == 'present' and self.kind in ('Storage', 'BlobStorage'):
-            self.module.deprecate(
-                "kind='{0}' is a legacy Azure storage account type. Microsoft is disabling creation of new "
-                "legacy blob storage accounts in September 2026 and fully retiring both 'Storage' "
-                "(general-purpose v1) and 'BlobStorage' accounts in October 2026, after which remaining "
-                "accounts will be auto-migrated to 'StorageV2'. Set kind='StorageV2' instead. See "
-                "https://learn.microsoft.com/en-us/azure/storage/common/legacy-blob-storage-account-migration-overview "
-                "and "
-                "https://learn.microsoft.com/en-us/azure/storage/common/general-purpose-version-1-account-migration-overview".format(self.kind),
-                version='4.0.0',
-                collection_name='azure.azcollection',
-            )
         self.account_dict = self.get_account()
 
         curr_identity = self.account_dict["identity"] if self.account_dict else None
@@ -1819,9 +1800,6 @@ class AzureRMStorageAccount(AzureRMModuleBaseExt):
 
         if not self.account_type:
             self.fail('Parameter error: account_type required when creating a storage account.')
-
-        if not self.access_tier and self.kind == 'BlobStorage':
-            self.fail('Parameter error: access_tier required when creating a storage account of type BlobStorage.')
 
         self.check_name_availability()
         self.results['changed'] = True


### PR DESCRIPTION
##### SUMMARY
Removes the legacy `Storage` (general-purpose v1) and `BlobStorage` values from `azure_rm_storageaccount`'s `kind` option, as part of the v4.0.0 removal sweep.

Both kinds were soft-deprecated in #2304 ahead of Azure's retirement timeline:
- **September 2026** — Azure disables creation of new `Storage` (GPv1) and `BlobStorage` accounts.
- **October 2026** — Both kinds are fully retired; any remaining accounts are auto-migrated to `StorageV2`.

The argspec default has been `StorageV2` (matching `az storage account create` and Terraform's `azurerm_storage_account`), and any playbook still passing `kind='Storage'` or `kind='BlobStorage'` has emitted a runtime `module.deprecate(..., version='4.0.0')` warning pointing at this cleanup.

##### ISSUE TYPE
- Removal Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_storageaccount.py