### PR TITLE
Migration fix #2334 & #2335: complete `azure-mgmt-postgresqlflexibleservers` move and fix `auth_config` drop

### DIFF
--- a/plugins/modules/azure_rm_postgresqlflexibleadministrator.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleadministrator.py
@@ -248,9 +248,9 @@ class AzureRMPostgreSqlFlexibleAdministrator(AzureRMModuleBase):
 
         try:
             response = self.postgresql_flexible_client.administrators_microsoft_entra.begin_create_or_update(resource_group_name=self.resource_group,
-                                                                                                          server_name=self.server_name,
-                                                                                                          object_id=self.object_id,
-                                                                                                          parameters=body)
+                                                                                                             server_name=self.server_name,
+                                                                                                             object_id=self.object_id,
+                                                                                                             parameters=body)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 
@@ -268,8 +268,8 @@ class AzureRMPostgreSqlFlexibleAdministrator(AzureRMModuleBase):
         self.log("Deleting the PostgreSQL Flexible Administrator instance {0}".format(self.object_id))
         try:
             self.postgresql_flexible_client.administrators_microsoft_entra.begin_delete(resource_group_name=self.resource_group,
-                                                                                       server_name=self.server_name,
-                                                                                       object_id=self.object_id)
+                                                                                        server_name=self.server_name,
+                                                                                        object_id=self.object_id)
         except Exception as ec:
             self.log('Error attempting to delete the PostgreSQL Flexible Administrator instance.')
             self.fail("Error deleting the PostgreSQL Flexible Administrator instance: {0}".format(str(ec)))
@@ -284,8 +284,8 @@ class AzureRMPostgreSqlFlexibleAdministrator(AzureRMModuleBase):
         found = False
         try:
             response = self.postgresql_flexible_client.administrators_microsoft_entra.get(resource_group_name=self.resource_group,
-                                                                                         server_name=self.server_name,
-                                                                                         object_id=self.object_id)
+                                                                                          server_name=self.server_name,
+                                                                                          object_id=self.object_id)
             found = True
             self.log("Response : {0}".format(response))
             self.log("PostgreSQL Flexible Administrator instance : {0} found".format(response.name))

--- a/plugins/modules/azure_rm_postgresqlflexibleadministrator.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleadministrator.py
@@ -247,10 +247,10 @@ class AzureRMPostgreSqlFlexibleAdministrator(AzureRMModuleBase):
         self.log("Adding the PostgreSQL Flexible Administrator instance {0}".format(self.object_id))
 
         try:
-            response = self.postgresql_flexible_client.administrators.begin_create(resource_group_name=self.resource_group,
-                                                                                   server_name=self.server_name,
-                                                                                   object_id=self.object_id,
-                                                                                   parameters=body)
+            response = self.postgresql_flexible_client.administrators_microsoft_entra.begin_create_or_update(resource_group_name=self.resource_group,
+                                                                                                          server_name=self.server_name,
+                                                                                                          object_id=self.object_id,
+                                                                                                          parameters=body)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)
 
