### PR TITLE
Fix 2322: Update `attach_caching` on managed disk when managed_by is not resupplied

### DIFF
--- a/plugins/modules/azure_rm_manageddisk.py
+++ b/plugins/modules/azure_rm_manageddisk.py
@@ -882,6 +882,10 @@ class AzureRMManagedDisk(AzureRMModuleBase):
                 self.image_reference = disk_instance.get('image_reference')
             if self.gallery_image_reference is None:
                 self.gallery_image_reference = disk_instance.get('gallery_image_reference')
+            if self.attach_caching is not None and self.managed_by is None:
+                current_managed_by = parse_resource_id(disk_instance.get('managed_by', '')).get('name') if disk_instance.get('managed_by') else None
+                if current_managed_by:
+                    self.managed_by = current_managed_by
 
         result = disk_instance
 

--- a/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_manageddisk/tasks/main.yml
@@ -418,6 +418,100 @@
           - output.state.tags.testtag2 == 'TestValue2'
           - output.state.tags.TestTag3 == 'TestValue3'
 
+    - name: Create virtual network for attach_caching test
+      azure.azcollection.azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "tr{{ rpfx }}"
+        address_prefixes: "10.10.0.0/16"
+
+    - name: Add subnet for attach_caching test
+      azure.azcollection.azure_rm_subnet:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "tr{{ rpfx }}"
+        address_prefix: "10.10.0.0/24"
+        virtual_network: "tr{{ rpfx }}"
+
+    - name: Create NIC for attach_caching test
+      azure.azcollection.azure_rm_networkinterface:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "tr{{ rpfx }}"
+        virtual_network: "tr{{ rpfx }}"
+        subnet_name: "tr{{ rpfx }}"
+        create_with_security_group: false
+
+    - name: Create virtual machine for attach_caching test
+      azure.azcollection.azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "tr{{ rpfx }}"
+        vm_size: Standard_D2s_v3
+        managed_disk_type: Standard_LRS
+        admin_username: adminuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/adminuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        os_type: Linux
+        network_interfaces: "tr{{ rpfx }}"
+        image:
+          offer: 0001-com-ubuntu-server-focal
+          publisher: Canonical
+          sku: 20_04-lts
+          version: latest
+
+    - name: Create managed disk attached with attach_caching=read_write
+      azure.azcollection.azure_rm_manageddisk:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "md{{ rpfx }}9"
+        disk_size_gb: 4
+        managed_by: "tr{{ rpfx }}"
+        attach_caching: read_write
+      register: output
+
+    - name: Assert disk created and attached with read_write caching
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Create managed disk attached with attach_caching=read_write (idempotent)
+      azure.azcollection.azure_rm_manageddisk:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "md{{ rpfx }}9"
+        disk_size_gb: 4
+        managed_by: "tr{{ rpfx }}"
+        attach_caching: read_write
+      register: output
+
+    - name: Assert disk create is idempotent
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Update attach_caching to read_only without re-specifying managed_by
+      azure.azcollection.azure_rm_manageddisk:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "md{{ rpfx }}9"
+        disk_size_gb: 4
+        attach_caching: read_only
+      register: output
+
+    - name: Assert attach_caching update reported changed
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Update attach_caching to read_only without re-specifying managed_by (idempotent)
+      azure.azcollection.azure_rm_manageddisk:
+        resource_group: "{{ resource_group }}-manageddisk"
+        name: "md{{ rpfx }}9"
+        disk_size_gb: 4
+        attach_caching: read_only
+      register: output
+
+    - name: Assert attach_caching update is idempotent
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
     - name: Delete all managed disk
       azure.azcollection.azure_rm_manageddisk:
         resource_group: "{{ resource_group }}-manageddisk"
@@ -433,6 +527,7 @@
         - 6
         - 7
         - 8
+        - 9
 
     - name: Delete virtual machine
       azure.azcollection.azure_rm_virtualmachine:


### PR DESCRIPTION
##### SUMMARY
Fix #2322.
`azure_rm_manageddisk` previously reported `ok` and applied no change when a caller updated only `attach_caching` on an existing attached disk without re-specifying `managed_by`, because the caching diff / detach-reattach path was gated behind `self.managed_by`. This patch backfills `self.managed_by` from the current disk when the user updates caching only, so the existing caching-diff path runs and the VM's `DataDisk.caching` is actually updated.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [ ] New Module Pull Request
- [x] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_manageddisk.py

##### ADDITIONAL INFORMATION
- On an existing attached managed disk, calling the module with only `attach_caching` (no `managed_by`) now correctly detects the caching drift and triggers the detach/reattach path that updates `DataDisk.caching` on the VM.
- Scope is intentionally narrow: the backfill fires only when `attach_caching is not None and managed_by is None`, so behavior for every other invocation (create, size change, tag change, explicit `managed_by`) is unchanged.
- Caching is a VM-side property (`VirtualMachine.storage_profile.data_disks[*].caching`), so the fix reuses the module's existing detach/reattach flow rather than introducing a disk-level PATCH.

##### REFERENCE
- https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/compute/azure-mgmt-compute/azure/mgmt/compute/v2024_07_01/models/_models_py3.py
- https://github.com/Azure/azure-rest-api-specs/tree/main/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-07-01