### PR TITLE
4.0.0 Removal: `azure_rm_containerinstance` remove `ports` option

### DIFF
--- a/plugins/modules/azure_rm_containerinstance.py
+++ b/plugins/modules/azure_rm_containerinstance.py
@@ -59,13 +59,6 @@ options:
         description:
             - The Dns name label for the IP.
         type: str
-    ports:
-        description:
-            - List of ports exposed within the container group.
-            - This option is deprecated, using I(ports) under I(containers)".
-        type: list
-        elements: int
-        default: []
     location:
         description:
             - Valid azure location. Defaults to location of the resource group.
@@ -354,8 +347,6 @@ EXAMPLES = '''
     location: eastus
     subnet_ids:
       - "{{ subnet_id }}"
-    ports:
-      - 80
     containers:
       - name: mycontainer1
         image: httpd
@@ -617,11 +608,6 @@ class AzureRMContainerInstance(AzureRMModuleBaseExt):
             ),
             dns_name_label=dict(
                 type='str',
-            ),
-            ports=dict(
-                type='list',
-                elements='int',
-                default=[]
             ),
             registry_login_server=dict(
                 type='str',

--- a/tests/integration/targets/azure_rm_containerinstance/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_containerinstance/tasks/main.yml
@@ -39,8 +39,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -67,8 +65,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -90,8 +86,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -123,8 +117,6 @@
         dns_name_label: mydnslabel{{ resource_group | hash('md5') | truncate(7, True, '') }}
         location: "{{ location }}"
         restart_policy: on_failure
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -167,8 +159,6 @@
         location: "{{ location }}"
         subnet_ids:
           - "{{ subnet_output.state.id }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -238,8 +228,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -279,8 +267,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -304,8 +290,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: mcr.microsoft.com/azuredocs/aci-helloworld
@@ -377,8 +361,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: mcr.microsoft.com/azuredocs/aci-helloworld
@@ -406,8 +388,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -430,8 +410,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
@@ -448,8 +426,6 @@
         os_type: linux
         ip_address: public
         location: "{{ location }}"
-        ports:
-          - 80
         containers:
           - name: mycontainer1
             image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"


### PR DESCRIPTION
##### SUMMARY
The top-level 'ports' option was a no-op since the module was created: `argspec` was declared but `self.ports` is never read at runtime. Port exposure is entirely driven by the per-container 'ports' inside each 'containers:' entry, and the union of those ports is what the module already surfaces on `IpAddress`. This aligns the module with the Azure REST API contract (`Container.ports` is the only ports field; container groups have no such field of their own).

##### ISSUE TYPE
- Removal Pull Request

##### COMPONENT NAME
plugins/modules/azure_rm_containerinstance.py