@@ -267,9 +267,9 @@ class AzureRMPostgreSqlFlexibleAdministrator(AzureRMModuleBase):
         '''
         self.log("Deleting the PostgreSQL Flexible Administrator instance {0}".format(self.object_id))
         try:
-            self.postgresql_flexible_client.administrators.begin_delete(resource_group_name=self.resource_group,
-                                                                        server_name=self.server_name,
-                                                                        object_id=self.object_id)
+            self.postgresql_flexible_client.administrators_microsoft_entra.begin_delete(resource_group_name=self.resource_group,
+                                                                                       server_name=self.server_name,
+                                                                                       object_id=self.object_id)
         except Exception as ec:
             self.log('Error attempting to delete the PostgreSQL Flexible Administrator instance.')
             self.fail("Error deleting the PostgreSQL Flexible Administrator instance: {0}".format(str(ec)))
@@ -283,9 +283,9 @@ class AzureRMPostgreSqlFlexibleAdministrator(AzureRMModuleBase):
         self.log("Checking if the PostgreSQL Flexible Administrator instance {0} is present".format(self.object_id))
         found = False
         try:
-            response = self.postgresql_flexible_client.administrators.get(resource_group_name=self.resource_group,
-                                                                          server_name=self.server_name,
-                                                                          object_id=self.object_id)
+            response = self.postgresql_flexible_client.administrators_microsoft_entra.get(resource_group_name=self.resource_group,
+                                                                                         server_name=self.server_name,
+                                                                                         object_id=self.object_id)
             found = True
             self.log("Response : {0}".format(response))
             self.log("PostgreSQL Flexible Administrator instance : {0} found".format(response.name))

--- a/plugins/modules/azure_rm_postgresqlflexibleadministrator_info.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleadministrator_info.py
@@ -159,9 +159,9 @@ class AzureRMPostgreSqlFlexibleAdministratorInfo(AzureRMModuleBase):
         response = None
         results = []
         try:
-            response = self.postgresql_flexible_client.administrators.get(resource_group_name=self.resource_group,
-                                                                          server_name=self.server_name,
-                                                                          object_id=self.object_id)
+            response = self.postgresql_flexible_client.administrators_microsoft_entra.get(resource_group_name=self.resource_group,
+                                                                                         server_name=self.server_name,
+                                                                                         object_id=self.object_id)
             self.log("Response : {0}".format(response))
         except ResourceNotFoundError:
             self.log('Could not get administrator facts for PostgreSQL Flexible Server.')
@@ -175,8 +175,8 @@ class AzureRMPostgreSqlFlexibleAdministratorInfo(AzureRMModuleBase):
         response = None
         results = []
         try:
-            response = self.postgresql_flexible_client.administrators.list_by_server(resource_group_name=self.resource_group,
-                                                                                     server_name=self.server_name)
+            response = self.postgresql_flexible_client.administrators_microsoft_entra.list_by_server(resource_group_name=self.resource_group,
+                                                                                                   server_name=self.server_name)
             self.log("Response : {0}".format(response))
         except Exception as ec:
             self.log('Could not list administrators facts for PostgreSQL Flexible Servers.')

--- a/plugins/modules/azure_rm_postgresqlflexibleadministrator_info.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleadministrator_info.py
@@ -160,8 +160,8 @@ class AzureRMPostgreSqlFlexibleAdministratorInfo(AzureRMModuleBase):
         results = []
         try:
             response = self.postgresql_flexible_client.administrators_microsoft_entra.get(resource_group_name=self.resource_group,
-                                                                                         server_name=self.server_name,
-                                                                                         object_id=self.object_id)
+                                                                                          server_name=self.server_name,
+                                                                                          object_id=self.object_id)
             self.log("Response : {0}".format(response))
         except ResourceNotFoundError:
             self.log('Could not get administrator facts for PostgreSQL Flexible Server.')
@@ -176,7 +176,7 @@ class AzureRMPostgreSqlFlexibleAdministratorInfo(AzureRMModuleBase):
         results = []
         try:
             response = self.postgresql_flexible_client.administrators_microsoft_entra.list_by_server(resource_group_name=self.resource_group,
-                                                                                                   server_name=self.server_name)
+                                                                                                     server_name=self.server_name)
             self.log("Response : {0}".format(response))
         except Exception as ec:
             self.log('Could not list administrators facts for PostgreSQL Flexible Servers.')

--- a/plugins/modules/azure_rm_postgresqlflexibleconfiguration.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleconfiguration.py
@@ -81,7 +81,7 @@ id:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-    from azure.mgmt.rdbms.postgresql_flexibleservers.models import Configuration
+    from azure.mgmt.postgresqlflexibleservers.models import ConfigurationForUpdate
     from azure.core.exceptions import ResourceNotFoundError
     from azure.core.polling import LROPoller
 except ImportError:
@@ -198,7 +198,7 @@ class AzureRMPostgreSqlFlexibleConfigurations(AzureRMModuleBase):
             response = self.postgresql_flexible_client.configurations.begin_update(resource_group_name=self.resource_group,
                                                                                    server_name=self.server_name,
                                                                                    configuration_name=self.name,
-                                                                                   parameters=Configuration(
+                                                                                   parameters=ConfigurationForUpdate(
                                                                                        value=self.value,
                                                                                        source='user-override'
                                                                                    ))
@@ -220,7 +220,7 @@ class AzureRMPostgreSqlFlexibleConfigurations(AzureRMModuleBase):
             response = self.postgresql_flexible_client.configurations.begin_update(resource_group_name=self.resource_group,
                                                                                    server_name=self.server_name,
                                                                                    configuration_name=self.name,
-                                                                                   parameters=Configuration(
+                                                                                   parameters=ConfigurationForUpdate(
                                                                                        value=default_value,
                                                                                        source='user-override'
                                                                                    ))

--- a/plugins/modules/azure_rm_postgresqlflexibleserver.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver.py
@@ -844,6 +844,9 @@ class AzureRMPostgreSqlFlexibleServers(AzureRMModuleBaseExt):
             if update_identity:
                 self.parameters['identity'] = new_identity
 
+        if self.auth_config is not None:
+            self.parameters['auth_config'] = self.auth_config
+
         current_tags = old_response.get('tags') if old_response else None
         if self.tags is not None:
             try:

--- a/plugins/modules/azure_rm_postgresqlflexibleserver_info.py
+++ b/plugins/modules/azure_rm_postgresqlflexibleserver_info.py
@@ -323,7 +323,7 @@ servers:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-    import azure.mgmt.rdbms.postgresql_flexibleservers.models as PostgreSQLFlexibleModels
+    import azure.mgmt.postgresqlflexibleservers.models as PostgreSQLFlexibleModels
     from azure.core.exceptions import ResourceNotFoundError
 except ImportError:
     # This is handled in azure_rm_common
@@ -401,7 +401,7 @@ class AzureRMPostgreSqlFlexibleServersInfo(AzureRMModuleBase):
         response = None
         results = []
         try:
-            response = self.postgresql_flexible_client.servers.list()
+            response = self.postgresql_flexible_client.servers.list_by_subscription()
             self.log("Response : {0}".format(response))
         except Exception:
             self.log('Could not get facts for PostgreSQL Flexible Servers.')

--- a/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml
@@ -218,6 +218,143 @@
         that:
           - output.state.identity.type == 'None'
 
+    - name: Look up service principal object id and set tenant_id for Entra tests
+      ansible.builtin.set_fact:
+        tenant_id: "{{ azure_tenant }}"
+        object_id: "{{ lookup('azure.azcollection.azure_service_principal_attribute',
+                       azure_client_id=azure_client_id,
+                       azure_secret=azure_secret,
+                       azure_tenant=azure_tenant) }}"
+
+    - name: Enable Entra ID authentication via auth_config
+      azure.azcollection.azure_rm_postgresqlflexibleserver:
+        resource_group: "{{ new_resource_group }}"
+        name: postflexible{{ rpfx }}
+        auth_config:
+          active_directory_auth: Enabled
+          password_auth: Enabled
+          tenant_id: "{{ tenant_id }}"
+      register: output
+
+    - name: Assert auth_config was applied
+      ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.state.auth_config.active_directory_auth == 'Enabled'
+          - output.state.auth_config.password_auth == 'Enabled'
+          - output.state.auth_config.tenant_id == tenant_id
+
+    - name: Enable Entra ID authentication via auth_config (Idempotent test)
+      azure.azcollection.azure_rm_postgresqlflexibleserver:
+        resource_group: "{{ new_resource_group }}"
+        name: postflexible{{ rpfx }}
+        auth_config:
+          active_directory_auth: Enabled
+          password_auth: Enabled
+          tenant_id: "{{ tenant_id }}"
+      register: output
+
+    - name: Assert auth_config is idempotent
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Assign Entra ID administrator (check mode)
+      azure.azcollection.azure_rm_postgresqlflexibleadministrator:
+        resource_group: "{{ new_resource_group }}"
+        server_name: postflexible{{ rpfx }}
+        object_id: "{{ object_id }}"
+        principal_name: "{{ azure_client_id }}"
+        principal_type: ServicePrincipal
+        tenant_id: "{{ tenant_id }}"
+        state: present
+      check_mode: true
+      register: output
+
+    - name: Assert Entra admin would be created (check mode)
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Assign Entra ID administrator
+      azure.azcollection.azure_rm_postgresqlflexibleadministrator:
+        resource_group: "{{ new_resource_group }}"
+        server_name: postflexible{{ rpfx }}
+        object_id: "{{ object_id }}"
+        principal_name: "{{ azure_client_id }}"
+        principal_type: ServicePrincipal
+        tenant_id: "{{ tenant_id }}"
+        state: present
+      register: output
+
+    - name: Assert Entra admin was created
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Assign Entra ID administrator (Idempotent test)
+      azure.azcollection.azure_rm_postgresqlflexibleadministrator:
+        resource_group: "{{ new_resource_group }}"
+        server_name: postflexible{{ rpfx }}
+        object_id: "{{ object_id }}"
+        principal_name: "{{ azure_client_id }}"
+        principal_type: ServicePrincipal
+        tenant_id: "{{ tenant_id }}"
+        state: present
+      register: output
+
+    - name: Assert Entra admin idempotent
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Gather Entra ID administrator facts by object_id
+      azure.azcollection.azure_rm_postgresqlflexibleadministrator_info:
+        resource_group: "{{ new_resource_group }}"
+        server_name: postflexible{{ rpfx }}
+        object_id: "{{ object_id }}"
+      register: output
+
+    - name: Assert Entra admin facts
+      ansible.builtin.assert:
+        that:
+          - output.administrators | length == 1
+          - output.administrators[0].principal_type == 'ServicePrincipal'
+          - output.administrators[0].tenant_id == tenant_id
+
+    - name: List Entra ID administrators on the server
+      azure.azcollection.azure_rm_postgresqlflexibleadministrator_info:
+        resource_group: "{{ new_resource_group }}"
+        server_name: postflexible{{ rpfx }}
+      register: output
+
+    - name: Assert list_by_server returned the administrator
+      ansible.builtin.assert:
+        that:
+          - output.administrators | length >= 1
+
+    - name: Delete Entra ID administrator
+      azure.azcollection.azure_rm_postgresqlflexibleadministrator:
+        resource_group: "{{ new_resource_group }}"
+        server_name: postflexible{{ rpfx }}
+        object_id: "{{ object_id }}"
+        state: absent
+      register: output
+
+    - name: Assert Entra admin deleted
+      ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: List PostgreSQL flexible servers by subscription
+      azure.azcollection.azure_rm_postgresqlflexibleserver_info:
+      register: output
+
+    - name: Assert list_by_subscription returned our test server
+      ansible.builtin.assert:
+        that:
+          - output.servers | length >= 1
+
     - name: Create postgresql elastic cluster
       azure.azcollection.azure_rm_postgresqlflexibleserver:
         resource_group: "{{ new_resource_group }}"


### PR DESCRIPTION
##### SUMMARY
Fix #2334, #2335.

Completes the migration from the deprecated `azure.mgmt.rdbms.postgresql_flexibleservers` submodule to the MSFT-recommended `azure-mgmt-postgresqlflexibleservers==2.0.0` package (already pinned in `requirements.txt`) for every PostgreSQL Flexible Server module still on the old client shape. This clears two reported bugs — `auth_config` silently dropped by `azure_rm_postgresqlflexibleserver`, and `AttributeError` on every call to `azure_rm_postgresqlflexibleadministrator*` — plus two latent bugs of the same class (`servers.list()` rename, `Configuration` model rename). No option-contract change.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [ ] New Module Pull Request
- [x] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [x] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_postgresqlflexibleserver.py
- plugins/modules/azure_rm_postgresqlflexibleserver_info.py
- plugins/modules/azure_rm_postgresqlflexibleadministrator.py
- plugins/modules/azure_rm_postgresqlflexibleadministrator_info.py
- plugins/modules/azure_rm_postgresqlflexibleconfiguration.py
- tests/integration/targets/azure_rm_postgresqlflexibleserver/tasks/main.yml

##### ADDITIONAL INFORMATION
- `azure_rm_postgresqlflexibleserver` now copies `self.auth_config` into `self.parameters` after the arg-spec routing loop, so the `authConfig` block is included in the create and update PUT bodies (SDK: `azure.mgmt.postgresqlflexibleservers.models.Server.auth_config` — Tier 1).
- `azure_rm_postgresqlflexibleadministrator` and `_info` now call the `administrators_microsoft_entra` operation group; the create call uses `begin_create_or_update` (SDK: `AdministratorsMicrosoftEntraOperations.begin_create_or_update / begin_delete / get / list_by_server` — Tier 1). The old `administrators` group and `begin_create` method do not exist in the new SDK, which is why every invocation raised `AttributeError`.
- `azure_rm_postgresqlflexibleserver_info` now imports models from `azure.mgmt.postgresqlflexibleservers.models` and calls `servers.list_by_subscription()`; the old `.list()` was renamed in the new SDK (Tier 1: `ServersOperations.list_by_subscription`).
- `azure_rm_postgresqlflexibleconfiguration` now uses `ConfigurationForUpdate` from the new SDK for the two `begin_update` bodies; the old `Configuration` model lives only in the deprecated submodule (Tier 1: `ConfigurationsOperations.begin_update` accepts `Union[ConfigurationForUpdate, IO[bytes]]`).
- Integration tests extend the existing `azure_rm_postgresqlflexibleserver` target to cover `auth_config` create + idempotence, Entra administrator lifecycle via both the main module and `_info` (check-mode create, create, idempotence, get-by-object_id, list_by_server, delete), and `azure_rm_postgresqlflexibleserver_info` with no args to exercise `list_by_subscription`. The service-principal `object_id` lookup follows the pattern already used by `azure_rm_keyvault`, `azure_rm_storageaccount`, and `azure_rm_storageblob`.
- `azure-mgmt-rdbms` remains pinned in `requirements.txt`; its `postgresql`, `mysql`, and `mariadb` submodules are still consumed by 24 legacy Single Server modules and by `plugins/module_utils/azure_rm_common.py`. Only the `postgresql_flexibleservers` submodule was deprecated, and this PR removes the last references to it.

##### REFERENCE
- https://pypi.org/project/azure-mgmt-postgresqlflexibleservers/ (release notes for `2.0.0`, 2025-11-17: adds `administrators_microsoft_entra`, `advanced_threat_protection_settings`, `backups_automatic_and_on_demand`, and related renames)
- https://pypi.org/project/azure-mgmt-rdbms/ (release notes for `10.2.0b18`, 2024-10-11, formal deprecation of `azure.mgmt.rdbms.postgresql_flexibleservers`)
- https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/postgresqlflexibleservers/azure-mgmt-postgresqlflexibleservers