### PR TITLE
CI Fix: Bump partner-certification-checker reusable workflow to v3.0.0

### DIFF
--- a/.github/workflows/rh_certification_checker.yml
+++ b/.github/workflows/rh_certification_checker.yml
@@ -1,8 +1,12 @@
-# This workflow calls the latest version of the
-# reusable workflow.
-# You can copy this file into your respository if
-# you want to check against pinned versions of
-# Automation Hub tests.
+---
+# This workflow calls a pinned version of the
+# reusable workflow. Copy this file into your
+# repository to check against pinned versions
+# of Automation Hub tests.
+# The version is pinned to an exact release tag
+# (e.g. @v1.2.0) for supply chain security.
+# Use Dependabot to receive automatic PRs when
+# new versions are released.
 name: Run collection certification checks
 
 permissions:
@@ -13,12 +17,11 @@ on:
     branches: [dev]
   workflow_dispatch:
   # schedule:
-  #   - cron: '0 6 * * *'
+  #   - cron: "0 6 * * *"
 
 concurrency:
   group: cert-ver-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 
 # Files that are not related to the core functionality
 # of your collection can cause Ansible Lint to fail.
@@ -34,12 +37,14 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@2f6d9300ebe9190da3120a740c3a4d5ca2f0f02e # v1.0.0
-    # If the minimal Ansible Core version your collection supports Ansible
-    # is greater than 2.16.0, specify it below.
-    # You might also have to specify Python version supported by that version,
-    # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v3.0.0 # zizmor: ignore[unpinned-uses]
+    # For details on tested ansible-core branches and Python versions,
+    # see: https://github.com/ansible-collections/partner-certification-checker#tested-ansible-core-branches-and-python-versions
     # with:
-    #   ansible-core-version: '2.17.0'
-    #   python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+    #   ansible-core-version: '2.18.0'
     #   collection-root: 'ansible_collections/junipernetworks/junos'
+    #   automation-hub: true
+    # Uncomment the lines below if you have 'automation-hub: true' and need to install collections from Red Hat Ansible Automation Hub.
+    # This requires setting a repository secret called 'AH_TOKEN' which value contains a Red Hat Ansible Automation Hub token.
+    # secrets:
+    #   AH_TOKEN: ${{ secrets.AH_TOKEN }}

--- a/.github/workflows/rh_certification_checker.yml
+++ b/.github/workflows/rh_certification_checker.yml
@@ -40,8 +40,8 @@ jobs:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v3.0.0 # zizmor: ignore[unpinned-uses]
     # For details on tested ansible-core branches and Python versions,
     # see: https://github.com/ansible-collections/partner-certification-checker#tested-ansible-core-branches-and-python-versions
-    # with:
-    #   ansible-core-version: '2.18.0'
+    with:
+      ansible-core-version: "2.21.0"
     #   collection-root: 'ansible_collections/junipernetworks/junos'
     #   automation-hub: true
     # Uncomment the lines below if you have 'automation-hub: true' and need to install collections from Red Hat Ansible Automation Hub.

--- a/roles/azure_arc/tasks/main.yml
+++ b/roles/azure_arc/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Connect if not already connected to azure
   when: azure_arc_show.resourceId | default('') == ''
   block:
-    - name: Get access token for arc onboarding
+    - name: Get access token for arc onboarding  # noqa: jinja[invalid]
       # Run on localhost, so that service principal secrets don't leave control node
       delegate_to: localhost
       # This command produces output that includes an access token


### PR DESCRIPTION
##### SUMMARY
Restore the `Run collection certification checks` CI workflow, which was failing on the `Lint production` job with `ModuleNotFoundError: No module named 'ansible.parsing.yaml.constructor'`. Two coordinated changes are required to fix it end-to-end:

1. Bump the pinned reference of the `partner-certification-checker` reusable workflow from `v1.0.0` to `v3.0.0`, and explicitly pass `ansible-core-version: '2.21.0'` so v3.0.0's version-detection gate installs a compatible `ansible-lint` (>= 25.2.0) instead of the default 24.12.2 (which is incompatible with ansible-core >= 2.19).
2. Suppress a `jinja[invalid]` false positive that the newer `ansible-lint` raises on the idiomatic `| default(omit)` pattern in `roles/azure_arc/tasks/main.yml`.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [ ] New Module Pull Request
- [ ] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- .github/workflows/rh_certification_checker.yml
- roles/azure_arc/tasks/main.yml

##### ADDITIONAL INFORMATION
- Bumps `partner-certification-checker` from `v1.0.0` (SHA `2f6d9300...`) to `v3.0.0`. The v3.0.0 reusable workflow contains logic that pins `ansible-lint==25.2.0` when `ansible-core-version` minor >= 19.
- Explicitly passes `ansible-core-version: '2.21.0'` because v3.0.0's default input is `2.16.0`, which would leave the lint version at the broken default 24.12.2 and still crash once `ansible-compat` transitively upgrades ansible-core to 2.21.x. `2.21.0` is already exercised by the collection's `ansible-test.yml` matrix (`stable-2.21`).
- Preserves this repository's local customizations to the workflow: `pull_request: branches: [dev]` trigger, the commented-out daily cron, and `workflow_dispatch`.
- Adds a task-level `# noqa: jinja[invalid]` to the `Get access token for arc onboarding` task in `roles/azure_arc/tasks/main.yml`. `ansible-lint` 25.x flags `| default(omit)` in that task as "A template was resolved to an Omit scalar" (5 hits, all on the same task), but the pattern is idiomatic Ansible and documented as the correct way to conditionally omit a module argument. Task-level suppression is preferred over a global `skip_list` entry to keep the rule active elsewhere.
- No changes to collection modules, module_utils, plugins, tests, meta, or docs.

##### REFERENCE
- https://github.com/ansible-collections/partner-certification-checker/releases/tag/v3.0.0
- https://github.com/ansible-collections/partner-certification-checker/blob/v3.0.0/.github/workflows/certification-reusable.yml
- https://ansible.readthedocs.io/projects/lint/rules/jinja/
- https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#omitting-values
